### PR TITLE
fix(builder): gas left calculations for constraints

### DIFF
--- a/builder/miner/worker.go
+++ b/builder/miner/worker.go
@@ -1206,7 +1206,11 @@ func (w *worker) commitTransactions(env *environment, plainTxs, blobTxs *transac
 			// Everything ok, collect the logs and shift in the next transaction from the same account
 			coalescedLogs = append(coalescedLogs, logs...)
 			env.tcount++
-			if !candidate.isConstraint {
+			if candidate.isConstraint {
+				// Update the amount of gas left for the constraints
+				constraintsTotalGasLeft -= candidate.tx.Gas()
+				constraintsTotalBlobGasLeft -= candidate.tx.BlobGas()
+			} else {
 				txs.Shift()
 			}
 


### PR DESCRIPTION
The quantities `constraintsTotalGasLeft` and `constraintsTotalBlobGasLeft` were introduced to take into account the amount of gas to be reserved in advance to constraints in the block building algorithm. However, once a constraint is processed they should be updated accordingly. By mistake this hasn't been done