### PR TITLE
Fix short options to allow startup

### DIFF
--- a/bolt-sidecar/src/config/mod.rs
+++ b/bolt-sidecar/src/config/mod.rs
@@ -57,7 +57,7 @@ pub struct Opts {
     pub(super) fee_recipient: Address,
     /// Secret BLS key to sign fallback payloads with
     /// (If not provided, a random key will be used)
-    #[clap(short = 'k', long)]
+    #[clap(short = 'K', long)]
     pub(super) builder_private_key: Option<String>,
     /// Chain config for the chain on which the sidecar is running
     #[clap(flatten)]

--- a/bolt-sidecar/src/config/signing.rs
+++ b/bolt-sidecar/src/config/signing.rs
@@ -11,6 +11,6 @@ pub struct SigningOpts {
     #[clap(short = 'k', long)]
     pub(super) private_key: Option<String>,
     /// URL for the commit-boost sidecar
-    #[clap(short = 'C', long, conflicts_with("private_key"))]
+    #[clap(short = 'B', long, conflicts_with("private_key"))]
     pub(super) commit_boost_url: Option<String>,
 }


### PR DESCRIPTION
Some short options were conflicting:

```
Command bolt-sidecar: Short option names must be unique for each argument, but '-k' is in use by both 'builder_private_key' and 'private_key'
```

```
Command bolt-sidecar: Short option names must be unique for each argument, but '-C' is in use by both 'chain' and 'commit_boost_url'
```

This changes short options to not conflict.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated command-line flags for better consistency and usability:
    - Changed the short flag for `builder_private_key` from `-k` to `-K`.
    - Changed the short flag for `commit_boost_url` from `-C` to `-B`.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->