### PR TITLE
feat(registry): add getallregistrants

### DIFF
--- a/bolt-contracts/src/contracts/BoltRegistry.sol
+++ b/bolt-contracts/src/contracts/BoltRegistry.sol
@@ -50,6 +50,8 @@ contract BoltRegistry is IBoltRegistry {
             metadata
         );
 
+        operators.push(msg.sender);
+
         // Set the delegations
         for (uint256 i = 0; i < validatorIndexes.length; i++) {
             delegations[validatorIndexes[i]] = msg.sender;

--- a/bolt-contracts/src/contracts/BoltRegistry.sol
+++ b/bolt-contracts/src/contracts/BoltRegistry.sol
@@ -97,6 +97,15 @@ contract BoltRegistry is IBoltRegistry {
             revert CooldownNotElapsed();
         }
 
+        // Remove operator from the operators array
+        for (uint256 i = 0; i < operators.length; i++) {
+            if (operators[i] == msg.sender) {
+                operators[i] = operators[operators.length - 1];
+                operators.pop();
+                break;
+            }
+        }
+        
         delete registrants[msg.sender];
 
         for (uint256 i = 0; i < registrant.validatorIndexes.length; i++) {

--- a/bolt-contracts/src/contracts/BoltRegistry.sol
+++ b/bolt-contracts/src/contracts/BoltRegistry.sol
@@ -134,11 +134,19 @@ contract BoltRegistry is IBoltRegistry {
     }
 
     function getAllRegistrants() external view returns (Registrant[] memory) {
-        Registrant[] memory _registrants = new Registrant[](operators.length);
-
+        uint256 activeCount = 0;
         for (uint256 i = 0; i < operators.length; i++) {
             if (isActiveOperator(operators[i])) {
-                _registrants[i] = registrants[operators[i]];
+                activeCount++;
+            }
+        }
+
+        Registrant[] memory _registrants = new Registrant[](activeCount);
+        uint256 index = 0;
+        for (uint256 i = 0; i < operators.length; i++) {
+            if (isActiveOperator(operators[i])) {
+                _registrants[index] = registrants[operators[i]];
+                index++;
             }
         }
 

--- a/bolt-contracts/src/contracts/BoltRegistry.sol
+++ b/bolt-contracts/src/contracts/BoltRegistry.sol
@@ -13,6 +13,9 @@ contract BoltRegistry is IBoltRegistry {
     // Mapping to hold the registrants
     mapping(address => Registrant) public registrants;
 
+    // Array to hold operator addresses
+    address[] public operators;
+
     // Mapping that holds the relationship between validator index and operator address
     mapping(uint64 => address) public delegations;
 
@@ -106,7 +109,7 @@ contract BoltRegistry is IBoltRegistry {
     /// @notice Check if an address is a based proposer opted into the protocol
     /// @param _operator The address to check
     /// @return True if the address is an active based proposer, false otherwise
-    function isActiveOperator(address _operator) external view returns (bool) {
+    function isActiveOperator(address _operator) public view returns (bool) {
         return registrants[_operator].status == Status.ACTIVE;
     }
 
@@ -128,5 +131,17 @@ contract BoltRegistry is IBoltRegistry {
         }
 
         revert NotFound();
+    }
+
+    function getAllRegistrants() external view returns (Registrant[] memory) {
+        Registrant[] memory _registrants = new Registrant[](operators.length);
+
+        for (uint256 i = 0; i < operators.length; i++) {
+            if (isActiveOperator(operators[i])) {
+                _registrants[i] = registrants[operators[i]];
+            }
+        }
+
+        return _registrants;
     }
 }


### PR DESCRIPTION
fixes #157 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit


- **New Features**
	- Introduced a method to retrieve all active registrants associated with operators.
	- Added a public array to track active operator addresses for improved operator management.
- **Improvements**
	- Enhanced the accessibility of the operator status check, allowing internal and external calls.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->