### PR TITLE
fix: commitment deadline in case of missed block

### DIFF
--- a/bolt-sidecar/src/driver.rs
+++ b/bolt-sidecar/src/driver.rs
@@ -166,7 +166,7 @@ impl<C: StateFetcher, BLS: SignerBLS, ECDSA: SignerECDSA> SidecarDriver<C, BLS, 
                 }
                 Some(slot) = slot_stream.next() => {
                     if let Err(e) = self.consensus.update_slot(slot).await {
-                        error!(err = ?e, "Failed to update consensus state head");
+                        error!(err = ?e, "Failed to update consensus state slot");
                     }
                 }
             }
@@ -228,7 +228,7 @@ impl<C: StateFetcher, BLS: SignerBLS, ECDSA: SignerECDSA> SidecarDriver<C, BLS, 
         };
     }
 
-    /// Handle a new head event, updating the execution and consensus state.
+    /// Handle a new head event, updating the execution state.
     async fn handle_new_head_event(&mut self, head_event: HeadEvent) {
         let slot = head_event.slot;
         info!(slot, "Received new head event");

--- a/bolt-sidecar/src/state/consensus.rs
+++ b/bolt-sidecar/src/state/consensus.rs
@@ -114,17 +114,17 @@ impl ConsensusState {
     }
 
     /// Update the latest head and fetch the relevant data from the beacon chain.
-    pub async fn update_slot(&mut self, head: u64) -> Result<(), ConsensusError> {
+    pub async fn update_slot(&mut self, slot: u64) -> Result<(), ConsensusError> {
         // Reset the commitment deadline to start counting for the next slot.
         self.commitment_deadline =
-            CommitmentDeadline::new(head + 1, self.commitment_deadline_duration);
+            CommitmentDeadline::new(slot + 1, self.commitment_deadline_duration);
 
         // Update the timestamp with current time
         self.latest_slot_timestamp = Instant::now();
-        self.latest_slot = head;
+        self.latest_slot = slot;
 
         // Calculate the current value of epoch
-        let epoch = head / SLOTS_PER_EPOCH;
+        let epoch = slot / SLOTS_PER_EPOCH;
 
         // If the epoch has changed, update the proposer duties
         if epoch != self.epoch.value {

--- a/bolt-sidecar/src/state/consensus.rs
+++ b/bolt-sidecar/src/state/consensus.rs
@@ -123,7 +123,7 @@ impl ConsensusState {
         self.latest_slot_timestamp = Instant::now();
         self.latest_slot = head;
 
-        // Get the current value of slot and epoch
+        // Calculate the current value of epoch
         let epoch = head / SLOTS_PER_EPOCH;
 
         // If the epoch has changed, update the proposer duties


### PR DESCRIPTION
Fixes #180 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Enhanced consensus management with the addition of a `consensus_clock` for improved time representation related to consensus slots.
	- New method to retrieve the cached beacon genesis timestamp from the `HeadTracker`.

- **Bug Fixes**
	- Improved resilience in fetching the beacon genesis timestamp with a retry mechanism.

- **Refactor**
	- Simplified `ConsensusState` by removing the `header` field and renaming `update_head` to `update_slot` for clearer slot management.
	- Standardized retry logic for subscribing to new head events in the `HeadTracker`.

- **Tests**
	- Added test cases to verify the correct behavior of the updated slot management functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->