### PR TITLE
feat(sidecar): added driver on higher register (`tokio::select`)

### DIFF
--- a/bolt-sidecar/bin/sidecar.rs
+++ b/bolt-sidecar/bin/sidecar.rs
@@ -1,188 +1,22 @@
-use std::time::Duration;
-
-use alloy::{rpc::types::beacon::events::HeadEvent, signers};
-use tokio::sync::mpsc;
-
-use bolt_sidecar::{
-    commitments::{
-        server::{CommitmentsApiServer, Event},
-        spec,
-    },
-    crypto::{bls::Signer, SignableBLS, SignerBLS},
-    primitives::{
-        CommitmentRequest, ConstraintsMessage, FetchPayloadRequest, LocalPayloadFetcher,
-        SignedConstraints,
-    },
-    start_builder_proxy_server,
-    state::{ConsensusState, ExecutionState, HeadTracker, StateClient},
-    BeaconClient, BuilderProxyConfig, Config, ConstraintsApi, LocalBuilder, MevBoostClient,
-};
+use bolt_sidecar::{Config, SidecarDriver};
+use eyre::{bail, Result};
+use tracing::info;
 
 #[tokio::main]
-async fn main() -> eyre::Result<()> {
+async fn main() -> Result<()> {
+    // TODO: improve telemetry setup (#116)
     tracing_subscriber::fmt::init();
 
     let config = Config::parse_from_cli()?;
+    info!(chain = config.chain.name(), "Starting Bolt sidecar");
 
-    tracing::info!(chain = config.chain.name(), "Starting Bolt sidecar");
-
-    // TODO: support external signers
-    // probably it's cleanest to have the Config parser initialize a generic Signer
-    let signer = Signer::new(config.private_key.clone().unwrap());
-
-    // TODO: support external signers
-    let commitment_signer = signers::local::PrivateKeySigner::random();
-
-    let state_client = StateClient::new(config.execution_api_url.clone());
-    let mut execution_state = ExecutionState::new(state_client, config.limits).await?;
-
-    let mevboost_client = MevBoostClient::new(config.mevboost_url.clone());
-    let beacon_client = BeaconClient::new(config.beacon_api_url.clone());
-
-    let (api_events, mut api_events_rx) = mpsc::channel(1024);
-
-    let mut api_server = CommitmentsApiServer::new(format!("0.0.0.0:{}", config.rpc_port));
-
-    api_server.run(api_events).await?;
-
-    let mut consensus_state = ConsensusState::new(
-        beacon_client.clone(),
-        config.validator_indexes.clone(),
-        config.chain.commitment_deadline(),
-    );
-
-    // TODO: this can be replaced with ethereum_consensus::clock::from_system_time()
-    // but using beacon node events is easier to work on a custom devnet for now
-    // (as we don't need to specify genesis time and slot duration)
-    let mut head_tracker = HeadTracker::start(beacon_client);
-
-    let builder_proxy_config = BuilderProxyConfig {
-        mevboost_url: config.mevboost_url.clone(),
-        server_port: config.mevboost_proxy_port,
+    match SidecarDriver::new(config).await {
+        Ok(driver) => driver.run_forever().await,
+        Err(err) => {
+            tracing::error!(?err, "Failed to initialize the sidecar driver");
+            bail!("Failed to initialize the sidecar driver: {:?}", err);
+        }
     };
-
-    let (payload_tx, mut payload_rx) = mpsc::channel(16);
-    let payload_fetcher = LocalPayloadFetcher::new(payload_tx);
-
-    let mut local_builder = LocalBuilder::new(&config);
-
-    tokio::spawn(async move {
-        if let Err(e) = start_builder_proxy_server(payload_fetcher, builder_proxy_config).await {
-            tracing::error!("Builder API proxy failed: {:?}", e);
-        }
-    });
-
-    // TODO: parallelize this
-    loop {
-        tokio::select! {
-            Some(Event { mut request, response }) = api_events_rx.recv() => {
-                let start = std::time::Instant::now();
-
-                let validator_index = match consensus_state.validate_request(&request) {
-                    Ok(index) => index,
-                    Err(e) => {
-                        tracing::error!(err = ?e, "Consensus State: Failed to validate request");
-                        let _ = response.send(Err(spec::Error::ValidationFailed(e.to_string())));
-                        continue;
-                    }
-                };
-
-                if let Err(e) = execution_state.validate_commitment_request(&mut request).await {
-                    tracing::error!(err = ?e, "Execution State: Failed to validate request");
-                    let _ = response.send(Err(spec::Error::ValidationFailed(e.to_string())));
-                    continue;
-                };
-
-                // TODO: match when we have more request types
-                let CommitmentRequest::Inclusion(ref req) = request;
-                tracing::info!(
-                    elapsed = ?start.elapsed(),
-                    digest = ?req.digest(),
-                    "Validation against execution state passed"
-                );
-
-                // parse the request into constraints and sign them with the sidecar signer
-                let slot = req.slot;
-                let message = ConstraintsMessage::build(validator_index, req.clone());
-                let signature = signer.sign(&message.digest())?.to_string();
-                let signed_constraints = SignedConstraints { message, signature };
-
-                execution_state.add_constraint(slot, signed_constraints);
-
-                // Create a commitment by signing the request with the commitment signer
-                match request.commit_and_sign(&commitment_signer).await {
-                    Ok(commitment) => {
-                        let _ = response.send(Ok(commitment));
-                    },
-                    Err(e) => {
-                        tracing::error!(err = ?e, "Failed to sign commitment");
-                        let _ = response.send(Err(spec::Error::Internal));
-                    }
-                }
-            },
-            Ok(HeadEvent { slot, .. }) = head_tracker.next_head() => {
-                tracing::info!(slot, "Received new head event");
-
-                // We use None to signal that we want to fetch the latest EL head
-                if let Err(e) = execution_state.update_head(None, slot).await {
-                    tracing::error!(err = ?e, "Failed to update execution state head");
-                }
-
-                if let Err(e) = consensus_state.update_head(slot).await {
-                    tracing::error!(err = ?e, "Failed to update consensus state head");
-                }
-            },
-            Some(slot) = consensus_state.commitment_deadline.wait() => {
-                tracing::info!(slot, "Commitment deadline reached, starting to build local block");
-
-                let Some(template) = execution_state.remove_block_template(slot) else {
-                    tracing::warn!("No block template found for slot {slot} when requested");
-                    continue;
-                };
-
-                tracing::trace!(?template.signed_constraints_list, "Submitting constraints to MEV-Boost");
-
-                // TODO: fix retry logic, and move this to separate task
-                let max_retries = 5;
-                let mut i = 0;
-                'inner: while let Err(e) = mevboost_client
-                    .submit_constraints(&template.signed_constraints_list)
-                .await
-                {
-                    tracing::error!(err = ?e, "Error submitting constraints, retrying...");
-                    tokio::time::sleep(Duration::from_millis(100)).await;
-                    i+=1;
-                    if i >= max_retries {
-                        tracing::error!("Max retries reached while submitting to MEV-Boost");
-                        break 'inner
-                    }
-                }
-
-                if let Err(e) = local_builder.build_new_local_payload(&template).await {
-                    tracing::error!(err = ?e, "CRITICAL: Error while building local payload at slot deadline for {slot}");
-                };
-            },
-            Some(FetchPayloadRequest { slot, response_tx }) = payload_rx.recv() => {
-                tracing::info!(slot, "Received local payload request");
-
-                let Some(payload_and_bid) = local_builder.get_cached_payload() else  {
-                        tracing::warn!("No local payload found for {slot}");
-                        let _ = response_tx.send(None);
-                        continue;
-                };
-
-                if let Err(e) = response_tx.send(Some(payload_and_bid)) {
-                    tracing::error!(err = ?e, "Failed to send payload and bid in response channel");
-                } else {
-                    tracing::debug!("Sent payload and bid to response channel");
-                }
-            },
-            Ok(_) = tokio::signal::ctrl_c() => {
-                tracing::info!("Received SIGINT, shutting down...");
-                break;
-            }
-        }
-    }
 
     Ok(())
 }

--- a/bolt-sidecar/bin/sidecar.rs
+++ b/bolt-sidecar/bin/sidecar.rs
@@ -7,15 +7,15 @@ async fn main() -> Result<()> {
     // TODO: improve telemetry setup (#116)
     tracing_subscriber::fmt::init();
 
-    let config = Config::parse_from_cli()?;
-    info!(chain = config.chain.name(), "Starting Bolt sidecar");
+    let config = match Config::parse_from_cli() {
+        Ok(config) => config,
+        Err(err) => bail!("Failed to parse CLI arguments: {:?}", err),
+    };
 
+    info!(chain = config.chain.name(), "Starting Bolt sidecar");
     match SidecarDriver::new(config).await {
         Ok(driver) => driver.run_forever().await,
-        Err(err) => {
-            tracing::error!(?err, "Failed to initialize the sidecar driver");
-            bail!("Failed to initialize the sidecar driver: {:?}", err);
-        }
+        Err(err) => bail!("Failed to initialize the sidecar driver: {:?}", err),
     };
 
     Ok(())

--- a/bolt-sidecar/src/api/builder.rs
+++ b/bolt-sidecar/src/api/builder.rs
@@ -255,7 +255,8 @@ where
         .route(GET_PAYLOAD_PATH, post(BuilderProxyServer::get_payload))
         .with_state(server);
 
-    let listener = TcpListener::bind(format!("0.0.0.0:{}", config.server_port)).await?;
+    let addr = format!("0.0.0.0:{}", config.server_port);
+    let listener = TcpListener::bind(addr).await?;
     axum::serve(listener, router).await?;
 
     Ok(())

--- a/bolt-sidecar/src/api/commitments/server.rs
+++ b/bolt-sidecar/src/api/commitments/server.rs
@@ -149,12 +149,14 @@ impl CommitmentsApiServer {
 
         let signal = self.signal.take().expect("Signal not set");
 
-        if let Err(err) = axum::serve(listener, router)
-            .with_graceful_shutdown(signal)
-            .await
-        {
-            tracing::error!(?err, "Commitments API Server error");
-        }
+        tokio::spawn(async move {
+            if let Err(err) = axum::serve(listener, router)
+                .with_graceful_shutdown(signal)
+                .await
+            {
+                tracing::error!(?err, "Commitments API Server error");
+            }
+        });
     }
 
     /// Returns the local addr the server is listening on (or configured with).

--- a/bolt-sidecar/src/api/commitments/server.rs
+++ b/bolt-sidecar/src/api/commitments/server.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::HashSet,
-    fmt::Debug,
+    fmt,
     future::Future,
     net::{SocketAddr, ToSocketAddrs},
     pin::Pin,
@@ -9,13 +9,14 @@ use std::{
 };
 
 use alloy::primitives::{Address, Signature};
-use axum::{extract::State, http::HeaderMap, routing::post, Json};
+use axum::{extract::State, http::HeaderMap, routing::post, Json, Router};
 use axum_extra::extract::WithRejection;
 use serde_json::Value;
 use tokio::{
     net::TcpListener,
     sync::{mpsc, oneshot},
 };
+use tracing::error;
 
 use crate::{
     common::CARGO_PKG_VERSION,
@@ -94,8 +95,8 @@ pub struct CommitmentsApiServer {
     signal: Option<Pin<Box<dyn Future<Output = ()> + Send>>>,
 }
 
-impl Debug for CommitmentsApiServer {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+impl fmt::Debug for CommitmentsApiServer {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.debug_struct("CommitmentsApiServer")
             .field("addr", &self.addr)
             .finish()
@@ -125,33 +126,35 @@ impl CommitmentsApiServer {
         }
     }
 
-    /// Runs the JSON-RPC server in the background, sending events to the provided channel.
-    pub async fn run(&mut self, events_tx: mpsc::Sender<Event>) -> eyre::Result<()> {
+    /// Runs the JSON-RPC server, sending events to the provided channel.
+    pub async fn run(&mut self, events_tx: mpsc::Sender<Event>) {
         let api = Arc::new(CommitmentsApiInner::new(events_tx));
 
-        let router = axum::Router::new()
+        let router = Router::new()
             .route("/", post(Self::handle_rpc))
             .with_state(api);
 
-        let listener = TcpListener::bind(self.addr).await?;
-        let addr = listener.local_addr()?;
+        let listener = match TcpListener::bind(self.addr).await {
+            Ok(listener) => listener,
+            Err(err) => {
+                error!(?err, "Failed to bind Commitments API server");
+                panic!("Failed to bind Commitments API server");
+            }
+        };
 
+        let addr = listener.local_addr().expect("Failed to get local address");
         self.addr = addr;
 
         tracing::info!("Commitments RPC server bound to {addr}");
 
-        let signal = self.signal.take();
+        let signal = self.signal.take().expect("Signal not set");
 
-        tokio::spawn(async move {
-            if let Err(e) = axum::serve(listener, router)
-                .with_graceful_shutdown(signal.unwrap())
-                .await
-            {
-                tracing::error!("Server error: {:?}", e);
-            }
-        });
-
-        Ok(())
+        if let Err(err) = axum::serve(listener, router)
+            .with_graceful_shutdown(signal)
+            .await
+        {
+            tracing::error!(?err, "Commitments API Server error");
+        }
     }
 
     /// Returns the local addr the server is listening on (or configured with).
@@ -175,10 +178,9 @@ impl CommitmentsApiServer {
         match payload.method.as_str() {
             GET_VERSION_METHOD => {
                 let version_string = format!("bolt-sidecar-v{CARGO_PKG_VERSION}");
-                let result = serde_json::to_value(version_string).unwrap_or(Value::Null);
                 Ok(Json(JsonResponse {
                     id: payload.id,
-                    result,
+                    result: Value::String(version_string),
                     ..Default::default()
                 }))
             }
@@ -289,7 +291,7 @@ mod test {
 
         let (events_tx, _) = mpsc::channel(1);
 
-        server.run(events_tx).await.unwrap();
+        server.run(events_tx).await;
         let addr = server.local_addr();
 
         let sk = SecretKey::random(&mut rand::thread_rng());
@@ -333,7 +335,7 @@ mod test {
 
         let (events_tx, mut events) = mpsc::channel(1);
 
-        server.run(events_tx).await.unwrap();
+        server.run(events_tx).await;
         let addr = server.local_addr();
 
         let sk = SecretKey::random(&mut rand::thread_rng());

--- a/bolt-sidecar/src/client/mevboost.rs
+++ b/bolt-sidecar/src/client/mevboost.rs
@@ -21,7 +21,7 @@ use crate::{
 };
 
 /// A client for interacting with the MEV-Boost API.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct MevBoostClient {
     url: Url,
     client: reqwest::Client,

--- a/bolt-sidecar/src/crypto/bls.rs
+++ b/bolt-sidecar/src/crypto/bls.rs
@@ -10,7 +10,7 @@ pub use ethereum_consensus::deneb::BlsSignature;
 pub const BLS_DST_PREFIX: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
 
 /// A fixed-size byte array for BLS signatures.
-pub type BLSBytes = FixedBytes<96>;
+pub type BLSSig = FixedBytes<96>;
 
 /// Trait for any types that can be signed and verified with BLS.
 /// This trait is used to abstract over the signing and verification of different types.
@@ -40,14 +40,14 @@ pub trait SignableBLS {
 #[allow(dead_code)]
 pub trait SignerBLS {
     /// Sign the given data and return the signature.
-    fn sign(&self, data: &[u8]) -> eyre::Result<BLSBytes>;
+    fn sign(&self, data: &[u8]) -> eyre::Result<BLSSig>;
 }
 
 /// A generic signing trait to generate BLS signatures asynchronously.
 #[async_trait::async_trait]
 pub trait SignerBLSAsync: Send + Sync {
     /// Sign the given data and return the signature.
-    async fn sign(&self, data: &[u8]) -> eyre::Result<BLSBytes>;
+    async fn sign(&self, data: &[u8]) -> eyre::Result<BLSSig>;
 }
 
 /// A BLS signer that can sign any type that implements the `Signable` trait.
@@ -82,17 +82,17 @@ impl Signer {
 }
 
 impl SignerBLS for Signer {
-    fn sign(&self, data: &[u8]) -> eyre::Result<BLSBytes> {
+    fn sign(&self, data: &[u8]) -> eyre::Result<BLSSig> {
         let sig = sign_with_prefix(&self.key, data);
-        Ok(BLSBytes::from(sig.to_bytes()))
+        Ok(BLSSig::from(sig.to_bytes()))
     }
 }
 
 #[async_trait::async_trait]
 impl SignerBLSAsync for Signer {
-    async fn sign(&self, data: &[u8]) -> eyre::Result<BLSBytes> {
+    async fn sign(&self, data: &[u8]) -> eyre::Result<BLSSig> {
         let sig = sign_with_prefix(&self.key, data);
-        Ok(BLSBytes::from(sig.to_bytes()))
+        Ok(BLSSig::from(sig.to_bytes()))
     }
 }
 

--- a/bolt-sidecar/src/driver.rs
+++ b/bolt-sidecar/src/driver.rs
@@ -69,6 +69,7 @@ impl<C: StateFetcher, BLS: SignerBLS, ECDSA: SignerECDSA> SidecarDriver<C, BLS, 
 
         let beacon_client = BeaconClient::new(cfg.beacon_api_url.clone());
 
+        // start the commitments api server
         let api_addr = format!("0.0.0.0:{}", cfg.rpc_port);
         let (api_events_tx, api_events_rx) = mpsc::channel(1024);
         CommitmentsApiServer::new(api_addr).run(api_events_tx).await;
@@ -91,6 +92,7 @@ impl<C: StateFetcher, BLS: SignerBLS, ECDSA: SignerECDSA> SidecarDriver<C, BLS, 
 
         let (payload_requests_tx, payload_requests_rx) = mpsc::channel(16);
 
+        // start the builder api proxy server
         tokio::spawn(async move {
             let payload_fetcher = LocalPayloadFetcher::new(payload_requests_tx);
             if let Err(err) = start_builder_proxy_server(payload_fetcher, builder_proxy_cfg).await {

--- a/bolt-sidecar/src/driver.rs
+++ b/bolt-sidecar/src/driver.rs
@@ -1,0 +1,251 @@
+use std::time::{Duration, Instant};
+
+use alloy::{
+    rpc::types::beacon::events::HeadEvent,
+    signers::{local::PrivateKeySigner, Signer as SignerECDSA},
+};
+use beacon_api_client::mainnet::Client as BeaconClient;
+use tokio::sync::mpsc;
+use tracing::{debug, error, info, warn};
+
+use crate::{
+    commitments::{
+        server::{CommitmentsApiServer, Event as CommitmentEvent},
+        spec::Error as CommitmentError,
+    },
+    crypto::{bls::Signer as BlsSigner, SignableBLS, SignerBLS},
+    primitives::{
+        CommitmentRequest, ConstraintsMessage, FetchPayloadRequest, LocalPayloadFetcher,
+        SignedConstraints,
+    },
+    start_builder_proxy_server,
+    state::{fetcher::StateFetcher, ConsensusState, ExecutionState, HeadTracker, StateClient},
+    BuilderProxyConfig, Config, ConstraintsApi, LocalBuilder, MevBoostClient,
+};
+
+/// The driver for the sidecar, responsible for managing the main event loop.
+#[derive(Debug)]
+pub struct SidecarDriver<C, BLS, ECDSA> {
+    head_tracker: HeadTracker,
+    execution: ExecutionState<C>,
+    consensus: ConsensusState,
+    constraint_signer: BLS,
+    commitment_signer: ECDSA,
+    local_builder: LocalBuilder,
+    mevboost_client: MevBoostClient,
+    api_events_rx: mpsc::Receiver<CommitmentEvent>,
+    payload_requests_rx: mpsc::Receiver<FetchPayloadRequest>,
+}
+
+impl SidecarDriver<StateClient, BlsSigner, PrivateKeySigner> {
+    /// Create a new sidecar driver with the given [Config] and default components.
+    pub async fn new(cfg: Config) -> eyre::Result<Self> {
+        // The default state client simply uses the execution API URL to fetch state updates.
+        let state_client = StateClient::new(cfg.execution_api_url.clone());
+
+        // Constraints are signed with a BLS private key, for now this is provided
+        // via CLI argument but this is expected to change soon.
+        let constraint_signer = BlsSigner::new(cfg.private_key.clone().unwrap());
+
+        // Commitment responses are signed with a regular Ethereum wallet private key.
+        // This is now generated randomly because slashing is not yet implemented.
+        let commitment_signer = PrivateKeySigner::random();
+
+        Self::from_components(cfg, constraint_signer, commitment_signer, state_client).await
+    }
+}
+
+impl<C: StateFetcher, BLS: SignerBLS, ECDSA: SignerECDSA> SidecarDriver<C, BLS, ECDSA> {
+    /// Create a new sidecar driver with the given components
+    pub async fn from_components(
+        cfg: Config,
+        constraint_signer: BLS,
+        commitment_signer: ECDSA,
+        fetcher: C,
+    ) -> eyre::Result<Self> {
+        let mevboost_client = MevBoostClient::new(cfg.mevboost_url.clone());
+        let execution = ExecutionState::new(fetcher, cfg.limits).await?;
+        let local_builder = LocalBuilder::new(&cfg);
+
+        let beacon_client = BeaconClient::new(cfg.beacon_api_url.clone());
+
+        let api_addr = format!("0.0.0.0:{}", cfg.rpc_port);
+        let (api_events_tx, api_events_rx) = mpsc::channel(1024);
+        CommitmentsApiServer::new(api_addr).run(api_events_tx).await;
+
+        let consensus = ConsensusState::new(
+            beacon_client.clone(),
+            cfg.validator_indexes.clone(),
+            cfg.chain.commitment_deadline(),
+        );
+
+        // TODO: this can be replaced with ethereum_consensus::clock::from_system_time()
+        // but using beacon node events is easier to work on a custom devnet for now
+        // (as we don't need to specify genesis time and slot duration)
+        let head_tracker = HeadTracker::start(beacon_client);
+
+        let builder_proxy_cfg = BuilderProxyConfig {
+            mevboost_url: cfg.mevboost_url.clone(),
+            server_port: cfg.mevboost_proxy_port,
+        };
+
+        let (payload_requests_tx, payload_requests_rx) = mpsc::channel(16);
+
+        tokio::spawn(async move {
+            let payload_fetcher = LocalPayloadFetcher::new(payload_requests_tx);
+            if let Err(err) = start_builder_proxy_server(payload_fetcher, builder_proxy_cfg).await {
+                error!(?err, "Builder API proxy server failed");
+            }
+        });
+
+        Ok(SidecarDriver {
+            head_tracker,
+            execution,
+            consensus,
+            constraint_signer,
+            commitment_signer,
+            local_builder,
+            mevboost_client,
+            api_events_rx,
+            payload_requests_rx,
+        })
+    }
+
+    /// Run the main event loop endlessly for the sidecar driver.
+    ///
+    /// Any errors encountered are contained to the specific `handler` in which
+    /// they occurred, and the driver will continue to run as long as possible.
+    pub async fn run_forever(mut self) -> ! {
+        loop {
+            tokio::select! {
+                Some(api_event) = self.api_events_rx.recv() => {
+                    self.handle_incoming_api_event(api_event).await;
+                }
+                Ok(head_event) = self.head_tracker.next_head() => {
+                    self.handle_new_head_event(head_event).await;
+                }
+                Some(slot) = self.consensus.commitment_deadline.wait() => {
+                    self.handle_commitment_deadline(slot);
+                }
+                Some(payload_request) = self.payload_requests_rx.recv() => {
+                    self.handle_fetch_payload_request(payload_request);
+                }
+            }
+        }
+    }
+
+    /// Handle an incoming API event, validating the request and responding with a commitment.
+    async fn handle_incoming_api_event(&mut self, event: CommitmentEvent) {
+        let CommitmentEvent {
+            mut request,
+            response,
+        } = event;
+        info!("Received new commitment request: {:?}", request);
+        let start = Instant::now();
+
+        let validator_index = match self.consensus.validate_request(&request) {
+            Ok(index) => index,
+            Err(err) => {
+                error!(?err, "Consensus: failed to validate request");
+                let _ = response.send(Err(CommitmentError::Consensus(err)));
+                return;
+            }
+        };
+
+        if let Err(err) = self.execution.validate_request(&mut request).await {
+            error!(?err, "Execution: failed to commit request");
+            let _ = response.send(Err(CommitmentError::Validation(err)));
+            return;
+        }
+
+        // TODO: match when we have more request types
+        let CommitmentRequest::Inclusion(inclusion_request) = request.clone();
+        let target_slot = inclusion_request.slot;
+
+        info!(
+            target_slot,
+            elapsed = ?start.elapsed(),
+            "Validation against execution state passed"
+        );
+
+        // parse the request into constraints and sign them
+        let slot = inclusion_request.slot;
+        let message = ConstraintsMessage::build(validator_index, inclusion_request);
+        let signed_constraints = match self.constraint_signer.sign(&message.digest()) {
+            Ok(signature) => SignedConstraints { message, signature },
+            Err(err) => {
+                error!(?err, "Failed to sign constraints");
+                let _ = response.send(Err(CommitmentError::Internal));
+                return;
+            }
+        };
+
+        self.execution.add_constraint(slot, signed_constraints);
+
+        // Create a commitment by signing the request
+        match request.commit_and_sign(&self.commitment_signer).await {
+            Ok(commitment) => response.send(Ok(commitment)).ok(),
+            Err(err) => {
+                error!(?err, "Failed to sign commitment");
+                response.send(Err(CommitmentError::Internal)).ok()
+            }
+        };
+    }
+
+    /// Handle a new head event, updating the execution and consensus state.
+    async fn handle_new_head_event(&mut self, head_event: HeadEvent) {
+        let slot = head_event.slot;
+        info!(slot, "Received new head event");
+
+        // We use None to signal that we want to fetch the latest EL head
+        if let Err(e) = self.execution.update_head(None, slot).await {
+            error!(err = ?e, "Failed to update execution state head");
+        }
+
+        if let Err(e) = self.consensus.update_head(slot).await {
+            error!(err = ?e, "Failed to update consensus state head");
+        }
+    }
+
+    /// Handle a commitment deadline event, submitting constraints to the MEV-Boost service.
+    fn handle_commitment_deadline(&mut self, slot: u64) {
+        debug!(slot, "Commitment deadline reached, building local block");
+
+        let Some(template) = self.execution.get_block_template(slot) else {
+            warn!("No block template found for slot {slot} when requested");
+            return;
+        };
+
+        // TODO: fix retry logic, and move this to separate task in the mevboost client itself
+        let constraints = template.signed_constraints_list.clone();
+        let mevboost = self.mevboost_client.clone();
+        tokio::spawn(async move {
+            let max_retries = 5;
+            let mut i = 0;
+            while let Err(e) = mevboost.submit_constraints(&constraints).await {
+                error!(err = ?e, "Error submitting constraints to mev-boost, retrying...");
+                tokio::time::sleep(Duration::from_millis(100)).await;
+                i += 1;
+                if i >= max_retries {
+                    error!("Max retries reached while submitting to MEV-Boost");
+                    break;
+                }
+            }
+        });
+    }
+
+    /// Handle a fetch payload request, responding with the local payload if available.
+    fn handle_fetch_payload_request(&mut self, request: FetchPayloadRequest) {
+        info!(slot = request.slot, "Received local payload request");
+
+        let Some(payload_and_bid) = self.local_builder.get_cached_payload() else {
+            warn!(slot = request.slot, "No local payload found");
+            let _ = request.response_tx.send(None);
+            return;
+        };
+
+        if let Err(e) = request.response_tx.send(Some(payload_and_bid)) {
+            error!(err = ?e, "Failed to send payload and bid in response channel");
+        }
+    }
+}

--- a/bolt-sidecar/src/lib.rs
+++ b/bolt-sidecar/src/lib.rs
@@ -18,6 +18,10 @@ pub use client::{mevboost::MevBoostClient, rpc::RpcClient, BeaconClient};
 /// (To be refactored)
 mod common;
 
+/// Driver for the sidecar, which manages the main event loop
+pub mod driver;
+pub use driver::SidecarDriver;
+
 /// Functionality for building local block templates that can
 /// be used as a fallback for proposers. It's also used to keep
 /// any intermediary state that is needed to simulate EVM execution

--- a/bolt-sidecar/src/primitives/constraint.rs
+++ b/bolt-sidecar/src/primitives/constraint.rs
@@ -2,7 +2,7 @@ use alloy::primitives::{keccak256, Address};
 use secp256k1::Message;
 use serde::Serialize;
 
-use crate::crypto::{ecdsa::SignableECDSA, SignableBLS};
+use crate::crypto::{bls::BLSSig, ecdsa::SignableECDSA, SignableBLS};
 
 use super::{FullTransaction, InclusionRequest};
 
@@ -31,12 +31,12 @@ pub type BatchedSignedConstraints = Vec<SignedConstraints>;
 /// A container for a list of constraints and the signature of the proposer sidecar.
 ///
 /// Reference: https://chainbound.github.io/bolt-docs/api/builder-api#ethv1builderconstraints
-#[derive(Serialize, Debug, Clone, PartialEq, Default)]
+#[derive(Serialize, Default, Debug, Clone, PartialEq)]
 pub struct SignedConstraints {
     /// The constraints that need to be signed.
     pub message: ConstraintsMessage,
     /// The signature of the proposer sidecar.
-    pub signature: String,
+    pub signature: BLSSig,
 }
 
 /// A message that contains the constraints that need to be signed by the proposer sidecar.

--- a/bolt-sidecar/src/state/consensus.rs
+++ b/bolt-sidecar/src/state/consensus.rs
@@ -1,4 +1,7 @@
-use std::time::{Duration, Instant};
+use std::{
+    fmt,
+    time::{Duration, Instant},
+};
 
 use beacon_api_client::{mainnet::Client, BlockId, ProposerDuty};
 use ethereum_consensus::{deneb::BeaconBlockHeader, phase0::mainnet::SLOTS_PER_EPOCH};
@@ -54,6 +57,18 @@ pub struct ConsensusState {
     pub commitment_deadline: CommitmentDeadline,
     /// The duration of the commitment deadline.
     commitment_deadline_duration: Duration,
+}
+
+impl fmt::Debug for ConsensusState {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("ConsensusState")
+            .field("header", &self.header)
+            .field("epoch", &self.epoch)
+            .field("latest_slot", &self.latest_slot)
+            .field("latest_slot_timestamp", &self.latest_slot_timestamp)
+            .field("commitment_deadline", &self.commitment_deadline)
+            .finish()
+    }
 }
 
 impl ConsensusState {


### PR DESCRIPTION
This PR introduces a refactor of the `sidecar` binary to streamline all components that go in the initialization and event loop phase of operating the sidecar.

In particular, this implementation differs from what attempted in #133 in not using a manual `Future` but instead still relying on `tokio::select!` to progress the loop. This simplifies things a lot, because of the following async tasks:

1. updating the consensus and execution head is an async operation (it requires fetching from both EL and CL)
2. validating the execution state of a request is an async operation (it requires fetching state from the EL)

This could be overcome in the future by transforming the `ExecutionState` and `ConsensusState` containers into actors with their own loops to respond to requests in channels instead of awaiting.