### PR TITLE
feat(sidecar): configurable `ValidatorIndex`

### DIFF
--- a/bolt-sidecar/bin/sidecar.rs
+++ b/bolt-sidecar/bin/sidecar.rs
@@ -52,7 +52,7 @@ async fn main() -> eyre::Result<()> {
     let (payload_tx, mut payload_rx) = mpsc::channel(16);
     let payload_fetcher = LocalPayloadFetcher::new(payload_tx);
 
-    let validator_indexes = config.validator_indexes;
+    let validator_indexes = &config.validator_indexes;
 
     tokio::spawn(async move {
         loop {
@@ -92,7 +92,7 @@ async fn main() -> eyre::Result<()> {
                     "Validation against execution state passed"
                 );
 
-                let validator_index = find_validator_index_for_slot(&validator_indexes, &consensus_state.get_epoch().proposer_duties, request.slot);
+                let validator_index = find_validator_index_for_slot(validator_indexes, &consensus_state.get_epoch().proposer_duties, request.slot);
 
                 // parse the request into constraints and sign them with the sidecar signer
                 let message = ConstraintsMessage::build(validator_index, request.slot, request.clone());

--- a/bolt-sidecar/bin/sidecar.rs
+++ b/bolt-sidecar/bin/sidecar.rs
@@ -51,6 +51,8 @@ async fn main() -> eyre::Result<()> {
     let (payload_tx, mut payload_rx) = mpsc::channel(16);
     let payload_fetcher = LocalPayloadFetcher::new(payload_tx);
 
+    let validator_indexes = config.validator_indexes;
+
     tokio::spawn(async move {
         loop {
             if let Err(e) =
@@ -90,8 +92,7 @@ async fn main() -> eyre::Result<()> {
                 );
 
                 // parse the request into constraints and sign them with the sidecar signer
-                // TODO: get the validator index from somewhere
-                let message = ConstraintsMessage::build(0, request.slot, request.clone());
+                let message = ConstraintsMessage::build(validator_indexes[0], request.slot, request.clone());
 
                 let signature = signer.sign(&message.digest())?;
                 let signed_constraints: BatchedSignedConstraints =

--- a/bolt-sidecar/bin/sidecar.rs
+++ b/bolt-sidecar/bin/sidecar.rs
@@ -19,6 +19,7 @@ use bolt_sidecar::{
     BuilderProxyConfig, Config, MevBoostClient,
 };
 
+use beacon_api_client::ProposerDuty;
 use tokio::sync::mpsc;
 use tracing::info;
 
@@ -91,8 +92,10 @@ async fn main() -> eyre::Result<()> {
                     "Validation against execution state passed"
                 );
 
+                let validator_index = find_validator_index_for_slot(&validator_indexes, &consensus_state.get_epoch().proposer_duties, request.slot);
+
                 // parse the request into constraints and sign them with the sidecar signer
-                let message = ConstraintsMessage::build(validator_indexes[0], request.slot, request.clone());
+                let message = ConstraintsMessage::build(validator_index, request.slot, request.clone());
 
                 let signature = signer.sign(&message.digest())?;
                 let signed_constraints: BatchedSignedConstraints =
@@ -138,4 +141,50 @@ async fn main() -> eyre::Result<()> {
     shutdown_tx.send(()).await.ok();
 
     Ok(())
+}
+
+/// Filters the proposer duties and returns the validator index for a given slot
+/// if it doesn't exists then returns 0 by default.
+pub fn find_validator_index_for_slot(
+    validator_indexes: &[u64],
+    proposer_duties: &[ProposerDuty],
+    slot: u64,
+) -> u64 {
+    for duty in proposer_duties {
+        if duty.slot == slot && validator_indexes.contains(&(duty.validator_index as u64)) {
+            return duty.validator_index as u64;
+        }
+    }
+    0
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::find_validator_index_for_slot;
+    use beacon_api_client::ProposerDuty;
+
+    #[test]
+    fn test_filter_index() {
+        let validator_indexes = vec![11, 22, 33];
+        let proposer_duties = vec![
+            ProposerDuty {
+                public_key: Default::default(),
+                slot: 1,
+                validator_index: 11,
+            },
+            ProposerDuty {
+                public_key: Default::default(),
+                slot: 2,
+                validator_index: 22,
+            },
+            ProposerDuty {
+                public_key: Default::default(),
+                slot: 3,
+                validator_index: 33,
+            },
+        ];
+
+        let result = find_validator_index_for_slot(&validator_indexes, &proposer_duties, 2);
+        assert_eq!(result, 22);
+    }
 }

--- a/bolt-sidecar/src/common.rs
+++ b/bolt-sidecar/src/common.rs
@@ -1,3 +1,5 @@
+use std::time::{SystemTime, UNIX_EPOCH};
+
 use alloy_consensus::TxEnvelope;
 use alloy_primitives::U256;
 
@@ -64,6 +66,14 @@ pub fn validate_transaction(
     }
 
     Ok(())
+}
+
+/// Get the current timestamp.
+pub fn unix_seconds() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_secs()
 }
 
 #[cfg(test)]

--- a/bolt-sidecar/src/config.rs
+++ b/bolt-sidecar/src/config.rs
@@ -1,6 +1,7 @@
-use crate::crypto::bls::random_bls_secret;
 use blst::min_pk::SecretKey;
 use clap::{ArgGroup, Args, Parser};
+
+use crate::crypto::bls::random_bls_secret;
 
 /// Command-line options for the sidecar
 #[derive(Parser, Debug)]

--- a/bolt-sidecar/src/config.rs
+++ b/bolt-sidecar/src/config.rs
@@ -29,7 +29,7 @@ pub struct Opts {
     pub(super) max_commitments: Option<usize>,
     /// Validator indexes
     #[clap(short = 'v', long, value_parser, num_args = 0.., value_delimiter = ',')]
-    pub(super) validator_indexes: Vec<String>,
+    pub(super) validator_indexes: Vec<u64>,
     /// Signing options
     #[clap(flatten)]
     pub(super) signing: SigningOpts,
@@ -133,25 +133,10 @@ impl TryFrom<Opts> for Config {
         config.beacon_api_url = opts.beacon_api_url.trim_end_matches('/').to_string();
         config.mevboost_url = opts.mevboost_url.trim_end_matches('/').to_string();
 
-        if let Some(validator_indexes) = opts.validator_indexes {
-            config.validator_indexes = parse_validator_indexes(&validator_indexes)?;
-        }
+        config.validator_indexes = opts.validator_indexes;
 
         Ok(config)
     }
-}
-
-/// Parse the validator indexes input of the form - "1,2,3,4"
-fn parse_validator_indexes(input: &str) -> eyre::Result<Vec<u64>> {
-    input
-        .trim_matches(|c| c == '"' || c == '"')
-        .split(',')
-        .map(|s| {
-            s.trim()
-                .parse()
-                .map_err(|e| eyre::eyre!("Invalid index: {}: {:?}", s, e))
-        })
-        .collect()
 }
 
 /// Limits for the sidecar.

--- a/bolt-sidecar/src/config.rs
+++ b/bolt-sidecar/src/config.rs
@@ -86,7 +86,7 @@ impl Default for Config {
             private_key: Some(random_bls_secret()),
             mevboost_proxy_port: 18551,
             limits: Limits::default(),
-            validator_indexes: vec![0], // Default to the first validator
+            validator_indexes: vec![0], // Default to 0 index
         }
     }
 }

--- a/bolt-sidecar/src/config.rs
+++ b/bolt-sidecar/src/config.rs
@@ -28,8 +28,8 @@ pub struct Opts {
     #[clap(short = 'm', long)]
     pub(super) max_commitments: Option<usize>,
     /// Validator indexes
-    #[clap(short = 'v', long)]
-    pub(super) validator_indexes: Option<String>,
+    #[clap(short = 'v', long, value_parser, num_args = 0.., value_delimiter = ',')]
+    pub(super) validator_indexes: Vec<String>,
     /// Signing options
     #[clap(flatten)]
     pub(super) signing: SigningOpts,

--- a/bolt-sidecar/src/config.rs
+++ b/bolt-sidecar/src/config.rs
@@ -28,7 +28,7 @@ pub struct Opts {
     #[clap(short = 'm', long)]
     pub(super) max_commitments: Option<usize>,
     /// Validator indexes
-    #[clap(short = 'v', long, value_parser, num_args = 0.., value_delimiter = ',')]
+    #[clap(short = 'v', long, value_parser, num_args = 1.., value_delimiter = ',')]
     pub(super) validator_indexes: Vec<u64>,
     /// Signing options
     #[clap(flatten)]

--- a/bolt-sidecar/src/config.rs
+++ b/bolt-sidecar/src/config.rs
@@ -144,7 +144,7 @@ impl TryFrom<Opts> for Config {
 /// Parse the validator indexes input of the form - "1,2,3,4"
 fn parse_validator_indexes(input: &str) -> eyre::Result<Vec<u64>> {
     input
-        .trim_matches(|c| c == '"' || c == '"') // Remove the surrounding brackets
+        .trim_matches(|c| c == '"' || c == '"')
         .split(',')
         .map(|s| {
             s.trim()

--- a/bolt-sidecar/src/config.rs
+++ b/bolt-sidecar/src/config.rs
@@ -86,7 +86,7 @@ impl Default for Config {
             private_key: Some(random_bls_secret()),
             mevboost_proxy_port: 18551,
             limits: Limits::default(),
-            validator_indexes: Vec::new(),
+            validator_indexes: vec![0], // Default to the first validator
         }
     }
 }
@@ -140,7 +140,7 @@ impl TryFrom<Opts> for Config {
     }
 }
 
-/// Parse the validator indexes from the command-line argument
+/// Parse the validator indexes to seperate them by commas
 fn parse_validator_indexes(input: &str) -> eyre::Result<Vec<u64>> {
     input
         .split(',')

--- a/bolt-sidecar/src/state/consensus.rs
+++ b/bolt-sidecar/src/state/consensus.rs
@@ -121,7 +121,7 @@ impl ConsensusState {
 
     /// Filters the proposer duties and returns the validator index for a given slot
     /// if it doesn't exists then returns error.
-    pub fn find_validator_index_for_slot(&self, slot: u64) -> Result<u64, ConsensusError> {
+    fn find_validator_index_for_slot(&self, slot: u64) -> Result<u64, ConsensusError> {
         self.epoch
             .proposer_duties
             .iter()
@@ -166,7 +166,7 @@ mod tests {
         let validator_indexes = vec![100, 102];
 
         // Create a ConsensusState with the sample proposer duties and validator indexes
-        let mut state = ConsensusState {
+        let state = ConsensusState {
             beacon_api_client: Client::new(Url::parse("http://localhost").unwrap()),
             header: BeaconBlockHeader::default(),
             epoch: Epoch {

--- a/bolt-sidecar/src/state/consensus.rs
+++ b/bolt-sidecar/src/state/consensus.rs
@@ -109,6 +109,10 @@ impl ConsensusState {
         self.epoch.proposer_duties = duties.1;
         Ok(())
     }
+
+    pub fn get_epoch(&self) -> &Epoch {
+        &self.epoch
+    }
 }
 
 /// Get the current timestamp.

--- a/bolt-sidecar/src/state/mod.rs
+++ b/bolt-sidecar/src/state/mod.rs
@@ -24,11 +24,6 @@ pub enum StateError {
     Rpc(#[from] TransportError),
 }
 
-#[derive(Debug, Clone)]
-struct ProposerDuties {
-    assigned_slots: Vec<u64>,
-}
-
 #[cfg(test)]
 mod tests {
     use alloy_consensus::constants::ETH_TO_WEI;


### PR DESCRIPTION
This PR adds CLI option to pass `validator_index` as comma-separated values i.e. `--validator-index "1,2,3,4"`

fixes #57 