### PR TITLE
wip: perform diffs of all flashbots packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 *_dump.log
+forkdiff/

--- a/Justfile
+++ b/Justfile
@@ -169,3 +169,11 @@ release tag:
     cd mev-boost-relay && docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/chainbound/bolt-relay:{{tag}} --push .
     cd builder && docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/chainbound/bolt-builder:{{tag}} --push .
     cd mev-boost && docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/chainbound/bolt-mev-boost:{{tag}} --push .
+
+# perform the forkdiff analysis on the provided flashbots upstream repository
+# - "repo_name" valid options are: mev-boost-relay, mev-boost, builder
+# - "tag" is the name of the git branch or tag to compare against in the original remote
+#
+# example: "just fb-forkdiff mev-boost develop"
+fb-forkdiff repo_name tag:
+    chmod +x ./scripts/flashbots-forkdiff.sh && ./scripts/flashbots-forkdiff.sh {{repo_name}} {{tag}}

--- a/scripts/flashbots-forkdiff.sh
+++ b/scripts/flashbots-forkdiff.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+set -e
+
+# take the repo name as the first argument
+REPO_NAME=$1
+# take the tag as the second argument
+GIT_TAG=$2
+
+OUT_DIR=$(pwd)/forkdiff
+
+# the repo name must be one of the supported packages
+if [ "$REPO_NAME" != "mev-boost-relay" ] && [ "$REPO_NAME" != "mev-boost" ] && [ "$REPO_NAME" != "builder" ]; then
+    echo "Usage: $0 <mev-boost-relay|mev-boost|builder>"
+    exit 1
+fi
+
+# create the outdir if it doesn't exist
+mkdir -p $OUT_DIR || true
+
+# create a temporary dir to hold just the package alone, 
+# without the monorepo path structure in the way
+mkdir -p /tmp/bolt-forkdiff/$REPO_NAME
+cp -r ./$REPO_NAME/* /tmp/bolt-forkdiff/$REPO_NAME/
+
+(
+    cd /tmp/bolt-forkdiff/$REPO_NAME
+
+    git init
+    git add .
+    git commit -m "Snapshot of $REPO_NAME from bolt monorepo"
+
+    git remote add origin https://github.com/flashbots/$REPO_NAME.git
+    git fetch origin
+
+    git diff origin/$GIT_TAG > $OUT_DIR/$REPO_NAME.diff
+)
+
+rm -rf /tmp/bolt-forkdiff/$REPO_NAME


### PR DESCRIPTION
This will create `.diff` files for internal use to assess changes with upstream flashbots packages in a simple way.
This doesn't include full `fork.yaml` definitions needed to build the forkdiff websites yet, but it's a first step.

*I hate bash*