### PR TITLE
fix(sidecar): process pending bundle diffs

### DIFF
--- a/bolt-client/src/main.rs
+++ b/bolt-client/src/main.rs
@@ -121,7 +121,7 @@ async fn main() -> Result<()> {
         } else {
             // Send rpc requests singularly for each transaction
             send_rpc_request(
-                vec![tx_rlp.clone()],
+                vec![tx_rlp],
                 vec![*tx_hash],
                 target_slot,
                 target_sidecar_url.clone(),

--- a/bolt-sidecar/src/api/commitments/server.rs
+++ b/bolt-sidecar/src/api/commitments/server.rs
@@ -283,7 +283,9 @@ mod test {
         let sk = SecretKey::random(&mut rand::thread_rng());
         let signer = PrivateKeySigner::from(sk.clone());
         let tx = default_test_transaction(signer.address(), None);
-        let req = create_signed_commitment_request(tx, &sk, 12).await.unwrap();
+        let req = create_signed_commitment_request(&[tx], &sk, 12)
+            .await
+            .unwrap();
 
         let payload = json!({
             "jsonrpc": "2.0",
@@ -325,7 +327,9 @@ mod test {
         let sk = SecretKey::random(&mut rand::thread_rng());
         let signer = PrivateKeySigner::from(sk.clone());
         let tx = default_test_transaction(signer.address(), None);
-        let req = create_signed_commitment_request(tx, &sk, 12).await.unwrap();
+        let req = create_signed_commitment_request(&[tx], &sk, 12)
+            .await
+            .unwrap();
 
         let sig = req.signature().unwrap().to_hex();
 

--- a/bolt-sidecar/src/primitives/constraint.rs
+++ b/bolt-sidecar/src/primitives/constraint.rs
@@ -55,10 +55,11 @@ pub struct ConstraintsMessage {
 impl ConstraintsMessage {
     /// Builds a constraints message from an inclusion request and metadata
     pub fn build(validator_index: u64, request: InclusionRequest) -> Self {
-        let mut constraints = Vec::with_capacity(request.txs.len());
-        for tx in request.txs {
-            constraints.push(Constraint::from_transaction(tx, None));
-        }
+        let constraints = request
+            .txs
+            .into_iter()
+            .map(|tx| Constraint::from_transaction(tx, None))
+            .collect();
 
         Self {
             validator_index,

--- a/bolt-sidecar/src/state/execution.rs
+++ b/bolt-sidecar/src/state/execution.rs
@@ -353,7 +353,6 @@ impl<C: StateFetcher> ExecutionState<C> {
                     .saturating_sub(balance_diff)
                     .saturating_sub(*sender_balance_diff),
 
-                // TODO(nico): what if this changes in the middle of the request?
                 has_code: account_state.has_code,
             };
 


### PR DESCRIPTION
### Overview

When validating requests containing multiple transactions, we need to take into account the previous transactions in the bundle as increasing the nonce (and decreasing the balance) of the account that sent it, even if they haven't been committed yet to the template. 

This fixes the issue by introducing two maps to keep track of the pending state due to these requests. 

Note that if anything in the request fails validation, the whole bundle won't be committed, as expected.

### Tests
- currently testing from this branch in release candidate `v0.1.3-alpha.rc2`
- multiple type 2 txs: Included: https://dora.helder-devnets.xyz/slot/273556