### PR TITLE
chore(sidecar): slot too low error messages improvement

### DIFF
--- a/bolt-sidecar/src/common.rs
+++ b/bolt-sidecar/src/common.rs
@@ -1,5 +1,6 @@
 use alloy::primitives::U256;
 use reth_primitives::PooledTransactionsElement;
+use std::any::type_name;
 
 use crate::{
     primitives::{AccountState, TransactionExt},
@@ -80,6 +81,10 @@ pub fn validate_transaction(
     }
 
     Ok(())
+}
+
+pub(crate) fn function_name<T>(_func: T) -> &'static str {
+    type_name::<T>()
 }
 
 #[cfg(test)]


### PR DESCRIPTION
This PR provides more context on `SlotTooLow` error messages that can be a bit difficult to debug on a production environment