### PR TITLE
fix: self-building payloads in kurtosis devnet

### DIFF
--- a/bolt-sidecar/Cargo.lock
+++ b/bolt-sidecar/Cargo.lock
@@ -1282,6 +1282,8 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
+ "tree_hash",
+ "tree_hash_derive",
  "warp",
 ]
 

--- a/bolt-sidecar/Cargo.toml
+++ b/bolt-sidecar/Cargo.toml
@@ -14,6 +14,8 @@ futures = "0.3"
 
 # crypto
 blst = "0.3.12"
+tree_hash = "0.5"
+tree_hash_derive = "0.5"
 secp256k1 = { version = "0.29.0", features = ["rand"] }
 
 # alloy

--- a/bolt-sidecar/src/api/spec.rs
+++ b/bolt-sidecar/src/api/spec.rs
@@ -133,7 +133,7 @@ pub trait BuilderApi {
     async fn get_payload(
         &self,
         signed_block: SignedBlindedBeaconBlock,
-    ) -> Result<VersionedValue<GetPayloadResponse>, BuilderApiError>;
+    ) -> Result<GetPayloadResponse, BuilderApiError>;
 }
 
 #[async_trait::async_trait]

--- a/bolt-sidecar/src/api/spec.rs
+++ b/bolt-sidecar/src/api/spec.rs
@@ -19,9 +19,6 @@ pub const STATUS_PATH: &str = "/eth/v1/builder/status";
 pub const REGISTER_VALIDATORS_PATH: &str = "/eth/v1/builder/validators";
 /// The path to the builder API get header endpoint.
 pub const GET_HEADER_PATH: &str = "/eth/v1/builder/header/:slot/:parent_hash/:pubkey";
-/// The path to the constriants API get header with proofs endpoint.
-pub const GET_HEADER_WITH_PROOFS_PATH: &str =
-    "/eth/v1/builder/header_with_proofs/:slot/:parent_hash/:pubkey";
 /// The path to the builder API get payload endpoint.
 pub const GET_PAYLOAD_PATH: &str = "/eth/v1/builder/blinded_blocks";
 /// The path to the constraints API submit constraints endpoint.

