### PR TITLE
wip(sidecar): low-level `SidecarDriver`

### DIFF
--- a/bolt-sidecar/bin/sidecar.rs
+++ b/bolt-sidecar/bin/sidecar.rs
@@ -104,7 +104,7 @@ async fn main() -> eyre::Result<()> {
                 let res = serde_json::to_value(signed_constraints).map_err(Into::into);
                 let _ = response_tx.send(res).ok();
             },
-            Ok(HeadEvent { slot, .. }) = head_tracker.next_head() => {
+            Some(HeadEvent { slot, .. }) = head_tracker.next_head() => {
                 tracing::info!(slot, "Received new head event");
 
                 // We use None to signal that we want to fetch the latest EL head

--- a/bolt-sidecar/src/builder/mod.rs
+++ b/bolt-sidecar/src/builder/mod.rs
@@ -60,7 +60,7 @@ pub enum BuilderError {
 
 /// Local builder instance that can ingest a sealed header and
 /// create the corresponding builder bid ready for the Builder API.
-#[allow(missing_debug_implementations)]
+#[derive(Debug)]
 pub struct LocalBuilder {
     /// BLS credentials for the local builder. We use this to sign the
     /// payload bid submissions built by the sidecar.

--- a/bolt-sidecar/src/builder/payload_builder.rs
+++ b/bolt-sidecar/src/builder/payload_builder.rs
@@ -39,7 +39,6 @@ const DEFAULT_EXTRA_DATA: [u8; 20] = [
 ///
 /// Find more information about this process & its reasoning here:
 /// <https://github.com/chainbound/bolt/discussions/59>
-#[allow(missing_debug_implementations)]
 pub struct FallbackPayloadBuilder {
     extra_data: Bytes,
     fee_recipient: Address,
@@ -390,6 +389,18 @@ pub(crate) fn build_header_with_hints_and_context(
         parent_beacon_block_root: Some(context.parent_beacon_block_root),
         requests_root: None,
         extra_data: context.extra_data.clone(),
+    }
+}
+
+impl fmt::Debug for FallbackPayloadBuilder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("FallbackPayloadBuilder")
+            .field("extra_data", &self.extra_data)
+            .field("fee_recipient", &self.fee_recipient)
+            .field("execution_rpc_client", &self.execution_rpc_client)
+            .field("engine_hinter", &self.engine_hinter)
+            .field("slot_time_in_seconds", &self.slot_time_in_seconds)
+            .finish()
     }
 }
 

--- a/bolt-sidecar/src/builder/payload_builder.rs
+++ b/bolt-sidecar/src/builder/payload_builder.rs
@@ -1,3 +1,5 @@
+use std::fmt;
+
 use alloy::{
     eips::{calc_excess_blob_gas, calc_next_block_base_fee, eip1559::BaseFeeParams},
     primitives::{Address, Bytes, B256, U256},

--- a/bolt-sidecar/src/builder/template.rs
+++ b/bolt-sidecar/src/builder/template.rs
@@ -27,7 +27,7 @@ use crate::{
 /// - Simulate new commitment requests.
 /// - Update state every block, to invalidate old commitments.
 /// - Make sure we DO NOT accept invalid commitments in any circumstances.
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct BlockTemplate {
     /// The state diffs per address given the list of commitments.
     pub(crate) state_diff: StateDiff,
@@ -210,7 +210,7 @@ impl BlockTemplate {
 }
 
 /// StateDiff tracks the intermediate changes to the state according to the block template.
-#[derive(Debug, Default)]
+#[derive(Debug, Clone, Default)]
 pub struct StateDiff {
     /// Map of diffs per address. Each diff is a tuple of the nonce and balance diff
     /// that should be applied to the current state.

--- a/bolt-sidecar/src/client/mevboost.rs
+++ b/bolt-sidecar/src/client/mevboost.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 /// A client for interacting with the MEV-Boost API.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MevBoostClient {
     url: Url,
     client: reqwest::Client,

--- a/bolt-sidecar/src/driver/mod.rs
+++ b/bolt-sidecar/src/driver/mod.rs
@@ -1,0 +1,203 @@
+use std::{
+    pin::Pin,
+    task::{Context, Poll},
+    time::Duration,
+};
+
+use alloy_rpc_types_beacon::events::HeadEvent;
+use eyre::eyre;
+use futures::Future;
+use tokio::sync::mpsc;
+
+use crate::{
+    crypto::{SignableBLS, SignerBLS},
+    json_rpc::api::{ApiError, ApiEvent},
+    primitives::{CommitmentRequest, ConstraintsMessage, FetchPayloadRequest, SignedConstraints},
+    state::{fetcher::StateFetcher, ConsensusState, ExecutionState, HeadTracker},
+    ConstraintsApi, LocalBuilder, MevBoostClient,
+};
+
+/// The main driver for the sidecar, managing the event loop and coordinating
+/// the various components of the system.
+#[derive(Debug)]
+pub struct SidecarDriver<C, S> {
+    head_tracker: HeadTracker,
+    execution_state: ExecutionState<C>,
+    consensus_state: ConsensusState,
+    signer: S,
+    local_builder: LocalBuilder,
+    mevboost_client: MevBoostClient,
+    shutdown_rx: mpsc::Receiver<()>,
+    api_events_rx: mpsc::Receiver<ApiEvent>,
+    payload_requests_rx: mpsc::Receiver<FetchPayloadRequest>,
+}
+
+/// Helper macro to return an Eyre error from a poll function
+#[macro_export]
+macro_rules! poll_bail {
+    ($($tt:tt)*) => {
+        return Poll::Ready(Err(eyre!($($tt)*)))
+    };
+}
+
+impl<C: StateFetcher + Unpin, S: SignerBLS + Unpin> Future for SidecarDriver<C, S> {
+    type Output = eyre::Result<()>;
+
+    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Self::Output> {
+        let this = self.get_mut();
+
+        match this.api_events_rx.poll_recv(cx) {
+            Poll::Ready(Some(api_event)) => this.handle_incoming_api_event(api_event),
+            Poll::Ready(None) => poll_bail!("API events channel closed"),
+            Poll::Pending => { /* pass-through */ }
+        }
+
+        match this.head_tracker.poll_next_head(cx) {
+            Poll::Ready(Some(head_event)) => this.handle_new_head_event(head_event),
+            Poll::Ready(None) => poll_bail!("Head tracker channel closed"),
+            Poll::Pending => { /* pass-through */ }
+        }
+
+        match this.consensus_state.commitment_deadline.poll_wait(cx) {
+            Poll::Ready(Some(slot)) => this.handle_commitment_deadline(slot),
+            Poll::Ready(None) => { /* pass-through as there is no pending deadline */ }
+            Poll::Pending => { /* pass-through */ }
+        }
+
+        match this.payload_requests_rx.poll_recv(cx) {
+            Poll::Ready(Some(req)) => this.handle_fetch_payload_request(req),
+            Poll::Ready(None) => poll_bail!("Payload request channel closed"),
+            Poll::Pending => { /* pass-through */ }
+        }
+
+        match this.shutdown_rx.poll_recv(cx) {
+            Poll::Ready(Some(())) => {
+                tracing::warn!("Received shutdown signal, shutting down...");
+                return Poll::Ready(Ok(()));
+            }
+            Poll::Ready(None) => poll_bail!("Shutdown channel closed"),
+            Poll::Pending => { /* pass-through */ }
+        }
+
+        Poll::Pending
+    }
+}
+
+impl<C: StateFetcher + Unpin, S: SignerBLS + Unpin> SidecarDriver<C, S> {
+    fn handle_incoming_api_event(&mut self, api_event: ApiEvent) {
+        let start = std::time::Instant::now();
+        tracing::info!("Received commitment request: {:?}", api_event.request);
+
+        let validator_index = match self.consensus_state.validate_request(&api_event.request) {
+            Ok(index) => index,
+            Err(e) => {
+                tracing::error!("Failed to validate request: {:?}", e);
+                let _ = api_event.response_tx.send(Err(ApiError::Consensus(e)));
+                return;
+            }
+        };
+
+        let sender = match self
+            .execution_state
+            .validate_commitment_request(&api_event.request)
+            .await
+        {
+            Ok(sender) => sender,
+            Err(e) => {
+                tracing::error!("Failed to commit request: {:?}", e);
+                let _ = api_event.response_tx.send(Err(ApiError::Validation(e)));
+                return;
+            }
+        };
+
+        // TODO: match when we have more request types
+        let CommitmentRequest::Inclusion(request) = api_event.request;
+
+        tracing::info!(
+            elapsed = ?start.elapsed(),
+            tx_hash = %request.tx.hash(),
+            "Validation against execution state passed"
+        );
+
+        // TODO: review all this `clone` usage
+
+        // parse the request into constraints and sign them with the sidecar signer
+        let message = ConstraintsMessage::build(validator_index, request.clone(), sender);
+        let signature = match self.signer.sign(&message.digest()) {
+            Ok(sig) => sig.to_string(),
+            Err(e) => {
+                let _ = api_event.response_tx.send(Err(ApiError::Eyre(e)));
+                return;
+            }
+        };
+
+        let signed_constraints = SignedConstraints { message, signature };
+
+        self.execution_state
+            .add_constraint(request.slot, signed_constraints.clone());
+
+        let res = serde_json::to_value(signed_constraints).map_err(Into::into);
+        let _ = api_event.response_tx.send(res).ok();
+    }
+
+    fn handle_new_head_event(&mut self, head_event: HeadEvent) {
+        let slot = head_event.slot;
+        tracing::info!(slot, "Received new head event");
+
+        // We use None to signal that we want to fetch the latest EL head
+        if let Err(e) = self.execution_state.update_head(None, slot).await {
+            tracing::error!(err = ?e, "Failed to update execution state head");
+        }
+
+        if let Err(e) = self.consensus_state.update_head(slot).await {
+            tracing::error!(err = ?e, "Failed to update consensus state head");
+        }
+    }
+
+    fn handle_commitment_deadline(&mut self, slot: u64) {
+        tracing::info!(
+            slot,
+            "Commitment deadline reached, starting to build local block"
+        );
+
+        let Some(template) = self.execution_state.get_block_template(slot) else {
+            tracing::warn!("No block template found for slot {slot} when requested");
+            return;
+        };
+
+        // TODO: fix retry logic, and move this to separate task in the mevboost client itself
+        let mevboost = self.mevboost_client.clone();
+        tokio::spawn(async move {
+            let max_retries = 5;
+            let mut i = 0;
+            'inner: while let Err(e) = mevboost
+                .submit_constraints(&template.signed_constraints_list)
+                .await
+            {
+                tracing::error!(err = ?e, "Error submitting constraints, retrying...");
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                i += 1;
+                if i >= max_retries {
+                    tracing::error!("Max retries reached while submitting to MEV-Boost");
+                    break 'inner;
+                }
+            }
+        });
+    }
+
+    fn handle_fetch_payload_request(&mut self, request: FetchPayloadRequest) {
+        tracing::info!(slot = request.slot, "Received local payload request");
+
+        let Some(payload_and_bid) = self.local_builder.get_cached_payload() else {
+            tracing::warn!(slot = request.slot, "No local payload found");
+            let _ = request.response_tx.send(None);
+            return;
+        };
+
+        if let Err(e) = request.response_tx.send(Some(payload_and_bid)) {
+            tracing::error!(err = ?e, "Failed to send payload and bid in response channel");
+        } else {
+            tracing::debug!("Sent payload and bid to response channel");
+        }
+    }
+}

--- a/bolt-sidecar/src/json_rpc/api.rs
+++ b/bolt-sidecar/src/json_rpc/api.rs
@@ -7,7 +7,10 @@ use thiserror::Error;
 use tokio::sync::{mpsc, oneshot};
 use tracing::info;
 
-use crate::primitives::{CommitmentRequest, Slot};
+use crate::{
+    primitives::{CommitmentRequest, Slot},
+    state::{consensus::ConsensusError, ValidationError},
+};
 
 /// Default size of the api request cache (implemented as a LRU).
 const DEFAULT_API_REQUEST_CACHE_SIZE: usize = 1000;
@@ -31,6 +34,10 @@ pub enum ApiError {
     Rlp(#[from] alloy::transports::HttpError),
     #[error("failed during HTTP call: {0}")]
     Http(#[from] reqwest::Error),
+    #[error("consensus error: {0}")]
+    Consensus(#[from] ConsensusError),
+    #[error("execution state validation error: {0}")]
+    Validation(#[from] ValidationError),
     #[error("downstream error: {0}")]
     Eyre(#[from] eyre::Report),
     #[error("failed while processing API request: {0}")]

--- a/bolt-sidecar/src/lib.rs
+++ b/bolt-sidecar/src/lib.rs
@@ -27,6 +27,10 @@ pub use builder::LocalBuilder;
 mod config;
 pub use config::{ChainConfig, Config, Opts};
 
+/// Driver for the sidecar, which manages the main event loop
+pub mod driver;
+pub use driver::SidecarDriver;
+
 /// Crypto utilities, including BLS and ECDSA
 pub mod crypto;
 

--- a/bolt-sidecar/src/state/consensus.rs
+++ b/bolt-sidecar/src/state/consensus.rs
@@ -1,4 +1,7 @@
-use std::time::{Duration, Instant};
+use std::{
+    fmt::Debug,
+    time::{Duration, Instant},
+};
 
 use beacon_api_client::{mainnet::Client, BlockId, ProposerDuty};
 use ethereum_consensus::{deneb::BeaconBlockHeader, phase0::mainnet::SLOTS_PER_EPOCH};
@@ -35,7 +38,6 @@ pub struct Epoch {
 }
 
 /// Represents the consensus state container for the sidecar.
-#[allow(missing_debug_implementations)]
 pub struct ConsensusState {
     beacon_api_client: Client,
     header: BeaconBlockHeader,
@@ -152,6 +154,18 @@ impl ConsensusState {
             })
             .map(|duty| duty.validator_index as u64)
             .ok_or(ConsensusError::ValidatorNotFound)
+    }
+}
+
+impl Debug for ConsensusState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("ConsensusState")
+            .field("header", &self.header)
+            .field("epoch", &self.epoch)
+            .field("latest_slot", &self.latest_slot)
+            .field("latest_slot_timestamp", &self.latest_slot_timestamp)
+            .field("commitment_deadline", &self.commitment_deadline)
+            .finish()
     }
 }
 

--- a/bolt-sidecar/src/state/head_tracker.rs
+++ b/bolt-sidecar/src/state/head_tracker.rs
@@ -1,11 +1,12 @@
 use std::{
+    pin::Pin,
     task::{Context, Poll},
     time::Duration,
 };
 
 use alloy::rpc::types::beacon::events::HeadEvent;
 use beacon_api_client::Topic;
-use futures::StreamExt;
+use futures::{Stream, StreamExt};
 use tokio::{sync::mpsc, task::AbortHandle};
 
 use crate::BeaconClient;
@@ -86,9 +87,12 @@ impl HeadTracker {
     pub async fn next_head(&mut self) -> Option<HeadEvent> {
         self.new_heads_rx.recv().await
     }
+}
 
-    /// Poll for the next head event in a non-blocking way
-    pub fn poll_next_head(&mut self, cx: &mut Context<'_>) -> Poll<Option<HeadEvent>> {
+impl Stream for HeadTracker {
+    type Item = HeadEvent;
+
+    fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         self.new_heads_rx.poll_recv(cx)
     }
 }

--- a/bolt-sidecar/src/state/mod.rs
+++ b/bolt-sidecar/src/state/mod.rs
@@ -45,6 +45,11 @@ impl CommitmentDeadline {
         self.sleep = None;
         slot
     }
+
+    /// Poll the deadline in an unpin context.
+    pub fn poll_wait(&mut self, cx: &mut Context<'_>) -> Poll<Option<u64>> {
+        self.poll_unpin(cx)
+    }
 }
 
 /// Poll the deadline until it is reached.

--- a/bolt-sidecar/src/state/mod.rs
+++ b/bolt-sidecar/src/state/mod.rs
@@ -15,7 +15,7 @@ pub use execution::{ExecutionState, ValidationError};
 
 /// Module to fetch state from the Execution layer.
 pub mod fetcher;
-pub use fetcher::StateClient;
+pub use fetcher::{StateClient, StateFetcher};
 
 /// Module to track the consensus state.
 pub mod consensus;


### PR DESCRIPTION
This PR introduces a driver task for the main loop to replace the `tokio::select!` usage in our main binary.
This is an experiment and probably not worth to merge until we have a more stable release of the sidecar.

- closes #99 

To make the remaining handlers sync, we essentially need to process these 3 events synchronously:
1. update head (execution)
2. update head (consensus)
3. validate request (execution): this is async because we may need to fetch some missing state from the node via API

The best way to do this is by turning execution and consensus state containers into actors and control them from the driver by their handles. 