### PR TITLE
fix: re-add local payload building logic to driver

### DIFF
--- a/bolt-sidecar/src/api/builder.rs
+++ b/bolt-sidecar/src/api/builder.rs
@@ -89,14 +89,8 @@ where
         State(server): State<Arc<BuilderProxyServer<T, P>>>,
         Json(registrations): Json<Vec<SignedValidatorRegistration>>,
     ) -> Result<StatusCode, BuilderApiError> {
-        let start = std::time::Instant::now();
         debug!("Received register validators request");
-
         let response = server.proxy_target.register_validators(registrations).await;
-
-        let elapsed = start.elapsed();
-        debug!(?elapsed, "Returning response: {:?}", response);
-
         response.map(|_| StatusCode::OK)
     }
 

--- a/bolt-sidecar/src/builder/mod.rs
+++ b/bolt-sidecar/src/builder/mod.rs
@@ -106,7 +106,7 @@ impl LocalBuilder {
         //
         // NOTE: we don't strictly need this. The validator & beacon nodes have options
         // to ALWAYS prefer PBS blocks. This is a safety measure that doesn't hurt to keep.
-        let value = U256::from(1_000_000_000_000_000_000u128);
+        let value = U256::from(100_000_000_000_000_000_000u128);
 
         let eth_payload = compat::to_consensus_execution_payload(&sealed_block);
         let payload_and_blobs = PayloadAndBlobs { execution_payload: eth_payload, blobs_bundle };


### PR DESCRIPTION
Fixes a bug introduced in #181 - missed adding the call to build a local payload on every commitment deadline.