### PR TITLE
feat(contracts): parse validator indexes as arrays from solidity

### DIFF
--- a/bolt-contracts/script/RegisterValidators.s.sol
+++ b/bolt-contracts/script/RegisterValidators.s.sol
@@ -10,11 +10,18 @@ contract RegisterValidators is Script {
     uint64[] public validatorIndexes;
     address public registryAddress = 0xdF11D829eeC4C192774F3Ec171D822f6Cb4C14d9;
 
+    using StringToUintArrayLib for string;
+
     function run() public {
         signerKey = vm.envUint("PRIVATE_KEY");
-        string[] memory indexStrings = vm.envString("VALIDATOR_INDEXES", ",");
         string memory rpc = vm.envString("RPC_ADDR");
         vm.startBroadcast(signerKey);
+
+        string memory validatorIndexesEnv = vm.envString("VALIDATOR_INDEXES");
+        uint256[] memory indexes = StringToUintArrayLib.fromStr(validatorIndexesEnv);
+        for (uint256 i = 0; i < indexes.length; i++) {
+            validatorIndexes.push(uint64(indexes[i]));
+        }
 
         console.log("Bolt registry address:", registryAddress);
         BoltRegistry registry = BoltRegistry(registryAddress);
@@ -33,10 +40,6 @@ contract RegisterValidators is Script {
             revert("Insufficient balance");
         }
 
-        for (uint256 i = 0; i < indexStrings.length; i++) {
-            validatorIndexes.push(uint64(vm.parseUint(indexStrings[i])));
-        }
-
         // Register with minimal collateral
         registry.register{value: registry.MINIMUM_COLLATERAL()}(
             validatorIndexes,
@@ -45,5 +48,66 @@ contract RegisterValidators is Script {
         );
 
         vm.stopBroadcast();
+    }
+}
+
+library StringToUintArrayLib {
+    // Maximum number of validators parsed in a single function call
+    uint256 constant MAX_VALIDATORS = 256;
+
+    function fromStr(string memory s) internal pure returns (uint256[] memory) {
+        bytes memory strBytes = bytes(s);
+        uint256[] memory vec = new uint256[](MAX_VALIDATORS); // Initial allocation, will resize later
+        uint256 vecIndex = 0;
+        uint256 tempNum;
+        bool parsingRange = false;
+        uint256 rangeStart;
+
+        for (uint256 i = 0; i < strBytes.length; i++) {
+            if (strBytes[i] == ',') {
+                if (parsingRange) {
+                    // Handle end of range
+                    for (uint256 j = rangeStart; j <= tempNum; j++) {
+                        vec[vecIndex] = j;
+                        vecIndex++;
+                    }
+                    parsingRange = false;
+                } else {
+                    // Handle single number
+                    vec[vecIndex] = tempNum;
+                    vecIndex++;
+                }
+                tempNum = 0;
+            } else if (strBytes[i] == '.') {
+                if (i + 1 < strBytes.length && strBytes[i + 1] == '.') {
+                    // Handle start of range
+                    parsingRange = true;
+                    rangeStart = tempNum;
+                    tempNum = 0;
+                    i++; // Skip next dot
+                }
+            } else if (strBytes[i] >= '0' && strBytes[i] <= '9') {
+                tempNum = tempNum * 10 + (uint8(strBytes[i]) - 48); // Convert ASCII to integer
+            }
+        }
+
+        // Handle the last part after the final comma (or single number/range end)
+        if (parsingRange) {
+            for (uint256 j = rangeStart; j <= tempNum; j++) {
+                vec[vecIndex] = j;
+                vecIndex++;
+            }
+        } else {
+            vec[vecIndex] = tempNum;
+            vecIndex++;
+        }
+
+        // Resize array to actual size
+        uint256[] memory result = new uint256[](vecIndex);
+        for (uint256 i = 0; i < vecIndex; i++) {
+            result[i] = vec[i];
+        }
+
+        return result;
     }
 }

--- a/bolt-contracts/script/RegisterValidators.s.sol
+++ b/bolt-contracts/script/RegisterValidators.s.sol
@@ -10,8 +10,6 @@ contract RegisterValidators is Script {
     uint64[] public validatorIndexes;
     address public registryAddress = 0xdF11D829eeC4C192774F3Ec171D822f6Cb4C14d9;
 
-    using StringToUintArrayLib for string;
-
     function run() public {
         signerKey = vm.envUint("PRIVATE_KEY");
         string memory rpc = vm.envString("RPC_ADDR");

--- a/bolt-contracts/test/StringToUintArrayLib.t.sol
+++ b/bolt-contracts/test/StringToUintArrayLib.t.sol
@@ -1,0 +1,82 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import "forge-std/Test.sol";
+import "../script/RegisterValidators.s.sol";
+
+contract StringToUintArrayTest is Test {
+
+    function setUp() public {}
+
+    function testParseValidatorIndexes1() public pure {
+        uint256[] memory indexes = StringToUintArrayLib.fromStr("1,2,3,4");
+        uint256[4] memory expected;
+        expected[0] = 1;
+        expected[1] = 2;
+        expected[2] = 3;
+        expected[3] = 4;
+
+        assertEq(indexes.length, expected.length);
+        for (uint256 i = 0; i < indexes.length; i++) {
+            assertEq(indexes[i], expected[i]);
+        }
+    }
+
+    function testParseValidatorIndexes2() public pure {
+        uint256[] memory indexes = StringToUintArrayLib.fromStr("1..4");
+        uint256[4] memory expected;
+        expected[0] = 1;
+        expected[1] = 2;
+        expected[2] = 3;
+        expected[3] = 4;
+
+        assertEq(indexes.length, expected.length);
+        for (uint256 i = 0; i < indexes.length; i++) {
+            assertEq(indexes[i], expected[i]);
+        }
+    }
+
+    function testParseValidatorIndexes3() public pure {
+        uint256[] memory indexes = StringToUintArrayLib.fromStr("1..4,6..8");
+        uint256[7] memory expected;
+        expected[0] = 1;
+        expected[1] = 2;
+        expected[2] = 3;
+        expected[3] = 4;
+        expected[4] = 6;
+        expected[5] = 7;
+        expected[6] = 8;
+
+        assertEq(indexes.length, expected.length);
+        for (uint256 i = 0; i < indexes.length; i++) {
+            assertEq(indexes[i], expected[i]);
+        }
+    }
+
+    function testParseValidatorIndexes4() public pure {
+        uint256[] memory indexes = StringToUintArrayLib.fromStr("1,2..4,6..8");
+        uint256[7] memory expected;
+        expected[0] = 1;
+        expected[1] = 2;
+        expected[2] = 3;
+        expected[3] = 4;
+        expected[4] = 6;
+        expected[5] = 7;
+        expected[6] = 8;
+
+        assertEq(indexes.length, expected.length);
+        for (uint256 i = 0; i < indexes.length; i++) {
+            assertEq(indexes[i], expected[i]);
+        }
+    }
+
+    function testParse100Indexes() public pure {
+        string memory input = "1..100";
+
+        uint256[] memory indexes = StringToUintArrayLib.fromStr(input);
+        assertEq(indexes.length, 100);
+        for (uint256 i = 0; i < indexes.length; i++) {
+            assertEq(indexes[i], i + 1);
+        }
+    }
+}


### PR DESCRIPTION
Replicates the rust functionality added in #119, but in Solidity for registering on-chain.
Testing this soon with registration of our validators on Helder.

UPDATE: the script worked and allowed me to register 100 validators using the provided range.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Enhanced the `RegisterValidators` contract to process validator indexes more efficiently using a new library for string-to-uint256 conversion.
  - Introduced the `StringToUintArrayLib` library with the `fromStr` function to convert strings of validator indexes into `uint256` arrays.

- **Tests**
  - Added tests for the `StringToUintArrayLib` to validate its functionality in converting strings to arrays of `uint256`.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->