### PR TITLE
chore(sidecar): add parsing validator indexes as ranges

### DIFF
--- a/bolt-sidecar/bin/sidecar.rs
+++ b/bolt-sidecar/bin/sidecar.rs
@@ -37,7 +37,7 @@ async fn main() -> eyre::Result<()> {
     let shutdown_tx = start_rpc_server(&config, api_events).await?;
     let mut consensus_state = ConsensusState::new(
         beacon_client.clone(),
-        &config.validator_indexes,
+        config.validator_indexes.clone(),
         config.chain.commitment_deadline(),
     );
 

--- a/bolt-sidecar/src/config/mod.rs
+++ b/bolt-sidecar/src/config/mod.rs
@@ -1,4 +1,4 @@
-use std::{fs::read_to_string, path::Path};
+use std::{fs::read_to_string, path::Path, str::FromStr};
 
 use alloy_primitives::Address;
 use blst::min_pk::SecretKey;
@@ -6,6 +6,9 @@ use clap::Parser;
 use reqwest::Url;
 
 use crate::crypto::bls::random_bls_secret;
+
+pub mod validator_indexes;
+pub use validator_indexes::ValidatorIndexes;
 
 pub mod chain;
 pub use chain::ChainConfig;
@@ -43,9 +46,13 @@ pub struct Opts {
     /// Max number of commitments to accept per block
     #[clap(short = 'm', long)]
     pub(super) max_commitments: Option<usize>,
-    /// Validator indexes
-    #[clap(short = 'v', long, value_parser, num_args = 1.., value_delimiter = ',')]
-    pub(super) validator_indexes: Vec<u64>,
+    /// Validator indexes of connected validators that the sidecar
+    /// should accept commitments on behalf of. Accepted values:
+    /// - a comma-separated list of indexes (e.g. "1,2,3,4")
+    /// - a contiguous range of indexes (e.g. "1..4")
+    /// - a mix of the above (e.g. "1,2..4,6..8")
+    #[clap(short = 'v', long, value_parser = ValidatorIndexes::from_str)]
+    pub(super) validator_indexes: ValidatorIndexes,
     /// The JWT secret token to authenticate calls to the engine API.
     ///
     /// It can either be a hex-encoded string or a file path to a file
@@ -95,7 +102,7 @@ pub struct Config {
     pub limits: Limits,
     /// Validator indexes of connected validators that the
     /// sidecar should accept commitments on behalf of
-    pub validator_indexes: Vec<u64>,
+    pub validator_indexes: ValidatorIndexes,
     /// Local bulider private key for signing fallback payloads.
     /// If not provided, a random key will be used.
     pub builder_private_key: SecretKey,
@@ -118,7 +125,7 @@ impl Default for Config {
             fee_recipient: Address::ZERO,
             builder_private_key: random_bls_secret(),
             limits: Limits::default(),
-            validator_indexes: Vec::new(),
+            validator_indexes: ValidatorIndexes::default(),
             chain: ChainConfig::default(),
         }
     }

--- a/bolt-sidecar/src/config/validator_indexes.rs
+++ b/bolt-sidecar/src/config/validator_indexes.rs
@@ -1,0 +1,72 @@
+use std::str::FromStr;
+
+#[derive(Debug, Clone, Default)]
+pub struct ValidatorIndexes(Vec<u64>);
+
+impl ValidatorIndexes {
+    pub fn contains(&self, index: u64) -> bool {
+        self.0.contains(&index)
+    }
+}
+
+impl FromStr for ValidatorIndexes {
+    type Err = eyre::Report;
+
+    /// Parse an array of validator indexes. Accepted values:
+    /// - a comma-separated list of indexes (e.g. "1,2,3,4")
+    /// - a contiguous range of indexes (e.g. "1..4")
+    /// - a mix of the above (e.g. "1,2..4,6..8")
+    ///
+    /// TODO: add parsing from a directory path, using the format of
+    /// validator definitions
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        let s = s.trim();
+        let mut vec = Vec::new();
+
+        for comma_separated_part in s.split(',') {
+            if comma_separated_part.contains("..") {
+                let mut parts = comma_separated_part.split("..");
+
+                let start = parts.next().ok_or_else(|| eyre::eyre!("Invalid range"))?;
+                let start = start.parse::<u64>()?;
+
+                let end = parts.next().ok_or_else(|| eyre::eyre!("Invalid range"))?;
+                let end = end.parse::<u64>()?;
+
+                vec.extend(start..=end);
+            } else {
+                let index = comma_separated_part.parse::<u64>()?;
+                vec.push(index);
+            }
+        }
+
+        Ok(Self(vec))
+    }
+}
+
+impl From<Vec<u64>> for ValidatorIndexes {
+    fn from(vec: Vec<u64>) -> Self {
+        Self(vec)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_parse_validator_indexes() {
+        use super::ValidatorIndexes;
+        use std::str::FromStr;
+
+        let indexes = ValidatorIndexes::from_str("1,2,3,4").unwrap();
+        assert_eq!(indexes.0, vec![1, 2, 3, 4]);
+
+        let indexes = ValidatorIndexes::from_str("1..4").unwrap();
+        assert_eq!(indexes.0, vec![1, 2, 3, 4]);
+
+        let indexes = ValidatorIndexes::from_str("1..4,6..8").unwrap();
+        assert_eq!(indexes.0, vec![1, 2, 3, 4, 6, 7, 8]);
+
+        let indexes = ValidatorIndexes::from_str("1,2..4,6..8").unwrap();
+        assert_eq!(indexes.0, vec![1, 2, 3, 4, 6, 7, 8]);
+    }
+}


### PR DESCRIPTION
This PR adds the ability to parse validator index ranges from an array of comma-separated ranges.
ValidatorIndex also becomes a separate struct to allow for future parsing methods too, including from a keystore directory which would be handy for validators

example of valid values:

```
--validator-indexes 1,2,3,4,5
--validator-indexes 1..3,5..7
--validator-indexes 1,2,3,67..97,194,529..541
```