### PR TITLE
chore(client): small update

### DIFF
--- a/bolt-client/README.md
+++ b/bolt-client/README.md
@@ -19,7 +19,7 @@ This is a simple CLI tool to interact with Bolt.
 instead of relying on the RPC server:
 
 - `--use-registry`: bool flag to fetch data from a local node instead of the RPC_URL (default: false)
-- `BOLT_REGISTRY_ADDRESS` or `--registry-address`: the address of the bolt-registry contract
+- `BOLT_REGISTRY` or `--registry`: the address of the bolt-registry smart contract
 - `BOLT_BEACON_CLIENT_URL` or `--beacon-client-url`: the URL of the CL node to use
 
 1. Run the CLI tool with the desired command and arguments, if any.

--- a/bolt-client/README.md
+++ b/bolt-client/README.md
@@ -4,26 +4,43 @@ This is a simple CLI tool to interact with Bolt.
 
 ## Requirements
 
-- Rust toolchain & Cargo
+- [Rust toolchain & Cargo](https://doc.rust-lang.org/cargo/getting-started/installation.html) installed
+- A wallet with some funds to send transactions
 
 ## How to use
 
-1. Prepare the environment variables (either in a `.env` file, or as CLI arguments):
+Bolt Client offers different ways to send commitment requests. Here's how to use them:
 
-   - `BOLT_RPC_URL` or `--rpc-url`: the URL of the Bolt RPC server (default: Chainbound's RPC)
-   - `BOLT_PRIVATE_KEY` or `--private-key`: the private key of the account to send transactions from
-   - `BOLT_NONCE_OFFSET` or `--nonce-offset`: the offset to add to the account's nonce (default: 0)
-   - `--blob`: bool flag to send a blob-carrying transaction (default: false)
+### Use the default Bolt RPC
 
-**Optionally**, you can use the following flags to fetch the lookahead data from the beacon chain directly
-instead of relying on the RPC server:
+For regular usage, you can use the default Bolt RPC server to automatically fetch the
+lookahead data from the beacon chain and send the transaction to the next Bolt sidecar in line.
+
+To do this, prepare the environment variables (either in a `.env` file, or as CLI arguments):
+
+- `BOLT_PRIVATE_KEY` or `--private-key`: the private key of the account to send transactions from
+- `--blob`: bool flag to send a blob-carrying transaction (default: false)
+- `--count`: the number of transactions to send in a single request (default: 1)
+
+Run the CLI tool:
+
+```shell
+ cargo run
+```
+
+### Use your own beacon node and registry contract
+
+If you don't want to use the default RPC server, you can send transactions manually.
+To do this, you need to provide the following environment variables (either in a `.env` file, or as CLI arguments):
 
 - `--use-registry`: bool flag to fetch data from a local node instead of the RPC_URL (default: false)
+- `BOLT_RPC_URL` or `--rpc-url`: the URL of an execution client (e.g. Geth)'s RPC server (default: Chainbound's RPC)
+- `BOLT_NONCE_OFFSET` or `--nonce-offset`: the offset to add to the account's nonce (default: 0)
 - `BOLT_REGISTRY_ADDRESS` or `--registry-address`: the address of the bolt-registry smart contract
-- `BOLT_BEACON_CLIENT_URL` or `--beacon-client-url`: the URL of the CL node to use
+- `BOLT_BEACON_CLIENT_URL` or `--beacon-client-url`: the URL of the beacon client's HTTP server
 
-1. Run the CLI tool with the desired command and arguments, if any.
+Run the CLI tool with the desired command and arguments, if any.
 
-   ```shell
-    cargo run -- [options]
-   ```
+```shell
+ cargo run -- [options]
+```

--- a/bolt-client/README.md
+++ b/bolt-client/README.md
@@ -19,7 +19,7 @@ This is a simple CLI tool to interact with Bolt.
 instead of relying on the RPC server:
 
 - `--use-registry`: bool flag to fetch data from a local node instead of the RPC_URL (default: false)
-- `BOLT_REGISTRY` or `--registry`: the address of the bolt-registry smart contract
+- `BOLT_REGISTRY_ADDRESS` or `--registry-address`: the address of the bolt-registry smart contract
 - `BOLT_BEACON_CLIENT_URL` or `--beacon-client-url`: the URL of the CL node to use
 
 1. Run the CLI tool with the desired command and arguments, if any.

--- a/bolt-client/src/main.rs
+++ b/bolt-client/src/main.rs
@@ -47,7 +47,7 @@ struct Opts {
     bundle: bool,
 
     /// Flag for using the registry to fetch the lookahead
-    #[clap(long, default_value_t = false, requires_ifs([("true", "registry"), ("true", "beacon_client_url")]))]
+    #[clap(long, default_value_t = false, requires_ifs([("true", "registry_address"), ("true", "beacon_client_url")]))]
     use_registry: bool,
     /// URL of the beacon client to use for fetching the lookahead
     /// (only used with the "use-registry" flag)
@@ -55,8 +55,8 @@ struct Opts {
     beacon_client_url: Option<Url>,
     /// Address of the registry contract to read bolt sidecars from
     /// (only used with the "use-registry" flag)
-    #[clap(long, env = "BOLT_REGISTRY", default_value_t = DEFAULT_REGISTRY)]
-    registry: Address,
+    #[clap(long, env = "BOLT_REGISTRY_ADDRESS", default_value_t = DEFAULT_REGISTRY)]
+    registry_address: Address,
 }
 
 #[tokio::main]
@@ -75,7 +75,7 @@ async fn main() -> Result<()> {
     let (target_sidecar_url, target_slot) = if opts.use_registry {
         // Fetch the next preconfer slot from the registry and use it
         let beacon_api_client = BeaconApiClient::new(opts.beacon_client_url.unwrap());
-        let registry = BoltRegistry::new(opts.rpc_url, opts.registry);
+        let registry = BoltRegistry::new(opts.rpc_url, opts.registry_address);
         let curr_slot = get_current_slot(&beacon_api_client).await?;
         let duties = get_proposer_duties(&beacon_api_client, curr_slot, curr_slot / 32).await?;
         match registry.next_preconfer_from_registry(duties).await {

--- a/bolt-client/src/main.rs
+++ b/bolt-client/src/main.rs
@@ -2,7 +2,7 @@ use alloy::{
     eips::eip2718::Encodable2718,
     hex,
     network::{EthereumWallet, TransactionBuilder},
-    primitives::{Address, B256},
+    primitives::{address, Address, B256},
     providers::{Provider, ProviderBuilder},
     signers::local::PrivateKeySigner,
 };
@@ -19,34 +19,35 @@ use registry::BoltRegistry;
 mod utils;
 use utils::*;
 
+// Default Bolt RPC URL (on Helder)
+pub const DEFAULT_RPC_URL: &str = "https://bolt.chainbound.io/rpc";
+
+// Default Bolt-Registry address (on Helder)
+pub const DEFAULT_REGISTRY: Address = address!("dF11D829eeC4C192774F3Ec171D822f6Cb4C14d9");
+
 #[derive(Parser)]
 struct Opts {
     /// Bolt RPC URL to send requests to
-    #[clap(
-        short = 'p',
-        long,
-        default_value = "http://135.181.191.125:8015/rpc",
-        env = "BOLT_RPC_URL"
-    )]
+    #[clap(long, default_value = DEFAULT_RPC_URL, env = "BOLT_RPC_URL")]
     rpc_url: Url,
     /// Private key to sign transactions with
     #[clap(short = 'k', long, env = "BOLT_PRIVATE_KEY")]
     private_key: String,
     /// Optional nonce offset to use for the transaction
-    #[clap(short, long, default_value_t = 0, env = "BOLT_NONCE_OFFSET")]
+    #[clap(long, default_value_t = 0, env = "BOLT_NONCE_OFFSET")]
     nonce_offset: u64,
     /// Flag for generating a blob tx instead of a regular tx
     #[clap(long, default_value_t = false)]
     blob: bool,
     /// Number of transactions to send in a sequence
-    #[clap(short, long, default_value_t = 1)]
+    #[clap(long, default_value_t = 1)]
     count: u64,
     /// Flag for sending all "count" transactions in a single bundle
     #[clap(long, default_value_t = false)]
     bundle: bool,
 
     /// Flag for using the registry to fetch the lookahead
-    #[clap(short, long, default_value_t = false, requires_ifs([("true", "registry_address"), ("true", "beacon_client_url")]))]
+    #[clap(long, default_value_t = false, requires_ifs([("true", "registry"), ("true", "beacon_client_url")]))]
     use_registry: bool,
     /// URL of the beacon client to use for fetching the lookahead
     /// (only used with the "use-registry" flag)
@@ -54,13 +55,8 @@ struct Opts {
     beacon_client_url: Option<Url>,
     /// Address of the registry contract to read bolt sidecars from
     /// (only used with the "use-registry" flag)
-    #[clap(
-        short,
-        long,
-        env = "BOLT_REGISTRY_ADDRESS",
-        default_value = "0xdF11D829eeC4C192774F3Ec171D822f6Cb4C14d9"
-    )]
-    registry_address: Address,
+    #[clap(long, env = "BOLT_REGISTRY", default_value_t = DEFAULT_REGISTRY)]
+    registry: Address,
 }
 
 #[tokio::main]
@@ -79,7 +75,7 @@ async fn main() -> Result<()> {
     let (target_sidecar_url, target_slot) = if opts.use_registry {
         // Fetch the next preconfer slot from the registry and use it
         let beacon_api_client = BeaconApiClient::new(opts.beacon_client_url.unwrap());
-        let registry = BoltRegistry::new(opts.rpc_url, opts.registry_address);
+        let registry = BoltRegistry::new(opts.rpc_url, opts.registry);
         let curr_slot = get_current_slot(&beacon_api_client).await?;
         let duties = get_proposer_duties(&beacon_api_client, curr_slot, curr_slot / 32).await?;
         match registry.next_preconfer_from_registry(duties).await {
@@ -88,12 +84,10 @@ async fn main() -> Result<()> {
             Err(e) => bail!("error fetching next preconfer slot from registry: {:?}", e),
         }
     } else {
-        // TODO: remove "cbOnly=true"
-        let url =
-            opts.rpc_url.join("proposers/lookahead?activeOnly=true&futureOnly=true&cbOnly=true")?;
+        let url = opts.rpc_url.join("proposers/lookahead?activeOnly=true&futureOnly=true")?;
         let lookahead_response = reqwest::get(url).await?.json::<Value>().await?;
         if lookahead_response.as_array().unwrap_or(&vec![]).is_empty() {
-            bail!("no bolt proposer found in lookahead, try again later");
+            bail!("no bolt proposer found in lookahead, try again later 🥲");
         }
         let next_preconfer_slot = lookahead_response[0].get("slot").unwrap().as_u64().unwrap();
         (opts.rpc_url, next_preconfer_slot)


### PR DESCRIPTION
- chore: Use all proposers instead of `cbOnly` (which used only Chainbound-operated validators) for v0.1.3-alpha
- chore: improved docs