--- a/bolt-sidecar/src/builder/mod.rs
+++ b/bolt-sidecar/src/builder/mod.rs
@@ -115,7 +115,7 @@ impl LocalBuilder {
         let payload_and_blobs = PayloadAndBlobs {
             execution_payload: eth_payload,
             // TODO: add included blobs here
-            blobs_bundle: None,
+            blobs_bundle: Default::default(),
         };
 
         // 2. create a signed builder bid with the sealed block header we just created

--- a/bolt-sidecar/src/builder/signature.rs
+++ b/bolt-sidecar/src/builder/signature.rs
@@ -118,7 +118,7 @@ mod tests {
     use crate::{builder::signature::compute_builder_domain, config::Chain};
 
     #[test]
-    pub fn test_compute_builder_domain() {
+    fn test_compute_builder_domain() {
         let mainnet = Chain::Mainnet;
         assert_eq!(
             compute_builder_domain(mainnet.fork_version(), None),

--- a/bolt-sidecar/src/builder/signature.rs
+++ b/bolt-sidecar/src/builder/signature.rs
@@ -1,0 +1,146 @@
+use alloy_rpc_types_beacon::{constants::BLS_DST_SIG, BlsSignature};
+use blst::min_pk::{PublicKey, SecretKey};
+use blst::BLST_ERROR;
+use ethereum_consensus::crypto::Signature;
+use ethereum_consensus::deneb::{compute_fork_data_root, Domain, DomainType, Root};
+use ethereum_consensus::ssz::prelude::{HashTreeRoot, MerkleizationError};
+use tree_hash::TreeHash;
+use tree_hash_derive::TreeHash;
+
+use crate::Chain;
+
+/// Sign a SSZ object a BLS secret key, using the Application Builder domain
+/// for signing arbitrary builder-api messages in the out-of-protocol specifications.
+///
+/// Fun Note: we use a `blst` secret key to sign a message, and produce an `alloy` signature,
+/// which is then converted to an `ethereum-consensus` signature.
+pub fn sign_builder_message<T: HashTreeRoot>(
+    chain: &Chain,
+    sk: &SecretKey,
+    msg: &T,
+) -> Result<Signature, MerkleizationError> {
+    let domain = chain.builder_domain();
+    let object_root = msg.hash_tree_root()?.0;
+    let signing_root = compute_signing_root(object_root, domain);
+
+    let alloy_signature = sign_message(sk, &signing_root);
+    let consensus_signature =
+        Signature::try_from(alloy_signature.as_slice()).expect("valid signature bytes");
+
+    Ok(consensus_signature)
+}
+
+/// Verify a SSZ object signed with a BLS public key, using the Application Builder domain
+/// for signing arbitrary builder-api messages in the out-of-protocol specifications.
+pub fn verify_signed_builder_message<T: HashTreeRoot>(
+    chain: &Chain,
+    pubkey: &PublicKey,
+    msg: &T,
+    signature: &BlsSignature,
+) -> Result<(), ethereum_consensus::Error> {
+    let domain = chain.builder_domain();
+    let object_root = msg.hash_tree_root()?.0;
+    let signing_root = compute_signing_root(object_root, domain);
+
+    verify_signature(pubkey, &signing_root, signature).map_err(|_| {
+        ethereum_consensus::Error::Bls(ethereum_consensus::crypto::BlsError::InvalidSignature)
+    })
+}
+
+/// Verify a BLS signature for a given message and public key.
+pub fn verify_signature(
+    pubkey: &PublicKey,
+    msg: &[u8],
+    signature: &BlsSignature,
+) -> Result<(), blst::BLST_ERROR> {
+    let sig = blst::min_pk::Signature::from_bytes(&signature.0).expect("valid signature bytes");
+
+    let res = sig.verify(true, msg, BLS_DST_SIG, &[], pubkey, true);
+    if res == BLST_ERROR::BLST_SUCCESS {
+        Ok(())
+    } else {
+        Err(res)
+    }
+}
+
+/// Sign arbitrary bytes with a BLS secret key, using the BLS DST signature domain,
+/// as defined in the Ethereum 2.0 specification. It stands for "Domain Separation Tag
+/// for hash_to_point in Ethereum beacon chain BLS12-381 signatures".
+pub fn sign_message(secret_key: &SecretKey, msg: &[u8]) -> BlsSignature {
+    let signature = secret_key.sign(msg, BLS_DST_SIG, &[]).to_bytes();
+    BlsSignature::from_slice(&signature)
+}
+
+/// Helper struct to compute the signing root for a given object
+/// root and signing domain as defined in the Ethereum 2.0 specification.
+#[derive(Default, Debug, TreeHash)]
+struct SigningData {
+    object_root: [u8; 32],
+    signing_domain: [u8; 32],
+}
+
+/// Compute the signing root for a given object root and signing domain.
+pub fn compute_signing_root(object_root: [u8; 32], signing_domain: [u8; 32]) -> [u8; 32] {
+    let signing_data = SigningData {
+        object_root,
+        signing_domain,
+    };
+    signing_data.tree_hash_root().0
+}
+
+/// Compute the Application Builder domain for signing arbitrary
+/// builder-api messages in the out-of-protocol specifications
+///
+/// Docs: <https://github.com/ethereum/builder-specs/blob/982af908707113de373e62babee113782e6bb6cd/specs/bellatrix/builder.md#signing>
+#[allow(dead_code)]
+pub fn compute_builder_domain(
+    fork_version: [u8; 4],
+    genesis_validators_root: Option<[u8; 32]>,
+) -> [u8; 32] {
+    // The builder-specs require the genesis_validators_root to be 0x00
+    // for any out-of-protocol message. Here we leave the option to set
+    // it to a custom value if any devnet violates this rule.
+    let root = genesis_validators_root.map_or(Root::default(), |root| Root::from_slice(&root));
+
+    let fork_data_root = compute_fork_data_root(fork_version, root).expect("valid fork data");
+
+    // Also known as `DOMAIN_APPLICATION_BUILDER` in the specs
+    let domain_type = DomainType::ApplicationBuilder;
+
+    let mut domain = Domain::default();
+    domain[..4].copy_from_slice(&domain_type.as_bytes());
+    domain[4..].copy_from_slice(&fork_data_root[..28]);
+    domain
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::{builder::signature::compute_builder_domain, config::Chain};
+
+    #[test]
+    pub fn test_compute_builder_domain() {
+        let mainnet = Chain::Mainnet;
+        assert_eq!(
+            compute_builder_domain(mainnet.fork_version(), None),
+            mainnet.builder_domain()
+        );
+
+        let holesky = Chain::Holesky;
+        assert_eq!(
+            compute_builder_domain(holesky.fork_version(), None),
+            holesky.builder_domain()
+        );
+
+        let kurtosis = Chain::Kurtosis;
+        assert_eq!(
+            compute_builder_domain(kurtosis.fork_version(), None),
+            kurtosis.builder_domain()
+        );
+
+        let helder = Chain::Helder;
+        assert_eq!(
+            compute_builder_domain(helder.fork_version(), None),
+            helder.builder_domain()
+        );
+    }
+}

--- a/bolt-sidecar/src/client/mevboost.rs
+++ b/bolt-sidecar/src/client/mevboost.rs
@@ -109,7 +109,7 @@ impl BuilderApi for MevBoostClient {
     async fn get_payload(
         &self,
         signed_block: SignedBlindedBeaconBlock,
-    ) -> Result<VersionedValue<GetPayloadResponse>, BuilderApiError> {
+    ) -> Result<GetPayloadResponse, BuilderApiError> {
         let response = self
             .client
             .post(self.endpoint(GET_PAYLOAD_PATH))

--- a/bolt-sidecar/src/config.rs
+++ b/bolt-sidecar/src/config.rs
@@ -121,8 +121,8 @@ impl Chain {
             }
             Chain::Kurtosis => {
                 // TODO: verify this
-                b256!("00000001f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a9").0
-                // b256!("000000013e2b3354ba8a4ebaed231d0ae887bf5c974f080dbc63f09a57da1637").0
+                // b256!("00000001f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a9").0
+                b256!("000000010b41be4cdb34d183dddca5398337626dcdcfaf1720c1202d3b95f84e").0
             }
             Chain::Helder => {
                 b256!("0000000194c41af484fff7964969e0bdd922f82dff0f4be87a60d0664cc9d1ff").0
@@ -135,7 +135,7 @@ impl Chain {
         match self {
             Chain::Mainnet => [0u8; 4],
             Chain::Holesky => [1, 1, 112, 0],
-            Chain::Kurtosis => [0u8; 4], // TODO
+            Chain::Kurtosis => [16, 0, 0, 56],
             Chain::Helder => [16, 0, 0, 0],
         }
     }

--- a/bolt-sidecar/src/config.rs
+++ b/bolt-sidecar/src/config.rs
@@ -120,8 +120,6 @@ impl Chain {
                 b256!("000000015b83a23759c560b2d0c64576e1dcfc34ea94c4988f3e0d9f77f05387").0
             }
             Chain::Kurtosis => {
-                // TODO: verify this
-                // b256!("00000001f5a5fd42d16a20302798ef6ed309979b43003d2320d9f0e8ea9831a9").0
                 b256!("000000010b41be4cdb34d183dddca5398337626dcdcfaf1720c1202d3b95f84e").0
             }
             Chain::Helder => {

--- a/bolt-sidecar/src/json_rpc/mod.rs
+++ b/bolt-sidecar/src/json_rpc/mod.rs
@@ -19,7 +19,7 @@ use self::api::CommitmentsRpc;
 use self::spec::{JsonRpcError, JsonRpcRequest, JsonRpcResponse};
 
 /// Start the JSON-RPC server. Returns a sender that can be used to send a shutdown signal.
-pub async fn start_server(
+pub async fn start_rpc_server(
     config: &Config,
     event_tx: mpsc::Sender<ApiEvent>,
 ) -> eyre::Result<mpsc::Sender<()>> {

--- a/bolt-sidecar/src/lib.rs
+++ b/bolt-sidecar/src/lib.rs
@@ -6,8 +6,8 @@
 /// Builder API proxy and utilities
 mod api;
 pub use api::{
-    builder::{start_builder_proxy, BuilderProxyConfig},
-    spec,
+    builder::{start_builder_proxy_server, BuilderProxyConfig},
+    spec::{BuilderApi, ConstraintsApi},
 };
 
 mod client;
@@ -21,16 +21,18 @@ mod common;
 /// be used as a fallback for proposers. It's also used to keep
 /// any intermediary state that is needed to simulate EVM execution
 pub mod builder;
+pub use builder::LocalBuilder;
 
 /// Configuration and command-line argument parsing
 mod config;
-pub use config::{Config, Opts};
+pub use config::{Chain, Config, Opts};
 
 /// Crypto utilities, including BLS and ECDSA
 pub mod crypto;
 
 /// JSON-RPC server and handlers
 pub mod json_rpc;
+pub use json_rpc::start_rpc_server;
 
 /// Primitive types and utilities
 pub mod primitives;

--- a/bolt-sidecar/src/primitives/mod.rs
+++ b/bolt-sidecar/src/primitives/mod.rs
@@ -5,9 +5,9 @@ use std::sync::{atomic::AtomicU64, Arc};
 
 use alloy_primitives::U256;
 use ethereum_consensus::{
-    capella,
     crypto::{KzgCommitment, PublicKey as BlsPublicKey, Signature as BlsSignature},
     deneb::{
+        self,
         mainnet::{BlobsBundle, MAX_BLOB_COMMITMENTS_PER_BLOCK},
         presets::mainnet::ExecutionPayloadHeader,
         Hash32,
@@ -145,14 +145,14 @@ impl PayloadFetcher for NoopPayloadFetcher {
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
 pub struct PayloadAndBlobs {
     pub execution_payload: ExecutionPayload,
-    pub blobs_bundle: Option<BlobsBundle>,
+    pub blobs_bundle: BlobsBundle,
 }
 
 impl Default for PayloadAndBlobs {
     fn default() -> Self {
         Self {
-            execution_payload: ExecutionPayload::Capella(capella::ExecutionPayload::default()),
-            blobs_bundle: None,
+            execution_payload: ExecutionPayload::Deneb(deneb::ExecutionPayload::default()),
+            blobs_bundle: BlobsBundle::default(),
         }
     }
 }


### PR DESCRIPTION
- [x] fixed: signature error on `get_header` response with fallback payloads
- [x] fixed: added fork_version to compute builder_domain for signing builder-api messages
- [x] fixed: wrong return type for get_payload (due to serde enum tag versioning)
- [x] fixed: SSZ transactions_root and withdrawals_root in consensus execution payload header instead of MPT