### PR TITLE
fix(sidecar): bundle verification logic

### DIFF
--- a/bolt-sidecar/src/state/execution.rs
+++ b/bolt-sidecar/src/state/execution.rs
@@ -358,10 +358,6 @@ impl<C: StateFetcher> ExecutionState<C> {
                 has_code: account_state.has_code,
             };
 
-            // Increase the bundle nonce and balance diffs for this sender for the next iteration
-            *sender_nonce_diff += 1;
-            *sender_balance_diff += max_transaction_cost(tx);
-
             // Validate the transaction against the account state with existing diffs
             validate_transaction(&account_state_with_diffs, tx)?;
 
@@ -390,6 +386,10 @@ impl<C: StateFetcher> ExecutionState<C> {
                 // Validate blob against KZG settings
                 transaction.validate_blob(&blob_transaction.sidecar, self.kzg_settings.get())?;
             }
+
+            // Increase the bundle nonce and balance diffs for this sender for the next iteration
+            *sender_nonce_diff += 1;
+            *sender_balance_diff += max_transaction_cost(tx);
         }
 
         Ok(())


### PR DESCRIPTION
In the sidecar we've recently introduced bundle support, which need special nonce and balance checks when verified. 

In particular, when processing the next transaction in the bundle we should increment the user nonce and decrease its balance, however this operationis done before the transaction validation and not at the end of the loop, causing an off-by-one error in nonce checks (`NonceTooLow`)