### PR TITLE
chore(justfile): beacon logs, restart rebuilding only sidecar

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -52,6 +52,11 @@ sidecar-logs:
     docker logs -f $id
 
 # show the logs for the bolt devnet for beacon node
+beacon-logs:
+    @id=$(docker ps -n 100 | grep 'cl-1-lighthouse-geth' | awk -F' ' '{print $1}') && \
+    docker logs -f $id
+
+# show the logs for the bolt devnet for beacon node
 beacon-dump:
     @id=$(docker ps -n 100 | grep 'cl-1-lighthouse-geth' | awk -F' ' '{print $1}') && \
     docker logs $id 2>&1 | tee beacon_dump.log

--- a/Justfile
+++ b/Justfile
@@ -27,6 +27,11 @@ restart:
 	@just build-images
 	@just up
 
+_restart-sidecar:
+    @just down
+    @just _build-sidecar
+    @just up
+
 # show the running containers and port mappings for the bolt devnet
 inspect:
 	kurtosis enclave inspect bolt-devnet


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new target for restarting the sidecar service, streamlining the development process.
  - Added a target to fetch and follow logs from the beacon node, enhancing debugging and monitoring capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->