### PR TITLE
chore(sidecar): import tracing macros in files

### DIFF
--- a/bolt-client/src/registry.rs
+++ b/bolt-client/src/registry.rs
@@ -10,6 +10,7 @@ use alloy::{
 };
 use beacon_api_client::ProposerDuty;
 use reqwest::Client;
+use tracing::info;
 use url::Url;
 use BoltRegistryContract::{BoltRegistryContractErrors, BoltRegistryContractInstance, Registrant};
 
@@ -87,7 +88,7 @@ impl BoltRegistry {
                 Ok(Some(token_raw)) => {
                     next_preconfer_slot = duty.slot;
                     proposer_rpc = token_raw.metadata.rpc;
-                    tracing::info!(
+                    info!(
                         "pre-confirmation will be sent for slot {} to validator with index {} at url {}",
                         duty.slot,
                         duty.validator_index,
@@ -99,10 +100,7 @@ impl BoltRegistry {
                     // Handle the case where the result is Ok but contains None.
                     // You might want to continue to the next iteration, log something, or handle it
                     // in another way.
-                    tracing::info!(
-                        "No registrant found for validator index {}",
-                        duty.validator_index
-                    );
+                    info!("No registrant found for validator index {}", duty.validator_index);
                     continue;
                 }
                 Err(e) => {

--- a/bolt-kurtosis-client/src/main.rs
+++ b/bolt-kurtosis-client/src/main.rs
@@ -40,7 +40,7 @@ struct Opts {
 #[tokio::main]
 async fn main() -> Result<()> {
     tracing_subscriber::fmt::init();
-    tracing::info!("starting bolt-spammer");
+    info!("starting bolt-spammer");
 
     let opts = Opts::parse();
 

--- a/bolt-sidecar/src/builder/template.rs
+++ b/bolt-sidecar/src/builder/template.rs
@@ -12,6 +12,7 @@ use ethereum_consensus::{
     deneb::mainnet::{Blob, BlobsBundle},
 };
 use reth_primitives::TransactionSigned;
+use tracing::warn;
 
 use crate::{
     common::max_transaction_cost,
@@ -188,7 +189,7 @@ impl BlockTemplate {
 
         if state.balance < max_total_cost || state.transaction_count > min_nonce {
             // Remove invalidated constraints due to balance / nonce of chain state
-            tracing::warn!(
+            warn!(
                 %address,
                 "Removing invalidated constraints for address"
             );

--- a/bolt-sidecar/src/client/mevboost.rs
+++ b/bolt-sidecar/src/client/mevboost.rs
@@ -8,6 +8,7 @@ use ethereum_consensus::{
     builder::SignedValidatorRegistration, deneb::mainnet::SignedBlindedBeaconBlock, Fork,
 };
 use reqwest::Url;
+use tracing::error;
 
 use crate::{
     api::{
@@ -38,7 +39,7 @@ impl MevBoostClient {
 
     fn endpoint(&self, path: &str) -> Url {
         self.url.join(path).unwrap_or_else(|e| {
-            tracing::error!(err = ?e, "Failed to join path: {} with url: {}", path, self.url);
+            error!(err = ?e, "Failed to join path: {} with url: {}", path, self.url);
             self.url.clone()
         })
     }

--- a/bolt-sidecar/src/primitives/mod.rs
+++ b/bolt-sidecar/src/primitives/mod.rs
@@ -31,6 +31,7 @@ pub use commitment::{CommitmentRequest, InclusionRequest};
 /// for validation.
 pub mod constraint;
 pub use constraint::{BatchedSignedConstraints, ConstraintsMessage, SignedConstraints};
+use tracing::{error, info};
 
 /// An alias for a Beacon Chain slot number
 pub type Slot = u64;
@@ -125,7 +126,7 @@ impl PayloadFetcher for LocalPayloadFetcher {
         match response_rx.await {
             Ok(res) => res,
             Err(e) => {
-                tracing::error!(err = ?e, "Failed to fetch payload");
+                error!(err = ?e, "Failed to fetch payload");
                 None
             }
         }
@@ -143,7 +144,7 @@ pub struct NoopPayloadFetcher;
 #[async_trait::async_trait]
 impl PayloadFetcher for NoopPayloadFetcher {
     async fn fetch_payload(&self, slot: u64) -> Option<PayloadAndBid> {
-        tracing::info!(slot, "Fetch payload called");
+        info!(slot, "Fetch payload called");
         None
     }
 }

--- a/bolt-sidecar/src/state/fetcher.rs
+++ b/bolt-sidecar/src/state/fetcher.rs
@@ -11,6 +11,7 @@ use alloy::{
 };
 use futures::{stream::FuturesOrdered, StreamExt};
 use reqwest::Url;
+use tracing::error;
 
 use crate::{client::rpc::RpcClient, primitives::AccountState};
 
@@ -197,7 +198,7 @@ impl StateFetcher for StateClient {
                         return Err(e);
                     }
 
-                    tracing::error!(error = ?e, "Error getting account state, retrying...");
+                    error!(error = ?e, "Error getting account state, retrying...");
                     tokio::time::sleep(self.retry_backoff).await;
                 }
             }

--- a/bolt-sidecar/src/test_util.rs
+++ b/bolt-sidecar/src/test_util.rs
@@ -13,6 +13,7 @@ use alloy_node_bindings::{Anvil, AnvilInstance};
 use blst::min_pk::SecretKey;
 use reth_primitives::PooledTransactionsElement;
 use secp256k1::Message;
+use tracing::warn;
 
 use crate::{
     crypto::{ecdsa::SignableECDSA, SignableBLS},
@@ -74,7 +75,7 @@ pub(crate) async fn get_test_config() -> Option<Config> {
     let _ = dotenvy::dotenv();
 
     let Some(jwt) = std::env::var("ENGINE_JWT").ok() else {
-        tracing::warn!("ENGINE_JWT not found in environment variables");
+        warn!("ENGINE_JWT not found in environment variables");
         return None;
     };
 


### PR DESCRIPTION
- after #183 

Import `tracing` in files instead of using `tracing::info!` directives in files.
Part of a small cleanup of the sidecar codebase 🧹