### PR TITLE
fix(devnet): build docker images using --load flag

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -109,19 +109,19 @@ build-images:
 
 # build the docker image for the bolt builder
 _build-builder:
-	cd builder && docker buildx build -t ghcr.io/chainbound/bolt-builder:0.1.0 .
+	cd builder && docker buildx build -t ghcr.io/chainbound/bolt-builder:0.1.0 . --load
 
 # build the docker image for the bolt relay
 _build-relay:
-	cd mev-boost-relay && docker buildx build -t ghcr.io/chainbound/bolt-relay:0.1.0 .
+	cd mev-boost-relay && docker buildx build -t ghcr.io/chainbound/bolt-relay:0.1.0 . --load
 
 # build the docker image for the bolt sidecar
 _build-sidecar:
-	cd bolt-sidecar && docker buildx build -t ghcr.io/chainbound/bolt-sidecar:0.1.0 .
+	cd bolt-sidecar && docker buildx build -t ghcr.io/chainbound/bolt-sidecar:0.1.0 . --load
 
 # build the docker image for the bolt mev-boost sidecar
 _build-mevboost:
-	cd mev-boost && docker buildx build -t ghcr.io/chainbound/bolt-mev-boost:0.1.0 .
+	cd mev-boost && docker buildx build -t ghcr.io/chainbound/bolt-mev-boost:0.1.0 . --load
 
 # push all the docker images to the private github container registry
 _push-images:


### PR DESCRIPTION
Apparently, new docker versions (using `v24.0.9`) require a `--load` flag to actually load the image into docker, otherwise it will be just kept in the cache, as outlined by this warning after the command `docker buildx build -t ghcr.io/chainbound/bolt-mev-boost:0.1.0 .`:
```text
WARNING: No output specified with docker-container driver. Build result will only remain in the build cache. To push result image into registry use --push or to load image into docker use --load
```

Such flag is now introduced in the `justfile` for all building commands

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Updated Docker build commands to include the `--load` flag, optimizing the image building process in the container registry setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->