### PR TITLE
fix(sidecar): wrong slot-diff while checking preconf

### DIFF
--- a/bolt-sidecar/bin/sidecar.rs
+++ b/bolt-sidecar/bin/sidecar.rs
@@ -122,7 +122,7 @@ async fn main() -> eyre::Result<()> {
                 tracing::info!(slot, "Received new head event");
 
                 // We use None to signal that we want to fetch the latest EL head
-                if let Err(e) = execution_state.update_head(None).await {
+                if let Err(e) = execution_state.update_head(None, slot).await {
                     tracing::error!(err = ?e, "Failed to update execution state head");
                 }
 

--- a/bolt-sidecar/src/state/execution.rs
+++ b/bolt-sidecar/src/state/execution.rs
@@ -188,7 +188,7 @@ impl<C: StateFetcher> ExecutionState<C> {
         }
     }
 
-    /// Updates the state corresponding to the provided block number or slot.
+    /// Updates the state corresponding to the provided block number and slot.
     /// If the block number is not provided, the state will be updated to
     /// the latest head from the EL.
     pub async fn update_head(

--- a/bolt-sidecar/src/state/mod.rs
+++ b/bolt-sidecar/src/state/mod.rs
@@ -297,7 +297,10 @@ mod tests {
         let receipt = notif.get_receipt().await.unwrap();
 
         // Update the head, which should invalidate the transaction due to a nonce conflict
-        state.update_head(receipt.block_number).await.unwrap();
+        state
+            .update_head(receipt.block_number, receipt.block_number.unwrap())
+            .await
+            .unwrap();
 
         let transactions_len = state.block_templates().get(&10).unwrap().transactions_len();
         assert!(transactions_len == 0);


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Enhanced `update_head` function to track slot information, improving transaction validation and state updates.
  
- **Bug Fixes**
  - Improved execution state management by introducing slot tracking.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->