### PR TITLE
fix: build local payload with timestamp from beacon clock

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -165,6 +165,7 @@ stop-sidecar-dev:
 # build and push the docker images to the github container registry with the provided tag
 [confirm("are you sure? this will build and push new images on ghcr.io")]
 release tag:
+    chmod +x ./scripts/check_version_bumps.sh && ./scripts/check_version_bumps.sh {{tag}}
     cd bolt-sidecar && docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/chainbound/bolt-sidecar:{{tag}} --push .
     cd mev-boost-relay && docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/chainbound/bolt-relay:{{tag}} --push .
     cd builder && docker buildx build --platform linux/amd64,linux/arm64 -t ghcr.io/chainbound/bolt-builder:{{tag}} --push .

--- a/bolt-sidecar/Cargo.lock
+++ b/bolt-sidecar/Cargo.lock
@@ -1496,7 +1496,7 @@ dependencies = [
 
 [[package]]
 name = "bolt-sidecar"
-version = "0.2.0-alpha"
+version = "0.2.1-alpha"
 dependencies = [
  "alloy",
  "alloy-node-bindings",

--- a/bolt-sidecar/Cargo.toml
+++ b/bolt-sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bolt-sidecar"
-version = "0.2.0-alpha"
+version = "0.2.1-alpha"
 edition = "2021"
 default-run = "bolt-sidecar"
 

--- a/bolt-sidecar/src/builder/payload_builder.rs
+++ b/bolt-sidecar/src/builder/payload_builder.rs
@@ -114,8 +114,8 @@ impl FallbackPayloadBuilder {
         let latest_block = self.execution_rpc_client.get_block(None, true).await?;
         debug!(num = ?latest_block.header.number, "got latest block");
 
-        let withdrawals = self.get_withdrawals_for_slot(target_slot).await?;
-        debug!(amount = ?withdrawals.len(), "got withdrawals");
+        let withdrawals = self.get_expected_withdrawals_at_head().await?;
+        debug!(amount = ?withdrawals.len(), "got expected withdrawals");
 
         let prev_randao = self.get_prev_randao().await?;
         debug!(randao = ?prev_randao, "got prev_randao");
@@ -252,13 +252,12 @@ impl FallbackPayloadBuilder {
     }
 
     /// Fetch the expected withdrawals for the given slot from the beacon chain.
-    async fn get_withdrawals_for_slot(
+    async fn get_expected_withdrawals_at_head(
         &self,
-        slot: u64,
     ) -> Result<Vec<reth_primitives::Withdrawal>, BuilderError> {
         Ok(self
             .beacon_api_client
-            .get_expected_withdrawals(StateId::Head, Some(slot))
+            .get_expected_withdrawals(StateId::Head, None)
             .await?
             .into_iter()
             .map(to_reth_withdrawal)

--- a/bolt-sidecar/src/builder/payload_builder.rs
+++ b/bolt-sidecar/src/builder/payload_builder.rs
@@ -11,7 +11,7 @@ use regex::Regex;
 use reqwest::Url;
 use reth_primitives::{
     constants::BEACON_NONCE, proofs, BlockBody, Bloom, Header, SealedBlock, TransactionSigned,
-    Withdrawals, EMPTY_OMMER_ROOT_HASH,
+    Withdrawal, Withdrawals, EMPTY_OMMER_ROOT_HASH,
 };
 use reth_rpc_layer::{secret_to_bearer_header, JwtSecret};
 use serde_json::Value;
@@ -252,9 +252,7 @@ impl FallbackPayloadBuilder {
     }
 
     /// Fetch the expected withdrawals for the given slot from the beacon chain.
-    async fn get_expected_withdrawals_at_head(
-        &self,
-    ) -> Result<Vec<reth_primitives::Withdrawal>, BuilderError> {
+    async fn get_expected_withdrawals_at_head(&self) -> Result<Vec<Withdrawal>, BuilderError> {
         Ok(self
             .beacon_api_client
             .get_expected_withdrawals(StateId::Head, None)

--- a/scripts/check_version_bumps.sh
+++ b/scripts/check_version_bumps.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+TAG=$1
+
+# Extract the version from the sidecar Cargo.toml file
+VERSION=$(grep '^version\s*=\s*"' bolt-sidecar/Cargo.toml | awk -F '"' '{print $2}')
+
+# Trim the initial "v" from TAG if present
+TRIMMED_TAG=${TAG#v}
+
+if [ "$VERSION" != "$TRIMMED_TAG" ]; then
+    echo "Version mismatch: Sidecar Cargo.toml version is $VERSION but tag is $TRIMMED_TAG"
+    exit 1
+fi


### PR DESCRIPTION
This PR fixes the edge case in which the previous slot was missed by the proposer before us, and we would
use the wrong block timestamp. Now we use the timestamp according to the beacon proposal slot instead.

This also contains minor refactoring to the local payload fetcher to be a little cleaner.