### PR TITLE
Telemetry & Metrics

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -101,6 +101,15 @@ dora:
     xdg-open "$url"; \
   fi
 
+# show the grafana dashboard in the browser. NOTE: works only for Linux and MacOS at the moment
+grafana:
+  @url=$(just inspect | grep 'grafana\s*http' | awk -F'-> ' '{print $2}' | awk '{print $1}') && \
+  if [ "$(uname)" = "Darwin" ]; then \
+    open "$url"; \
+  else \
+    xdg-open "$url"; \
+  fi
+
 # manually send a preconfirmation to the bolt devnet
 send-preconf count='1':
 	cd bolt-kurtosis-client && RUST_LOG=info cargo run -- \

--- a/README.md
+++ b/README.md
@@ -23,12 +23,14 @@
 
 <!-- vim-markdown-toc Marked -->
 
-- [How it works](#how-it-works)
-- [Scope of this repository](#scope-of-this-repository)
-- [Devnet and demo app](#devnet-and-demo-app)
-  - [Requirements and setup](#requirements-and-setup)
-  - [Running the devnet and demo](#running-the-devnet-and-demo)
-  - [Stopping the devnet and demo](#stopping-the-devnet-and-demo)
+* [How it works](#how-it-works)
+* [Scope of this repository](#scope-of-this-repository)
+* [Devnet and demo app](#devnet-and-demo-app)
+  * [Requirements and setup](#requirements-and-setup)
+  * [Running the devnet and demo](#running-the-devnet-and-demo)
+  * [Stopping the devnet and demo](#stopping-the-devnet-and-demo)
+* [Telemetry & Metrics](#telemetry-&-metrics)
+* [License](#license)
 
 <!-- vim-markdown-toc -->
 
@@ -184,5 +186,13 @@ just clean
 [fb-builder]: https://github.com/flashbots/builder
 [kurtosis]: https://www.kurtosis.com/
 
+## Telemetry & Metrics
+
+The Bolt sidecar offers an optional set of metrics that can be scraped by a Prometheus server, and shown in Grafana dashboards.
+They show various informations such as the number of constraints received, the number of blocks proposed, etc.
+
+These metrics are enabled by default but can be disabled by setting running the sidecar with the `--metrics` flag set to `false`.
+
 ## License
+
 MIT. Forked repositories have their own licenses.

--- a/bolt-sidecar/Cargo.lock
+++ b/bolt-sidecar/Cargo.lock
@@ -1234,6 +1234,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c4b4d0bd25bd0b74681c0ad21497610ce1b7c91b1022cd21c80c6fbdd9476b0"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ae74d9bd0a7530e8afd1770739ad34b36838829d6ad61818f9230f683f5ad77"
+dependencies = [
+ "aws-lc-sys",
+ "mirai-annotations",
+ "paste",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.20.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f0e249228c6ad2d240c2dc94b714d711629d52bad946075d8e9b2f5391f0703"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+ "libc",
+ "paste",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1409,6 +1436,29 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "230c5f1ca6a325a32553f8640d31ac9b49f2411e901e427570154868b46da4f7"
 
 [[package]]
+name = "bindgen"
+version = "0.69.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
+dependencies = [
+ "bitflags 2.6.0",
+ "cexpr",
+ "clang-sys",
+ "itertools 0.12.1",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "prettyplease",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash 1.1.0",
+ "shlex",
+ "syn 2.0.67",
+ "which",
+]
+
+[[package]]
 name = "bit-set"
 version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1515,6 +1565,8 @@ dependencies = [
  "futures",
  "hex",
  "lru",
+ "metrics",
+ "metrics-exporter-prometheus",
  "parking_lot",
  "partial-mpt",
  "rand 0.8.5",
@@ -1649,6 +1701,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
+name = "cexpr"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6fac387a98bb7c37292057cffc56d62ecb629900026402633ae9160df93a8766"
+dependencies = [
+ "nom",
+]
+
+[[package]]
 name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1665,6 +1726,17 @@ dependencies = [
  "num-traits",
  "serde",
  "windows-targets 0.52.5",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -1706,6 +1778,15 @@ name = "clap_lex"
 version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b82cf0babdbd58558212896d1a4272303a57bdb245c2bf1147185fb45640e70"
+
+[[package]]
+name = "cmake"
+version = "0.1.51"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb1e43aa7fd152b1f968787f7dbcdeb306d1867ff373c69955211876c053f91a"
+dependencies = [
+ "cc",
+]
 
 [[package]]
 name = "colorchoice"
@@ -2434,6 +2515,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "fs_extra"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
+
+[[package]]
 name = "funty"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2740,6 +2827,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "home"
+version = "0.5.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3d1354bf6b7235cb4a0576c2619fd4ed18183f689b12b006a0ee7329eeff9a5"
+dependencies = [
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "http"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2884,6 +2980,7 @@ dependencies = [
  "hyper-util",
  "log",
  "rustls",
+ "rustls-native-certs",
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
@@ -3307,10 +3404,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
 
 [[package]]
+name = "lazycell"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830d08ce1d1d941e6b30645f1a0eb5643013d835ce3779a5fc208261dbe10f55"
+
+[[package]]
 name = "libc"
 version = "0.2.155"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97b3888a4aecf77e811145cadf6eef5901f4782c53886191b2f693f24761847c"
+
+[[package]]
+name = "libloading"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4979f22fdb869068da03c9f7528f8297c6fd2606bc3a4affe42e6a823fdb8da4"
+dependencies = [
+ "cfg-if",
+ "windows-targets 0.52.5",
+]
 
 [[package]]
 name = "libm"
@@ -3356,6 +3469,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3366,6 +3488,52 @@ name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
+
+[[package]]
+name = "metrics"
+version = "0.23.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "884adb57038347dfbaf2d5065887b6cf4312330dc8e94bc30a1a839bd79d3261"
+dependencies = [
+ "ahash",
+ "portable-atomic",
+]
+
+[[package]]
+name = "metrics-exporter-prometheus"
+version = "0.15.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4f0c8427b39666bf970460908b213ec09b3b350f20c0c2eabcbba51704a08e6"
+dependencies = [
+ "base64 0.22.1",
+ "http-body-util",
+ "hyper 1.3.1",
+ "hyper-rustls",
+ "hyper-util",
+ "indexmap 2.2.6",
+ "ipnet",
+ "metrics",
+ "metrics-util",
+ "quanta",
+ "thiserror",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "metrics-util"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4259040465c955f9f2f1a4a8a16dc46726169bca0f88e8fb2dbeced487c3e828"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "hashbrown 0.14.5",
+ "metrics",
+ "num_cpus",
+ "quanta",
+ "sketches-ddsketch",
+]
 
 [[package]]
 name = "mev-share-sse"
@@ -3403,6 +3571,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "minimal-lexical"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
+
+[[package]]
 name = "miniz_oxide"
 version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3421,6 +3595,12 @@ dependencies = [
  "wasi 0.11.0+wasi-snapshot-preview1",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "mirai-annotations"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9be0862c1b3f26a88803c4a49de6889c10e608b3ee9344e6ef5b45fb37ad3d1"
 
 [[package]]
 name = "modular-bitfield"
@@ -3521,6 +3701,16 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "tempfile",
+]
+
+[[package]]
+name = "nom"
+version = "7.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
+dependencies = [
+ "memchr",
+ "minimal-lexical",
 ]
 
 [[package]]
@@ -3890,6 +4080,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d231b230927b5e4ad203db57bbcbee2802f6bce620b1e4a9024a07d94e2907ec"
 
 [[package]]
+name = "portable-atomic"
+version = "1.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da544ee218f0d287a911e9c99a39a8c9bc8fcad3cb8db5959940044ecfc67265"
+
+[[package]]
 name = "powerfmt"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3900,6 +4096,16 @@ name = "ppv-lite86"
 version = "0.2.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
+
+[[package]]
+name = "prettyplease"
+version = "0.2.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5f12335488a2f3b0a83b14edad48dca9879ce89b2edd10e80237e4e852dd645e"
+dependencies = [
+ "proc-macro2",
+ "syn 2.0.67",
+]
 
 [[package]]
 name = "primitive-types"
@@ -3981,10 +4187,25 @@ dependencies = [
  "rand 0.8.5",
  "rand_chacha 0.3.1",
  "rand_xorshift",
- "regex-syntax",
+ "regex-syntax 0.8.4",
  "rusty-fork",
  "tempfile",
  "unarray",
+]
+
+[[package]]
+name = "quanta"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5167a477619228a0b284fac2674e3c388cba90631d7b7de620e6f1fcd08da5"
+dependencies = [
+ "crossbeam-utils",
+ "libc",
+ "once_cell",
+ "raw-cpuid",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "web-sys",
+ "winapi",
 ]
 
 [[package]]
@@ -4089,6 +4310,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "raw-cpuid"
+version = "11.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb9ee317cfe3fbd54b36a511efc1edd42e216903c9cd575e686dd68a2ba90d8d"
+dependencies = [
+ "bitflags 2.6.0",
+]
+
+[[package]]
 name = "rayon"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4131,8 +4361,17 @@ checksum = "b91213439dad192326a0d7c6ee3955910425f441d7038e0d6933b0aec5c4517f"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.7",
+ "regex-syntax 0.8.4",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -4143,8 +4382,14 @@ checksum = "38caf58cc5ef2fed281f89292ef23f6365465ed9a41b7a7754eb4e26496c92df"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.4",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -4276,7 +4521,7 @@ dependencies = [
  "crc",
  "dyn-clone",
  "once_cell",
- "rustc-hash",
+ "rustc-hash 2.0.0",
  "serde",
  "thiserror-no-std",
 ]
@@ -4521,6 +4766,12 @@ checksum = "719b953e2095829ee67db738b3bfa9fa368c94900df327b3f07fe6e794d2fe1f"
 
 [[package]]
 name = "rustc-hash"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08d43f7aa6b08d49f382cde6a7982047c3426db949b1424bc4b7ec9ae12c6ce2"
+
+[[package]]
+name = "rustc-hash"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "583034fd73374156e66797ed8e5b0d5690409c9226b22d87cb7f19821c05d152"
@@ -4568,6 +4819,7 @@ version = "0.23.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05cff451f60db80f490f3c182b77c35260baace73209e9cdbbe526bfe3a4d402"
 dependencies = [
+ "aws-lc-rs",
  "log",
  "once_cell",
  "ring 0.17.8",
@@ -4648,6 +4900,7 @@ version = "0.102.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff448f7e92e913c4b7d4c6d8e4540a1724b319b4152b8aef6d4cf8339712b33e"
 dependencies = [
+ "aws-lc-rs",
  "ring 0.17.8",
  "rustls-pki-types",
  "untrusted 0.9.0",
@@ -5025,6 +5278,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "shlex"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
 name = "signal-hook-registry"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5064,6 +5323,12 @@ dependencies = [
  "thiserror",
  "time",
 ]
+
+[[package]]
+name = "sketches-ddsketch"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "85636c14b73d81f541e525f585c0a2109e6744e1565b5c1668e31c70c10ed65c"
 
 [[package]]
 name = "slab"
@@ -5640,10 +5905,14 @@ version = "0.3.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ad0f048c97dbd9faa9b7df56362b8ebcaa52adb06b498c050d2f4e32f90a7a8b"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]
@@ -6035,6 +6304,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd7c23921eeb1713a4e851530e9b9756e4fb0e89978582942612524cf09f01cd"
 dependencies = [
  "rustls-pki-types",
+]
+
+[[package]]
+name = "which"
+version = "4.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "87ba24419a2078cd2b0f2ede2691b6c66d8e47836da3b6db8265ebad47afbfc7"
+dependencies = [
+ "either",
+ "home",
+ "once_cell",
+ "rustix",
 ]
 
 [[package]]

--- a/bolt-sidecar/Cargo.lock
+++ b/bolt-sidecar/Cargo.lock
@@ -1579,6 +1579,7 @@ dependencies = [
  "serde_json",
  "thiserror",
  "tokio",
+ "tower-http",
  "tracing",
  "tracing-subscriber",
  "tree_hash",
@@ -5841,6 +5842,23 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
+]
+
+[[package]]
+name = "tower-http"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
+dependencies = [
+ "bitflags 2.6.0",
+ "bytes",
+ "http 1.1.0",
+ "http-body 1.0.0",
+ "http-body-util",
+ "pin-project-lite",
+ "tokio",
+ "tower-layer",
+ "tower-service",
 ]
 
 [[package]]

--- a/bolt-sidecar/Cargo.toml
+++ b/bolt-sidecar/Cargo.toml
@@ -21,10 +21,10 @@ secp256k1 = { version = "0.29.0", features = ["rand"] }
 
 # alloy
 alloy = { version = "0.2.0", features = [
-    "full",
-    "provider-trace-api",
-    "rpc-types-beacon",
-    "rpc-types-engine",
+  "full",
+  "provider-trace-api",
+  "rpc-types-beacon",
+  "rpc-types-engine",
 ] }
 
 # alloy-rpc-types = { git = "https://github.com/chainbound/alloy", branch = "fix/account-override-serialize" }
@@ -58,7 +58,13 @@ regex = "1.10.5"
 
 # tracing
 tracing = "0.1.40"
-tracing-subscriber = "0.3.18"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter", "fmt"] }
+
+# telemetry
+metrics = "0.23"
+metrics-exporter-prometheus = { version = "0.15.3", features = [
+  "http-listener",
+] }
 
 # commit-boost
 cb-crypto = { git = "https://github.com/Commit-Boost/commit-boost-client" }

--- a/bolt-sidecar/Cargo.toml
+++ b/bolt-sidecar/Cargo.toml
@@ -9,6 +9,7 @@ default-run = "bolt-sidecar"
 clap = { version = "4.5.4", features = ["derive", "env"] }
 tokio = { version = "1", features = ["full"] }
 axum = { version = "0.7", features = ["macros"] }
+tower-http = { version = "0.5.2", features = ["timeout"] }
 axum-extra = "0.9.3"
 warp = "0.3.7"
 futures = "0.3"

--- a/bolt-sidecar/bin/sidecar.rs
+++ b/bolt-sidecar/bin/sidecar.rs
@@ -1,16 +1,18 @@
+use bolt_sidecar::telemetry::init_telemetry_stack;
 use bolt_sidecar::{Config, SidecarDriver};
 use eyre::{bail, Result};
 use tracing::info;
 
 #[tokio::main]
 async fn main() -> Result<()> {
-    // TODO: improve telemetry setup (#116)
-    tracing_subscriber::fmt::init();
-
     let config = match Config::parse_from_cli() {
         Ok(config) => config,
         Err(err) => bail!("Failed to parse CLI arguments: {:?}", err),
     };
+
+    if let Err(err) = init_telemetry_stack(config.metrics_port) {
+        bail!("Failed to initialize telemetry stack: {:?}", err)
+    }
 
     info!(chain = config.chain.name(), "Starting Bolt sidecar");
     match SidecarDriver::new(config).await {

--- a/bolt-sidecar/bin/sidecar.rs
+++ b/bolt-sidecar/bin/sidecar.rs
@@ -10,7 +10,7 @@ async fn main() -> Result<()> {
         Err(err) => bail!("Failed to parse CLI arguments: {:?}", err),
     };
 
-    let metrics_port = if config.disable_metrics { Some(config.metrics_port) } else { None };
+    let metrics_port = if !config.disable_metrics { Some(config.metrics_port) } else { None };
     if let Err(err) = init_telemetry_stack(metrics_port) {
         bail!("Failed to initialize telemetry stack: {:?}", err)
     }

--- a/bolt-sidecar/bin/sidecar.rs
+++ b/bolt-sidecar/bin/sidecar.rs
@@ -10,7 +10,7 @@ async fn main() -> Result<()> {
         Err(err) => bail!("Failed to parse CLI arguments: {:?}", err),
     };
 
-    let metrics_port = if config.metrics { Some(config.metrics_port) } else { None };
+    let metrics_port = if config.disable_metrics { Some(config.metrics_port) } else { None };
     if let Err(err) = init_telemetry_stack(metrics_port) {
         bail!("Failed to initialize telemetry stack: {:?}", err)
     }

--- a/bolt-sidecar/bin/sidecar.rs
+++ b/bolt-sidecar/bin/sidecar.rs
@@ -10,10 +10,9 @@ async fn main() -> Result<()> {
         Err(err) => bail!("Failed to parse CLI arguments: {:?}", err),
     };
 
-    if config.use_metrics {
-        if let Err(err) = init_telemetry_stack(config.metrics_port) {
-            bail!("Failed to initialize telemetry stack: {:?}", err)
-        }
+    let metrics_port = if config.metrics { Some(config.metrics_port) } else { None };
+    if let Err(err) = init_telemetry_stack(metrics_port) {
+        bail!("Failed to initialize telemetry stack: {:?}", err)
     }
 
     info!(chain = config.chain.name(), "Starting Bolt sidecar");

--- a/bolt-sidecar/bin/sidecar.rs
+++ b/bolt-sidecar/bin/sidecar.rs
@@ -10,8 +10,10 @@ async fn main() -> Result<()> {
         Err(err) => bail!("Failed to parse CLI arguments: {:?}", err),
     };
 
-    if let Err(err) = init_telemetry_stack(config.metrics_port) {
-        bail!("Failed to initialize telemetry stack: {:?}", err)
+    if config.use_metrics {
+        if let Err(err) = init_telemetry_stack(config.metrics_port) {
+            bail!("Failed to initialize telemetry stack: {:?}", err)
+        }
     }
 
     info!(chain = config.chain.name(), "Starting Bolt sidecar");

--- a/bolt-sidecar/infra/grafana/provisioning/dashboards/dashboard.json
+++ b/bolt-sidecar/infra/grafana/provisioning/dashboards/dashboard.json
@@ -1,0 +1,836 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": 2,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 0
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "builder",
+          "expr": "bolt_sidecar_transactions_preconfirmed",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Transactions Preconfirmed",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 0
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "builder",
+          "expr": "bolt_sidecar_validation_errors",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Invalid Transactions Reasons",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 2,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "builder",
+          "expr": "bolt_sidecar_remote_blocks_proposed",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Remote Blocks Proposed",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 4,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "builder",
+          "expr": "bolt_sidecar_inclusion_commitments_received",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Inclusion Commitments Received",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": [
+          {
+            "__systemRef": "hideSeriesFrom",
+            "matcher": {
+              "id": "byNames",
+              "options": {
+                "mode": "exclude",
+                "names": [
+                  "{__name__=\"bolt_sidecar_local_blocks_proposed\", instance=\"172.16.0.25:9063\", job=\"mev-sidecar\"}"
+                ],
+                "prefix": "All except:",
+                "readOnly": true
+              }
+            },
+            "properties": [
+              {
+                "id": "custom.hideFrom",
+                "value": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": true
+                }
+              }
+            ]
+          }
+        ]
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 16
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "pluginVersion": "9.5.12",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "builder",
+          "exemplar": false,
+          "expr": "bolt_sidecar_local_blocks_proposed",
+          "instant": false,
+          "interval": "",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Local Blocks Proposed",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "stepAfter",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 16
+      },
+      "id": 5,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "builder",
+          "expr": "bolt_sidecar_inclusion_commitments_accepted",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Inclusion Commitments Accepted",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "custom": {
+            "axisCenteredZero": false,
+            "axisColorMode": "text",
+            "axisLabel": "",
+            "axisPlacement": "auto",
+            "barAlignment": 0,
+            "drawStyle": "line",
+            "fillOpacity": 0,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineInterpolation": "linear",
+            "lineWidth": 1,
+            "pointSize": 5,
+            "scaleDistribution": {
+              "type": "linear"
+            },
+            "showPoints": "auto",
+            "spanNulls": false,
+            "stacking": {
+              "group": "A",
+              "mode": "none"
+            },
+            "thresholdsStyle": {
+              "mode": "off"
+            }
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 24
+      },
+      "id": 6,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "builder",
+          "expr": "bolt_sidecar_http_requests_total",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Total HTTP Requests",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "custom": {
+            "fillOpacity": 80,
+            "gradientMode": "none",
+            "hideFrom": {
+              "legend": false,
+              "tooltip": false,
+              "viz": false
+            },
+            "lineWidth": 1
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "red",
+                "value": 80
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 24
+      },
+      "id": 7,
+      "options": {
+        "bucketOffset": 0,
+        "legend": {
+          "calcs": [],
+          "displayMode": "list",
+          "placement": "bottom",
+          "showLegend": true
+        }
+      },
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "builder",
+          "expr": "bolt_sidecar_http_requests_duration_seconds",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "HTTP Requests Durations in ms",
+      "type": "histogram"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "PBFA97CFB590B2093"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "mappings": [],
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              }
+            ]
+          }
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 5,
+        "w": 3,
+        "x": 0,
+        "y": 32
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": ["lastNotNull"],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "pluginVersion": "9.5.12",
+      "targets": [
+        {
+          "datasource": {
+            "type": "prometheus",
+            "uid": "PBFA97CFB590B2093"
+          },
+          "editorMode": "builder",
+          "expr": "bolt_sidecar_latest_head",
+          "legendFormat": "__auto",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Latest Head Slot",
+      "type": "stat"
+    }
+  ],
+  "refresh": "",
+  "schemaVersion": 38,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Bolt Sidecar",
+  "uid": "e5960f6d-a1ed-4538-9c7c-3ecba4d4b4b1",
+  "version": 3,
+  "weekStart": ""
+}

--- a/bolt-sidecar/infra/grafana/provisioning/dashboards/dashboard.yml
+++ b/bolt-sidecar/infra/grafana/provisioning/dashboards/dashboard.yml
@@ -1,0 +1,11 @@
+apiVersion: 1
+
+providers:
+  - name: "Dashboards"
+    orgId: 1
+    folder: ""
+    type: file
+    disableDeletion: false
+    editable: true
+    options:
+      path: /etc/grafana/provisioning/dashboards

--- a/bolt-sidecar/infra/grafana/provisioning/datasources/prometheus_ds.yml
+++ b/bolt-sidecar/infra/grafana/provisioning/datasources/prometheus_ds.yml
@@ -1,0 +1,6 @@
+datasources:
+  - name: Prometheus
+    access: proxy
+    type: prometheus
+    url: http://prometheus:9090
+    isDefault: true

--- a/bolt-sidecar/infra/prometheus.yml
+++ b/bolt-sidecar/infra/prometheus.yml
@@ -1,0 +1,8 @@
+global:
+  scrape_interval: 5s
+
+scrape_configs:
+  - job_name: "bolt-sidecar"
+    static_configs:
+      # docker host subnet IP
+      - targets: ["172.17.0.1:3300"]

--- a/bolt-sidecar/infra/telemetry.compose.yml
+++ b/bolt-sidecar/infra/telemetry.compose.yml
@@ -1,0 +1,26 @@
+services:
+  prometheus:
+    image: prom/prometheus
+    container_name: prometheus
+    user: root
+    volumes:
+      - "/prometheus_data"
+      - ./prometheus.yml:/etc/prometheus/prometheus.yml
+    command: [
+        "--config.file=/etc/prometheus/prometheus.yml",
+        # the flag that specifies where Prometheus stores its database
+        "--storage.tsdb.path=/prometheus_data",
+      ]
+
+  grafana:
+    container_name: grafana
+    image: grafana/grafana:latest
+    restart: unless-stopped
+    ports:
+      - "3000:3000"
+    volumes:
+      - "/var/lib/grafana"
+      - "./grafana/provisioning:/etc/grafana/provisioning"
+    environment:
+      - GF_SECURITY_ADMIN_USER=bolt
+      - GF_SECURITY_ADMIN_PASSWORD=bolt

--- a/bolt-sidecar/src/api/builder.rs
+++ b/bolt-sidecar/src/api/builder.rs
@@ -187,7 +187,7 @@ where
         if let Some(local_payload) = server.local_payload.lock().take() {
             check_locally_built_payload_integrity(&signed_blinded_block, &local_payload)?;
 
-            debug!("Valid local block found, returning: {local_payload:?}");
+            info!("Valid local block found, returning: {local_payload:?}");
             return Ok(Json(local_payload));
         }
 
@@ -204,7 +204,7 @@ where
                 e
             })?;
 
-        debug!(elapsed = ?start.elapsed(), "Returning payload");
+        info!(elapsed = ?start.elapsed(), "Returning payload from mev-boost");
 
         Ok(payload)
     }

--- a/bolt-sidecar/src/api/builder.rs
+++ b/bolt-sidecar/src/api/builder.rs
@@ -13,7 +13,6 @@ use ethereum_consensus::{
     primitives::{BlsPublicKey, Hash32},
     Fork,
 };
-use metrics::counter;
 use parking_lot::Mutex;
 use reqwest::Url;
 use serde::Deserialize;
@@ -29,7 +28,7 @@ use super::spec::{
 use crate::{
     client::mevboost::MevBoostClient,
     primitives::{GetPayloadResponse, PayloadFetcher, SignedBuilderBid},
-    telemetry::ApiMetricType,
+    telemetry::ApiMetrics,
 };
 
 const MAX_BLINDED_BLOCK_LENGTH: usize = 1024 * 1024;
@@ -190,7 +189,7 @@ where
             check_locally_built_payload_integrity(&signed_blinded_block, &local_payload)?;
 
             info!("Valid local block found, returning: {local_payload:?}");
-            counter!(ApiMetricType::LocalBlocksProposed.name()).increment(1);
+            ApiMetrics::increment_local_blocks_proposed();
 
             return Ok(Json(local_payload));
         }
@@ -209,7 +208,7 @@ where
             })?;
 
         info!(elapsed = ?start.elapsed(), "Returning payload from mev-boost");
-        counter!(ApiMetricType::RemoteBlocksProposed.name()).increment(1);
+        ApiMetrics::increment_remote_blocks_proposed();
 
         Ok(payload)
     }

--- a/bolt-sidecar/src/api/builder.rs
+++ b/bolt-sidecar/src/api/builder.rs
@@ -29,7 +29,7 @@ use super::spec::{
 use crate::{
     client::mevboost::MevBoostClient,
     primitives::{GetPayloadResponse, PayloadFetcher, SignedBuilderBid},
-    telemetry::BoltMetrics,
+    telemetry::ApiMetricType,
 };
 
 const MAX_BLINDED_BLOCK_LENGTH: usize = 1024 * 1024;
@@ -190,7 +190,7 @@ where
             check_locally_built_payload_integrity(&signed_blinded_block, &local_payload)?;
 
             info!("Valid local block found, returning: {local_payload:?}");
-            counter!(BoltMetrics::LocalBlocksProposed.name()).increment(1);
+            counter!(ApiMetricType::LocalBlocksProposed.name()).increment(1);
 
             return Ok(Json(local_payload));
         }
@@ -209,7 +209,7 @@ where
             })?;
 
         info!(elapsed = ?start.elapsed(), "Returning payload from mev-boost");
-        counter!(BoltMetrics::RemoteBlocksProposed.name()).increment(1);
+        counter!(ApiMetricType::RemoteBlocksProposed.name()).increment(1);
 
         Ok(payload)
     }

--- a/bolt-sidecar/src/api/commitments/handlers.rs
+++ b/bolt-sidecar/src/api/commitments/handlers.rs
@@ -1,39 +1,19 @@
-use std::{
-    collections::HashSet,
-    fmt,
-    future::Future,
-    net::{SocketAddr, ToSocketAddrs},
-    pin::Pin,
-    str::FromStr,
-    sync::Arc,
-};
+use std::sync::Arc;
 
-use alloy::primitives::{Address, Signature};
-use axum::{extract::State, http::HeaderMap, routing::post, Json, Router};
+use axum::{extract::State, http::HeaderMap, Json};
 use axum_extra::extract::WithRejection;
 use serde_json::Value;
-use tokio::{
-    net::TcpListener,
-    sync::{mpsc, oneshot},
-};
 use tracing::{debug, error, info, instrument};
 
 use crate::{
-    commitments::headers::auth_from_headers,
-    common::CARGO_PKG_VERSION,
-    primitives::{
-        commitment::{InclusionCommitment, SignedCommitment},
-        CommitmentRequest, InclusionRequest,
-    },
+    commitments::headers::auth_from_headers, common::CARGO_PKG_VERSION,
+    primitives::InclusionRequest,
 };
 
 use super::{
     jsonrpc::{JsonPayload, JsonResponse},
     server::CommitmentsApiInner,
-    spec::{
-        CommitmentsApi, Error, RejectionError, GET_VERSION_METHOD, REQUEST_INCLUSION_METHOD,
-        SIGNATURE_HEADER,
-    },
+    spec::{CommitmentsApi, Error, RejectionError, GET_VERSION_METHOD, REQUEST_INCLUSION_METHOD},
 };
 
 /// Handler function for the root JSON-RPC path.

--- a/bolt-sidecar/src/api/commitments/handlers.rs
+++ b/bolt-sidecar/src/api/commitments/handlers.rs
@@ -1,0 +1,107 @@
+use std::{
+    collections::HashSet,
+    fmt,
+    future::Future,
+    net::{SocketAddr, ToSocketAddrs},
+    pin::Pin,
+    str::FromStr,
+    sync::Arc,
+};
+
+use alloy::primitives::{Address, Signature};
+use axum::{extract::State, http::HeaderMap, routing::post, Json, Router};
+use axum_extra::extract::WithRejection;
+use serde_json::Value;
+use tokio::{
+    net::TcpListener,
+    sync::{mpsc, oneshot},
+};
+use tracing::{debug, error, info, instrument};
+
+use crate::{
+    commitments::headers::auth_from_headers,
+    common::CARGO_PKG_VERSION,
+    primitives::{
+        commitment::{InclusionCommitment, SignedCommitment},
+        CommitmentRequest, InclusionRequest,
+    },
+};
+
+use super::{
+    jsonrpc::{JsonPayload, JsonResponse},
+    server::CommitmentsApiInner,
+    spec::{
+        CommitmentsApi, Error, RejectionError, GET_VERSION_METHOD, REQUEST_INCLUSION_METHOD,
+        SIGNATURE_HEADER,
+    },
+};
+
+/// Handler function for the root JSON-RPC path.
+#[instrument(skip_all, name = "RPC", fields(method = %payload.method))]
+pub async fn rpc_entrypoint(
+    headers: HeaderMap,
+    State(api): State<Arc<CommitmentsApiInner>>,
+    WithRejection(Json(payload), _): WithRejection<Json<JsonPayload>, Error>,
+) -> Result<Json<JsonResponse>, Error> {
+    debug!("Received new request");
+
+    let (signer, signature) = auth_from_headers(&headers).inspect_err(|e| {
+        error!("Failed to extract signature from headers: {:?}", e);
+    })?;
+
+    match payload.method.as_str() {
+        GET_VERSION_METHOD => {
+            let version_string = format!("bolt-sidecar-v{CARGO_PKG_VERSION}");
+            Ok(Json(JsonResponse {
+                id: payload.id,
+                result: Value::String(version_string),
+                ..Default::default()
+            }))
+        }
+
+        REQUEST_INCLUSION_METHOD => {
+            let Some(request_json) = payload.params.first().cloned() else {
+                return Err(RejectionError::ValidationFailed("Bad params".to_string()).into());
+            };
+
+            // Parse the inclusion request from the parameters
+            let mut inclusion_request: InclusionRequest = serde_json::from_value(request_json)
+                .map_err(|e| RejectionError::ValidationFailed(e.to_string()))?;
+
+            // Set the signature here for later processing
+            inclusion_request.set_signature(signature);
+
+            let digest = inclusion_request.digest();
+            let recovered_signer = signature.recover_address_from_prehash(&digest)?;
+
+            if recovered_signer != signer {
+                error!(
+                    ?recovered_signer,
+                    ?signer,
+                    "Recovered signer does not match the provided signer"
+                );
+
+                return Err(Error::InvalidSignature(crate::primitives::SignatureError));
+            }
+
+            // Set the request signer
+            inclusion_request.set_signer(recovered_signer);
+
+            info!(signer = ?recovered_signer, %digest, "New valid inclusion request received");
+            let inclusion_commitment = api.request_inclusion(inclusion_request).await?;
+
+            // Create the JSON-RPC response
+            let response = JsonResponse {
+                id: payload.id,
+                result: serde_json::to_value(inclusion_commitment).unwrap(),
+                ..Default::default()
+            };
+
+            Ok(Json(response))
+        }
+        other => {
+            error!("Unknown method: {}", other);
+            Err(Error::UnknownMethod)
+        }
+    }
+}

--- a/bolt-sidecar/src/api/commitments/handlers.rs
+++ b/bolt-sidecar/src/api/commitments/handlers.rs
@@ -100,3 +100,9 @@ pub async fn not_found(req: Request<Body>) -> Html<&'static str> {
     error!(uri = ?req.uri(), "Route not found");
     Html("404 - Not Found")
 }
+
+/// Status handler
+#[instrument(skip_all, name = "GET /status")]
+pub async fn status() -> Html<&'static str> {
+    Html("OK")
+}

--- a/bolt-sidecar/src/api/commitments/handlers.rs
+++ b/bolt-sidecar/src/api/commitments/handlers.rs
@@ -1,6 +1,12 @@
 use std::sync::Arc;
 
-use axum::{extract::State, http::HeaderMap, Json};
+use axum::{
+    body::Body,
+    extract::State,
+    http::{HeaderMap, Request},
+    response::Html,
+    Json,
+};
 use axum_extra::extract::WithRejection;
 use serde_json::Value;
 use tracing::{debug, error, info, instrument};
@@ -17,7 +23,7 @@ use super::{
 };
 
 /// Handler function for the root JSON-RPC path.
-#[instrument(skip_all, name = "RPC", fields(method = %payload.method))]
+#[instrument(skip_all, name = "POST /rpc", fields(method = %payload.method))]
 pub async fn rpc_entrypoint(
     headers: HeaderMap,
     State(api): State<Arc<CommitmentsApiInner>>,
@@ -84,4 +90,13 @@ pub async fn rpc_entrypoint(
             Err(Error::UnknownMethod)
         }
     }
+}
+
+/// Not found fallback handler for all non-matched routes.
+///
+/// This handler returns a simple 404 page.
+#[instrument(skip_all, name = "not_found")]
+pub async fn not_found(req: Request<Body>) -> Html<&'static str> {
+    error!(uri = ?req.uri(), "Route not found");
+    Html("404 - Not Found")
 }

--- a/bolt-sidecar/src/api/commitments/headers.rs
+++ b/bolt-sidecar/src/api/commitments/headers.rs
@@ -1,36 +1,9 @@
-use std::{
-    collections::HashSet,
-    fmt,
-    future::Future,
-    net::{SocketAddr, ToSocketAddrs},
-    pin::Pin,
-    str::FromStr,
-    sync::Arc,
-};
+use std::str::FromStr;
 
 use alloy::primitives::{Address, Signature};
-use axum::{extract::State, http::HeaderMap, routing::post, Json, Router};
-use axum_extra::extract::WithRejection;
-use serde_json::Value;
-use tokio::{
-    net::TcpListener,
-    sync::{mpsc, oneshot},
-};
-use tracing::{debug, error, info, instrument};
+use axum::http::HeaderMap;
 
-use crate::{
-    commitments::handlers,
-    common::CARGO_PKG_VERSION,
-    primitives::{
-        commitment::{InclusionCommitment, SignedCommitment},
-        CommitmentRequest, InclusionRequest,
-    },
-};
-
-use super::{
-    jsonrpc::{JsonPayload, JsonResponse},
-    spec::{Error, SIGNATURE_HEADER},
-};
+use super::spec::{Error, SIGNATURE_HEADER};
 
 /// Extracts the signature ([SIGNATURE_HEADER]) from the HTTP headers.
 #[inline]

--- a/bolt-sidecar/src/api/commitments/headers.rs
+++ b/bolt-sidecar/src/api/commitments/headers.rs
@@ -1,0 +1,81 @@
+use std::{
+    collections::HashSet,
+    fmt,
+    future::Future,
+    net::{SocketAddr, ToSocketAddrs},
+    pin::Pin,
+    str::FromStr,
+    sync::Arc,
+};
+
+use alloy::primitives::{Address, Signature};
+use axum::{extract::State, http::HeaderMap, routing::post, Json, Router};
+use axum_extra::extract::WithRejection;
+use serde_json::Value;
+use tokio::{
+    net::TcpListener,
+    sync::{mpsc, oneshot},
+};
+use tracing::{debug, error, info, instrument};
+
+use crate::{
+    commitments::handlers,
+    common::CARGO_PKG_VERSION,
+    primitives::{
+        commitment::{InclusionCommitment, SignedCommitment},
+        CommitmentRequest, InclusionRequest,
+    },
+};
+
+use super::{
+    jsonrpc::{JsonPayload, JsonResponse},
+    spec::{Error, SIGNATURE_HEADER},
+};
+
+/// Extracts the signature ([SIGNATURE_HEADER]) from the HTTP headers.
+#[inline]
+pub fn auth_from_headers(headers: &HeaderMap) -> Result<(Address, Signature), Error> {
+    let auth = headers.get(SIGNATURE_HEADER).ok_or(Error::NoSignature)?;
+
+    // Remove the "0x" prefix
+    let auth = auth.to_str().map_err(|_| Error::MalformedHeader)?;
+
+    let mut split = auth.split(':');
+
+    let address = split.next().ok_or(Error::MalformedHeader)?;
+    let address = Address::from_str(address).map_err(|_| Error::MalformedHeader)?;
+
+    let sig = split.next().ok_or(Error::MalformedHeader)?;
+    let sig = Signature::from_str(sig)
+        .map_err(|_| Error::InvalidSignature(crate::primitives::SignatureError))?;
+
+    Ok((address, sig))
+}
+
+#[cfg(test)]
+mod test {
+    use alloy::{
+        primitives::TxHash,
+        signers::{local::PrivateKeySigner, Signer},
+    };
+
+    use crate::primitives::commitment::ECDSASignatureExt;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_signature_from_headers() {
+        let mut headers = HeaderMap::new();
+        let hash = TxHash::random();
+        let signer = PrivateKeySigner::random();
+        let addr = signer.address();
+
+        let expected_sig = signer.sign_hash(&hash).await.unwrap();
+        headers
+            .insert(SIGNATURE_HEADER, format!("{addr}:{}", expected_sig.to_hex()).parse().unwrap());
+
+        let (address, signature) = auth_from_headers(&headers).unwrap();
+        assert_eq!(signature, expected_sig);
+        assert_eq!(address, addr);
+    }
+}

--- a/bolt-sidecar/src/api/commitments/middleware.rs
+++ b/bolt-sidecar/src/api/commitments/middleware.rs
@@ -1,6 +1,5 @@
-use crate::telemetry::ApiMetricType;
+use crate::telemetry::ApiMetrics;
 use axum::{extract::Request, middleware::Next, response::IntoResponse};
-use metrics::{counter, histogram};
 use std::time::Instant;
 
 /// Middleware to track server metrics for each request.
@@ -10,13 +9,10 @@ pub async fn track_server_metrics(req: Request, next: Next) -> impl IntoResponse
 
     let start = Instant::now();
     let response = next.run(req).await;
-    let latency = start.elapsed().as_secs_f64();
+    let latency = start.elapsed();
     let status = response.status().as_u16().to_string();
 
-    let labels = [("method", method), ("path", path), ("status", status)];
-
-    counter!(ApiMetricType::HttpRequestsTotal.name(), &labels).increment(1);
-    histogram!(ApiMetricType::HttpRequestsDurationSeconds.name(), &labels).record(latency);
+    ApiMetrics::observe_http_request(latency, method, path, status);
 
     response
 }

--- a/bolt-sidecar/src/api/commitments/middleware.rs
+++ b/bolt-sidecar/src/api/commitments/middleware.rs
@@ -1,0 +1,22 @@
+use crate::telemetry::BoltMetrics;
+use axum::{extract::Request, middleware::Next, response::IntoResponse};
+use metrics::{counter, histogram};
+use std::time::Instant;
+
+/// Middleware to track server metrics for each request.
+pub async fn track_server_metrics(req: Request, next: Next) -> impl IntoResponse {
+    let path = req.uri().path().to_owned();
+    let method = req.method().to_string();
+
+    let start = Instant::now();
+    let response = next.run(req).await;
+    let latency = start.elapsed().as_secs_f64();
+    let status = response.status().as_u16().to_string();
+
+    let labels = [("method", method), ("path", path), ("status", status)];
+
+    counter!(BoltMetrics::HttpRequestsTotal.name(), &labels).increment(1);
+    histogram!(BoltMetrics::HttpRequestsDurationSeconds.name(), &labels).record(latency);
+
+    response
+}

--- a/bolt-sidecar/src/api/commitments/middleware.rs
+++ b/bolt-sidecar/src/api/commitments/middleware.rs
@@ -1,4 +1,4 @@
-use crate::telemetry::BoltMetrics;
+use crate::telemetry::ApiMetricType;
 use axum::{extract::Request, middleware::Next, response::IntoResponse};
 use metrics::{counter, histogram};
 use std::time::Instant;
@@ -15,8 +15,8 @@ pub async fn track_server_metrics(req: Request, next: Next) -> impl IntoResponse
 
     let labels = [("method", method), ("path", path), ("status", status)];
 
-    counter!(BoltMetrics::HttpRequestsTotal.name(), &labels).increment(1);
-    histogram!(BoltMetrics::HttpRequestsDurationSeconds.name(), &labels).record(latency);
+    counter!(ApiMetricType::HttpRequestsTotal.name(), &labels).increment(1);
+    histogram!(ApiMetricType::HttpRequestsDurationSeconds.name(), &labels).record(latency);
 
     response
 }

--- a/bolt-sidecar/src/api/commitments/mod.rs
+++ b/bolt-sidecar/src/api/commitments/mod.rs
@@ -1,3 +1,7 @@
+/// The commitments-API request handlers.
+mod handlers;
+/// The commitments-API headers and constants.
+mod headers;
 /// JSON-RPC helper types and functions.
 mod jsonrpc;
 /// The commitments-API JSON-RPC server implementation.

--- a/bolt-sidecar/src/api/commitments/mod.rs
+++ b/bolt-sidecar/src/api/commitments/mod.rs
@@ -4,6 +4,8 @@ mod handlers;
 mod headers;
 /// JSON-RPC helper types and functions.
 mod jsonrpc;
+/// The commitments-API middleware.
+mod middleware;
 /// The commitments-API JSON-RPC server implementation.
 pub mod server;
 /// The commitments-API specification and errors.

--- a/bolt-sidecar/src/api/commitments/server.rs
+++ b/bolt-sidecar/src/api/commitments/server.rs
@@ -8,7 +8,11 @@ use std::{
 };
 
 use alloy::primitives::Address;
-use axum::{middleware, routing::post, Router};
+use axum::{
+    middleware,
+    routing::{get, post},
+    Router,
+};
 use tokio::{
     net::TcpListener,
     sync::{mpsc, oneshot},
@@ -153,6 +157,7 @@ impl CommitmentsApiServer {
 fn make_router(state: Arc<CommitmentsApiInner>) -> Router {
     Router::new()
         .route("/", post(handlers::rpc_entrypoint))
+        .route("/status", get(handlers::status))
         .fallback(handlers::not_found)
         .layer(TimeoutLayer::new(spec::MAX_REQUEST_TIMEOUT))
         .route_layer(middleware::from_fn(track_server_metrics))

--- a/bolt-sidecar/src/api/commitments/server.rs
+++ b/bolt-sidecar/src/api/commitments/server.rs
@@ -4,36 +4,26 @@ use std::{
     future::Future,
     net::{SocketAddr, ToSocketAddrs},
     pin::Pin,
-    str::FromStr,
     sync::Arc,
 };
 
-use alloy::primitives::{Address, Signature};
-use axum::{extract::State, http::HeaderMap, routing::post, Json, Router};
-use axum_extra::extract::WithRejection;
-use serde_json::Value;
+use alloy::primitives::Address;
+use axum::{routing::post, Router};
 use tokio::{
     net::TcpListener,
     sync::{mpsc, oneshot},
 };
-use tracing::{debug, error, info, instrument};
+use tracing::{error, info};
 
 use crate::{
     commitments::handlers,
-    common::CARGO_PKG_VERSION,
     primitives::{
         commitment::{InclusionCommitment, SignedCommitment},
         CommitmentRequest, InclusionRequest,
     },
 };
 
-use super::{
-    jsonrpc::{JsonPayload, JsonResponse},
-    spec::{
-        CommitmentsApi, Error, RejectionError, GET_VERSION_METHOD, REQUEST_INCLUSION_METHOD,
-        SIGNATURE_HEADER,
-    },
-};
+use super::spec::{CommitmentsApi, Error};
 
 /// Event type emitted by the commitments API.
 #[derive(Debug)]
@@ -155,10 +145,9 @@ impl CommitmentsApiServer {
 
 #[cfg(test)]
 mod test {
-    use alloy::{
-        primitives::TxHash,
-        signers::{k256::SecretKey, local::PrivateKeySigner, Signer},
-    };
+    use crate::commitments::jsonrpc::JsonResponse;
+    use crate::commitments::spec::SIGNATURE_HEADER;
+    use alloy::signers::{k256::SecretKey, local::PrivateKeySigner};
     use serde_json::json;
 
     use crate::{

--- a/bolt-sidecar/src/api/commitments/server.rs
+++ b/bolt-sidecar/src/api/commitments/server.rs
@@ -19,6 +19,7 @@ use tokio::{
 use tracing::{debug, error, info, instrument};
 
 use crate::{
+    commitments::handlers,
     common::CARGO_PKG_VERSION,
     primitives::{
         commitment::{InclusionCommitment, SignedCommitment},
@@ -122,7 +123,7 @@ impl CommitmentsApiServer {
     pub async fn run(&mut self, events_tx: mpsc::Sender<Event>) {
         let api = Arc::new(CommitmentsApiInner::new(events_tx));
 
-        let router = Router::new().route("/", post(Self::handle_rpc)).with_state(api);
+        let router = Router::new().route("/", post(handlers::rpc_entrypoint)).with_state(api);
 
         let listener = match TcpListener::bind(self.addr).await {
             Ok(listener) => listener,
@@ -150,96 +151,6 @@ impl CommitmentsApiServer {
     pub fn local_addr(&self) -> SocketAddr {
         self.addr
     }
-
-    /// Handler function for the root JSON-RPC path.
-    #[instrument(skip_all, name = "RPC", fields(method = %payload.method))]
-    async fn handle_rpc(
-        headers: HeaderMap,
-        State(api): State<Arc<CommitmentsApiInner>>,
-        WithRejection(Json(payload), _): WithRejection<Json<JsonPayload>, Error>,
-    ) -> Result<Json<JsonResponse>, Error> {
-        debug!("Received new request");
-
-        let (signer, signature) = auth_from_headers(&headers).inspect_err(|e| {
-            error!("Failed to extract signature from headers: {:?}", e);
-        })?;
-
-        match payload.method.as_str() {
-            GET_VERSION_METHOD => {
-                let version_string = format!("bolt-sidecar-v{CARGO_PKG_VERSION}");
-                Ok(Json(JsonResponse {
-                    id: payload.id,
-                    result: Value::String(version_string),
-                    ..Default::default()
-                }))
-            }
-
-            REQUEST_INCLUSION_METHOD => {
-                let Some(request_json) = payload.params.first().cloned() else {
-                    return Err(RejectionError::ValidationFailed("Bad params".to_string()).into());
-                };
-
-                // Parse the inclusion request from the parameters
-                let mut inclusion_request: InclusionRequest = serde_json::from_value(request_json)
-                    .map_err(|e| RejectionError::ValidationFailed(e.to_string()))?;
-
-                // Set the signature here for later processing
-                inclusion_request.set_signature(signature);
-
-                let digest = inclusion_request.digest();
-                let recovered_signer = signature.recover_address_from_prehash(&digest)?;
-
-                if recovered_signer != signer {
-                    error!(
-                        ?recovered_signer,
-                        ?signer,
-                        "Recovered signer does not match the provided signer"
-                    );
-
-                    return Err(Error::InvalidSignature(crate::primitives::SignatureError));
-                }
-
-                // Set the request signer
-                inclusion_request.set_signer(recovered_signer);
-
-                info!(signer = ?recovered_signer, %digest, "New valid inclusion request received");
-                let inclusion_commitment = api.request_inclusion(inclusion_request).await?;
-
-                // Create the JSON-RPC response
-                let response = JsonResponse {
-                    id: payload.id,
-                    result: serde_json::to_value(inclusion_commitment).unwrap(),
-                    ..Default::default()
-                };
-
-                Ok(Json(response))
-            }
-            other => {
-                error!("Unknown method: {}", other);
-                Err(Error::UnknownMethod)
-            }
-        }
-    }
-}
-
-/// Extracts the signature ([SIGNATURE_HEADER]) from the HTTP headers.
-#[inline]
-fn auth_from_headers(headers: &HeaderMap) -> Result<(Address, Signature), Error> {
-    let auth = headers.get(SIGNATURE_HEADER).ok_or(Error::NoSignature)?;
-
-    // Remove the "0x" prefix
-    let auth = auth.to_str().map_err(|_| Error::MalformedHeader)?;
-
-    let mut split = auth.split(':');
-
-    let address = split.next().ok_or(Error::MalformedHeader)?;
-    let address = Address::from_str(address).map_err(|_| Error::MalformedHeader)?;
-
-    let sig = split.next().ok_or(Error::MalformedHeader)?;
-    let sig = Signature::from_str(sig)
-        .map_err(|_| Error::InvalidSignature(crate::primitives::SignatureError))?;
-
-    Ok((address, sig))
 }
 
 #[cfg(test)]
@@ -256,22 +167,6 @@ mod test {
     };
 
     use super::*;
-
-    #[tokio::test]
-    async fn test_signature_from_headers() {
-        let mut headers = HeaderMap::new();
-        let hash = TxHash::random();
-        let signer = PrivateKeySigner::random();
-        let addr = signer.address();
-
-        let expected_sig = signer.sign_hash(&hash).await.unwrap();
-        headers
-            .insert(SIGNATURE_HEADER, format!("{addr}:{}", expected_sig.to_hex()).parse().unwrap());
-
-        let (address, signature) = auth_from_headers(&headers).unwrap();
-        assert_eq!(signature, expected_sig);
-        assert_eq!(address, addr);
-    }
 
     #[tokio::test]
     async fn test_request_unauthorized() {

--- a/bolt-sidecar/src/api/commitments/spec.rs
+++ b/bolt-sidecar/src/api/commitments/spec.rs
@@ -15,6 +15,8 @@ pub(super) const GET_VERSION_METHOD: &str = "bolt_getVersion";
 
 pub(super) const REQUEST_INCLUSION_METHOD: &str = "bolt_requestInclusion";
 
+pub(super) const MAX_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(6);
+
 /// Error type for the commitments API.
 #[derive(Debug, Error)]
 pub enum Error {

--- a/bolt-sidecar/src/builder/payload_builder.rs
+++ b/bolt-sidecar/src/builder/payload_builder.rs
@@ -15,7 +15,7 @@ use reth_primitives::{
 };
 use reth_rpc_layer::{secret_to_bearer_header, JwtSecret};
 use serde_json::Value;
-use tracing::{debug, info, trace, warn};
+use tracing::{trace};
 
 use super::{
     compat::{to_alloy_execution_payload, to_reth_withdrawal},

--- a/bolt-sidecar/src/builder/payload_builder.rs
+++ b/bolt-sidecar/src/builder/payload_builder.rs
@@ -112,24 +112,24 @@ impl FallbackPayloadBuilder {
         // For the timestamp, we must use the one expected by the beacon chain instead, to
         // prevent edge cases where the proposer before us has missed their slot.
         let latest_block = self.execution_rpc_client.get_block(None, true).await?;
-        debug!(num = ?latest_block.header.number, "got latest block");
+        trace!(num = ?latest_block.header.number, "got latest block");
 
         let withdrawals = self.get_expected_withdrawals_at_head().await?;
-        debug!(amount = ?withdrawals.len(), "got expected withdrawals");
+        trace!(amount = ?withdrawals.len(), "got expected withdrawals");
 
         let prev_randao = self.get_prev_randao().await?;
-        debug!(randao = ?prev_randao, "got prev_randao");
+        trace!(randao = ?prev_randao, "got prev_randao");
 
         let parent_beacon_block_root =
             self.beacon_api_client.get_beacon_block_root(BlockId::Head).await?;
-        debug!(parent = ?parent_beacon_block_root, "got parent_beacon_block_root");
+        trace!(parent = ?parent_beacon_block_root, "got parent_beacon_block_root");
 
         let versioned_hashes = transactions
             .iter()
             .flat_map(|tx| tx.blob_versioned_hashes())
             .flatten()
             .collect::<Vec<_>>();
-        info!(amount = ?versioned_hashes.len(), "got versioned_hashes");
+        trace!(amount = ?versioned_hashes.len(), "got versioned_hashes");
 
         let base_fee = calc_next_block_base_fee(
             latest_block.header.gas_used,
@@ -189,11 +189,11 @@ impl FallbackPayloadBuilder {
                 .fetch_next_payload_hint(&exec_payload, &versioned_hashes, parent_beacon_block_root)
                 .await?;
 
-            debug!("engine_hint: {:?}", engine_hint);
+            trace!("engine_hint: {:?}", engine_hint);
 
             match engine_hint {
                 EngineApiHint::BlockHash(hash) => {
-                    warn!("Should not receive block hash hint {:?}", hash);
+                    trace!("Should not receive block hash hint {:?}", hash);
                     hints.block_hash = Some(hash)
                 }
 
@@ -454,9 +454,9 @@ mod tests {
         let raw_encoded = tx_signed.encoded_2718();
         let tx_signed_reth = TransactionSigned::decode_enveloped(&mut raw_encoded.as_slice())?;
 
-        let slot = genesis_time +
-            (SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs() / cfg.chain.slot_time()) +
-            1;
+        let slot = genesis_time
+            + (SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs() / cfg.chain.slot_time())
+            + 1;
 
         let block = builder.build_fallback_payload(slot, &[tx_signed_reth]).await?;
         assert_eq!(block.body.len(), 1);

--- a/bolt-sidecar/src/client/rpc.rs
+++ b/bolt-sidecar/src/client/rpc.rs
@@ -1,9 +1,7 @@
 //! This module contains the `RpcClient` struct, which is a wrapper around the `alloy_rpc_client`.
 //! It provides a simple interface to interact with the Execution layer JSON-RPC API.
 
-use futures::future::join_all;
 use std::{
-    collections::HashSet,
     ops::{Deref, DerefMut},
 };
 
@@ -11,13 +9,9 @@ use alloy::{
     eips::BlockNumberOrTag,
     primitives::{Address, Bytes, B256, U256, U64},
     rpc::{
-        client::{self as alloyClient, ClientBuilder, Waiter},
+        client::{self as alloyClient, ClientBuilder},
         types::{
-            trace::{
-                geth::{GethDebugTracingCallOptions, GethTrace},
-                parity::{TraceResults, TraceType},
-            },
-            Block, EIP1186AccountProofResponse, FeeHistory, TransactionRequest,
+            Block, FeeHistory,
         },
     },
     transports::{http::Http, TransportErrorKind, TransportResult},

--- a/bolt-sidecar/src/client/rpc.rs
+++ b/bolt-sidecar/src/client/rpc.rs
@@ -121,67 +121,6 @@ impl RpcClient {
         self.0.request("eth_getBlockByNumber", (tag, full)).await
     }
 
-    /// Returns the account and storage values of the specified account including the Merkle-proof.
-    /// If the block number is `None`, the latest block is used.
-    pub async fn get_proof(
-        &self,
-        address: Address,
-        storage_keys: Vec<B256>,
-        block_number: Option<u64>,
-    ) -> TransportResult<EIP1186AccountProofResponse> {
-        let tag = block_number.map_or(BlockNumberOrTag::Latest, BlockNumberOrTag::Number);
-        let params = (address, storage_keys, tag);
-
-        self.0.request("eth_getProof", params).await
-    }
-
-    /// Perform multiple `eth_getProof` calls in a single batch.
-    pub async fn get_proof_batched(
-        &self,
-        opts: Vec<(Address, Vec<B256>, BlockNumberOrTag)>,
-    ) -> TransportResult<Vec<EIP1186AccountProofResponse>> {
-        let mut batch = self.0.new_batch();
-
-        let mut proofs: Vec<Waiter<EIP1186AccountProofResponse>> = Vec::new();
-
-        for params in opts {
-            proofs.push(batch.add_call("eth_getProof", &params).expect("Correct parameters"));
-        }
-
-        batch.send().await?;
-
-        // Important: join_all will preserve the order of the proofs
-        join_all(proofs).await.into_iter().collect::<Result<Vec<_>, _>>()
-    }
-
-    /// Performs multiple call traces on top of the same block. i.e. transaction n will be executed
-    /// on top of a pending block with all n-1 transactions applied (traced) first.
-    ///
-    /// Note: Allows tracing dependent transactions, hence all transactions are traced in sequence
-    pub async fn trace_call_many(
-        &self,
-        calls: Vec<(TransactionRequest, HashSet<TraceType>)>,
-        block_number: Option<u64>,
-    ) -> TransportResult<Vec<TraceResults>> {
-        let tag = block_number.map_or(BlockNumberOrTag::Latest, BlockNumberOrTag::Number);
-        let params = (calls, tag);
-
-        self.0.request("trace_callMany", params).await
-    }
-
-    /// Performs the `debug_traceCall` JSON-RPC method.
-    pub async fn debug_trace_call(
-        &self,
-        tx: TransactionRequest,
-        block_number: Option<u64>,
-        opts: Option<GethDebugTracingCallOptions>,
-    ) -> TransportResult<GethTrace> {
-        let tag = block_number.map_or(BlockNumberOrTag::Latest, BlockNumberOrTag::Number);
-        let params = (tx, tag, opts);
-
-        self.0.request("debug_traceCall", params).await
-    }
-
     /// Send a raw transaction to the network.
     pub async fn send_raw_transaction(&self, raw: Bytes) -> TransportResult<B256> {
         self.0.request("eth_sendRawTransaction", [raw]).await

--- a/bolt-sidecar/src/config/mod.rs
+++ b/bolt-sidecar/src/config/mod.rs
@@ -6,7 +6,6 @@ use clap::Parser;
 use eyre::{bail, eyre, Report, Result};
 use reqwest::Url;
 use std::num::NonZero;
-use telemetry::TelemetryOpts;
 use tracing::info;
 
 use crate::crypto::bls::random_bls_secret;
@@ -21,6 +20,7 @@ pub mod signing;
 pub use signing::SigningOpts;
 
 pub mod telemetry;
+use telemetry::TelemetryOpts;
 
 /// Default port for the JSON-RPC server exposed by the sidecar.
 pub const DEFAULT_RPC_PORT: u16 = 8000;
@@ -123,7 +123,7 @@ pub struct Config {
     /// Metrics port
     pub metrics_port: u16,
     /// Toggle for metrics
-    pub use_metrics: bool,
+    pub metrics: bool,
 }
 
 impl Default for Config {
@@ -144,7 +144,7 @@ impl Default for Config {
             validator_indexes: ValidatorIndexes::default(),
             chain: ChainConfig::default(),
             metrics_port: 0,
-            use_metrics: true,
+            metrics: true,
         }
     }
 }
@@ -241,7 +241,7 @@ impl TryFrom<Opts> for Config {
 
         config.chain = opts.chain;
         config.metrics_port = opts.telemetry.metrics_port;
-        config.use_metrics = opts.telemetry.use_metrics;
+        config.metrics = opts.telemetry.metrics;
 
         Ok(config)
     }

--- a/bolt-sidecar/src/config/mod.rs
+++ b/bolt-sidecar/src/config/mod.rs
@@ -120,6 +120,8 @@ pub struct Config {
     pub builder_private_key: SecretKey,
     /// The chain on which the sidecar is running
     pub chain: ChainConfig,
+    /// Metrics port
+    pub metrics_port: u16,
 }
 
 impl Default for Config {
@@ -139,6 +141,7 @@ impl Default for Config {
             limits: Limits::default(),
             validator_indexes: ValidatorIndexes::default(),
             chain: ChainConfig::default(),
+            metrics_port: 0,
         }
     }
 }
@@ -234,6 +237,7 @@ impl TryFrom<Opts> for Config {
         config.validator_indexes = opts.validator_indexes;
 
         config.chain = opts.chain;
+        config.metrics_port = opts.telemetry.metrics_port;
 
         Ok(config)
     }

--- a/bolt-sidecar/src/config/mod.rs
+++ b/bolt-sidecar/src/config/mod.rs
@@ -6,6 +6,7 @@ use clap::Parser;
 use eyre::{bail, eyre, Report, Result};
 use reqwest::Url;
 use std::num::NonZero;
+use telemetry::TelemetryOpts;
 use tracing::info;
 
 use crate::crypto::bls::random_bls_secret;
@@ -18,6 +19,8 @@ pub use chain::ChainConfig;
 
 pub mod signing;
 pub use signing::SigningOpts;
+
+pub mod telemetry;
 
 /// Default port for the JSON-RPC server exposed by the sidecar.
 pub const DEFAULT_RPC_PORT: u16 = 8000;
@@ -78,6 +81,9 @@ pub struct Opts {
     /// Commitment signing options.
     #[clap(flatten)]
     pub(super) signing: SigningOpts,
+    /// Telemetry options
+    #[clap(flatten)]
+    pub(super) telemetry: TelemetryOpts,
 }
 
 /// Configuration options for the sidecar. These are parsed from

--- a/bolt-sidecar/src/config/mod.rs
+++ b/bolt-sidecar/src/config/mod.rs
@@ -122,6 +122,8 @@ pub struct Config {
     pub chain: ChainConfig,
     /// Metrics port
     pub metrics_port: u16,
+    /// Toggle for metrics
+    pub use_metrics: bool,
 }
 
 impl Default for Config {
@@ -142,6 +144,7 @@ impl Default for Config {
             validator_indexes: ValidatorIndexes::default(),
             chain: ChainConfig::default(),
             metrics_port: 0,
+            use_metrics: true,
         }
     }
 }
@@ -238,6 +241,7 @@ impl TryFrom<Opts> for Config {
 
         config.chain = opts.chain;
         config.metrics_port = opts.telemetry.metrics_port;
+        config.use_metrics = opts.telemetry.use_metrics;
 
         Ok(config)
     }

--- a/bolt-sidecar/src/config/mod.rs
+++ b/bolt-sidecar/src/config/mod.rs
@@ -123,7 +123,7 @@ pub struct Config {
     /// Metrics port
     pub metrics_port: u16,
     /// Toggle for metrics
-    pub metrics: bool,
+    pub disable_metrics: bool,
 }
 
 impl Default for Config {
@@ -144,7 +144,7 @@ impl Default for Config {
             validator_indexes: ValidatorIndexes::default(),
             chain: ChainConfig::default(),
             metrics_port: 0,
-            metrics: true,
+            disable_metrics: false,
         }
     }
 }
@@ -241,7 +241,7 @@ impl TryFrom<Opts> for Config {
 
         config.chain = opts.chain;
         config.metrics_port = opts.telemetry.metrics_port;
-        config.metrics = opts.telemetry.metrics;
+        config.disable_metrics = opts.telemetry.disable_metrics;
 
         Ok(config)
     }

--- a/bolt-sidecar/src/config/telemetry.rs
+++ b/bolt-sidecar/src/config/telemetry.rs
@@ -1,0 +1,8 @@
+use clap::Parser;
+
+#[derive(Parser, Debug, Clone)]
+pub struct TelemetryOpts {
+    /// The port on which to expose Prometheus metrics
+    #[clap(short, long, env = "METRICS_PORT", default_value_t = 3300)]
+    pub metrics_port: u16,
+}

--- a/bolt-sidecar/src/config/telemetry.rs
+++ b/bolt-sidecar/src/config/telemetry.rs
@@ -5,6 +5,6 @@ pub struct TelemetryOpts {
     /// The port on which to expose Prometheus metrics
     #[clap(short, long, env = "METRICS_PORT", default_value_t = 3300)]
     pub metrics_port: u16,
-    #[clap(short, long, env = "USE_METRICS", default_value_t = true)]
+    #[clap(short, long, env = "METRICS", default_value_t = true)]
     pub metrics: bool,
 }

--- a/bolt-sidecar/src/config/telemetry.rs
+++ b/bolt-sidecar/src/config/telemetry.rs
@@ -5,4 +5,6 @@ pub struct TelemetryOpts {
     /// The port on which to expose Prometheus metrics
     #[clap(short, long, env = "METRICS_PORT", default_value_t = 3300)]
     pub metrics_port: u16,
+    #[clap(short, long, env = "USE_METRICS", default_value_t = true)]
+    pub use_metrics: bool,
 }

--- a/bolt-sidecar/src/config/telemetry.rs
+++ b/bolt-sidecar/src/config/telemetry.rs
@@ -6,5 +6,5 @@ pub struct TelemetryOpts {
     #[clap(short, long, env = "METRICS_PORT", default_value_t = 3300)]
     pub metrics_port: u16,
     #[clap(short, long, env = "USE_METRICS", default_value_t = true)]
-    pub use_metrics: bool,
+    pub metrics: bool,
 }

--- a/bolt-sidecar/src/config/telemetry.rs
+++ b/bolt-sidecar/src/config/telemetry.rs
@@ -5,6 +5,6 @@ pub struct TelemetryOpts {
     /// The port on which to expose Prometheus metrics
     #[clap(short, long, env = "METRICS_PORT", default_value_t = 3300)]
     pub metrics_port: u16,
-    #[clap(short, long, env = "METRICS", default_value_t = true)]
-    pub metrics: bool,
+    #[clap(short, long, env = "DISABLE_METRICS", default_value_t = false)]
+    pub disable_metrics: bool,
 }

--- a/bolt-sidecar/src/driver.rs
+++ b/bolt-sidecar/src/driver.rs
@@ -11,7 +11,6 @@ use ethereum_consensus::{
     phase0::mainnet::SLOTS_PER_EPOCH,
 };
 use futures::StreamExt;
-use metrics::counter;
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
 
@@ -27,7 +26,6 @@ use crate::{
     },
     start_builder_proxy_server,
     state::{fetcher::StateFetcher, ConsensusState, ExecutionState, HeadTracker, StateClient},
-    telemetry::BoltMetrics,
     BuilderProxyConfig, Config, ConstraintsApi, LocalBuilder, MevBoostClient,
 };
 

--- a/bolt-sidecar/src/driver.rs
+++ b/bolt-sidecar/src/driver.rs
@@ -11,6 +11,7 @@ use ethereum_consensus::{
     phase0::mainnet::SLOTS_PER_EPOCH,
 };
 use futures::StreamExt;
+use metrics::counter;
 use tokio::sync::mpsc;
 use tracing::{debug, error, info, warn};
 
@@ -26,6 +27,7 @@ use crate::{
     },
     start_builder_proxy_server,
     state::{fetcher::StateFetcher, ConsensusState, ExecutionState, HeadTracker, StateClient},
+    telemetry::BoltMetrics,
     BuilderProxyConfig, Config, ConstraintsApi, LocalBuilder, MevBoostClient,
 };
 

--- a/bolt-sidecar/src/lib.rs
+++ b/bolt-sidecar/src/lib.rs
@@ -14,6 +14,9 @@ pub use api::{
 mod client;
 pub use client::{mevboost::MevBoostClient, rpc::RpcClient, BeaconClient};
 
+/// Telemetry and metrics utilities
+pub mod telemetry;
+
 /// Common types and compatibility utilities
 /// (To be refactored)
 mod common;

--- a/bolt-sidecar/src/primitives/mod.rs
+++ b/bolt-sidecar/src/primitives/mod.rs
@@ -333,10 +333,20 @@ impl TransactionExt for PooledTransactionsElement {
     }
 }
 
+pub const fn tx_type_str(tx_type: TxType) -> &'static str {
+    match tx_type {
+        TxType::Legacy => "legacy",
+        TxType::Eip2930 => "eip2930",
+        TxType::Eip1559 => "eip1559",
+        TxType::Eip4844 => "eip4844",
+        TxType::Eip7702 => "eip7702",
+    }
+}
+
 /// A wrapper type for a full, complete transaction (i.e. with blob sidecars attached).
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FullTransaction {
-    tx: PooledTransactionsElement,
+    pub tx: PooledTransactionsElement,
     sender: Option<Address>,
 }
 

--- a/bolt-sidecar/src/state/consensus.rs
+++ b/bolt-sidecar/src/state/consensus.rs
@@ -5,14 +5,13 @@ use std::{
 
 use beacon_api_client::{mainnet::Client, ProposerDuty};
 use ethereum_consensus::phase0::mainnet::SLOTS_PER_EPOCH;
-use metrics::gauge;
 use tracing::debug;
 
 use super::CommitmentDeadline;
 use crate::{
     config::ValidatorIndexes,
     primitives::{CommitmentRequest, Slot},
-    telemetry::ApiMetricType,
+    telemetry::ApiMetrics,
     BeaconClient,
 };
 
@@ -119,7 +118,7 @@ impl ConsensusState {
     /// Update the latest head and fetch the relevant data from the beacon chain.
     pub async fn update_slot(&mut self, slot: u64) -> Result<(), ConsensusError> {
         debug!("Updating slot to {slot}");
-        gauge!(ApiMetricType::LatestHead.name()).set(slot as u32);
+        ApiMetrics::set_latest_head(slot as u32);
 
         // Reset the commitment deadline to start counting for the next slot.
         self.commitment_deadline =

--- a/bolt-sidecar/src/state/consensus.rs
+++ b/bolt-sidecar/src/state/consensus.rs
@@ -5,12 +5,14 @@ use std::{
 
 use beacon_api_client::{mainnet::Client, ProposerDuty};
 use ethereum_consensus::phase0::mainnet::SLOTS_PER_EPOCH;
+use metrics::gauge;
 use tracing::debug;
 
 use super::CommitmentDeadline;
 use crate::{
     config::ValidatorIndexes,
     primitives::{CommitmentRequest, Slot},
+    telemetry::BoltMetrics,
     BeaconClient,
 };
 
@@ -117,6 +119,8 @@ impl ConsensusState {
     /// Update the latest head and fetch the relevant data from the beacon chain.
     pub async fn update_slot(&mut self, slot: u64) -> Result<(), ConsensusError> {
         debug!("Updating slot to {slot}");
+        gauge!(BoltMetrics::LatestHead.name()).set(slot as u32);
+
         // Reset the commitment deadline to start counting for the next slot.
         self.commitment_deadline =
             CommitmentDeadline::new(slot + 1, self.commitment_deadline_duration);

--- a/bolt-sidecar/src/state/consensus.rs
+++ b/bolt-sidecar/src/state/consensus.rs
@@ -12,7 +12,7 @@ use super::CommitmentDeadline;
 use crate::{
     config::ValidatorIndexes,
     primitives::{CommitmentRequest, Slot},
-    telemetry::BoltMetrics,
+    telemetry::ApiMetricType,
     BeaconClient,
 };
 
@@ -119,7 +119,7 @@ impl ConsensusState {
     /// Update the latest head and fetch the relevant data from the beacon chain.
     pub async fn update_slot(&mut self, slot: u64) -> Result<(), ConsensusError> {
         debug!("Updating slot to {slot}");
-        gauge!(BoltMetrics::LatestHead.name()).set(slot as u32);
+        gauge!(ApiMetricType::LatestHead.name()).set(slot as u32);
 
         // Reset the commitment deadline to start counting for the next slot.
         self.commitment_deadline =

--- a/bolt-sidecar/src/state/execution.rs
+++ b/bolt-sidecar/src/state/execution.rs
@@ -20,6 +20,9 @@ use crate::{
 use super::fetcher::StateFetcher;
 
 /// Possible commitment validation errors.
+///
+/// NOTE: unfortuntately it cannot implement `Clone` due to `BlobTransactionValidationError`
+/// not implementing it
 #[derive(Debug, Error)]
 pub enum ValidationError {
     /// The transaction fee is too low to cover the maximum base fee.

--- a/bolt-sidecar/src/state/execution.rs
+++ b/bolt-sidecar/src/state/execution.rs
@@ -86,6 +86,35 @@ impl ValidationError {
     pub fn is_internal(&self) -> bool {
         matches!(self, Self::Internal(_))
     }
+
+    /// Returns the tag of the enum as a string, mainly for metrics purposes
+    pub const fn to_tag_str(&self) -> &'static str {
+        match self {
+            ValidationError::BaseFeeTooLow(_) => "base_fee_too_low",
+            ValidationError::BlobBaseFeeTooLow(_) => "blob_base_fee_too_low",
+            ValidationError::BlobValidation(_) => "blob_validation",
+            ValidationError::MaxBaseFeeCalcOverflow => "max_base_fee_calc_overflow",
+            ValidationError::NonceTooLow(_, _) => "nonce_too_low",
+            ValidationError::NonceTooHigh(_, _) => "nonce_too_high",
+            ValidationError::AccountHasCode => "account_has_code",
+            ValidationError::GasLimitTooHigh => "gas_limit_too_high",
+            ValidationError::TransactionSizeTooHigh => "transaction_size_too_high",
+            ValidationError::MaxPriorityFeePerGasTooHigh => "max_priority_fee_per_gas_too_high",
+            ValidationError::InsufficientBalance => "insufficient_balance",
+            ValidationError::Eip4844Limit => "eip4844_limit",
+            ValidationError::SlotTooLow(_) => "slot_too_low",
+            ValidationError::MaxCommitmentsReachedForSlot(_, _) => {
+                "max_commitments_reached_for_slot"
+            }
+            ValidationError::MaxCommittedGasReachedForSlot(_, _) => {
+                "max_committed_gas_reached_for_slot"
+            }
+            ValidationError::Signature(_) => "signature",
+            ValidationError::RecoverSigner => "recover_signer",
+            ValidationError::ChainIdMismatch => "chain_id_mismatch",
+            ValidationError::Internal(_) => "internal",
+        }
+    }
 }
 
 /// The minimal state of the execution layer at some block number (`head`).
@@ -267,6 +296,8 @@ impl<C: StateFetcher> ExecutionState<C> {
             debug!(%target_slot, %self.slot, "Target slot lower than current slot");
             return Err(ValidationError::SlotTooLow(self.slot));
         }
+
+        let mut tx_type_to_amount: HashMap<u8, u64> = HashMap::new();
 
         // Validate each transaction in the request against the account state,
         // keeping track of the nonce and balance diffs, including:

--- a/bolt-sidecar/src/state/execution.rs
+++ b/bolt-sidecar/src/state/execution.rs
@@ -297,8 +297,6 @@ impl<C: StateFetcher> ExecutionState<C> {
             return Err(ValidationError::SlotTooLow(self.slot));
         }
 
-        let mut tx_type_to_amount: HashMap<u8, u64> = HashMap::new();
-
         // Validate each transaction in the request against the account state,
         // keeping track of the nonce and balance diffs, including:
         // - any existing state in the account trie

--- a/bolt-sidecar/src/telemetry/metrics.rs
+++ b/bolt-sidecar/src/telemetry/metrics.rs
@@ -5,55 +5,94 @@ use reth_primitives::TxType;
 
 use crate::primitives::tx_type_str;
 
+//  Counters ----------------------------------------------------------------
+/// Counter for the total number of HTTP requests received.
+const HTTP_REQUESTS_TOTAL: &str = "bolt_sidecar_http_requests_total";
+/// Counter for the number of local blocks proposed.
+const LOCAL_BLOCKS_PROPOSED: &str = "bolt_sidecar_local_blocks_proposed";
+/// Counter for the number of remote blocks proposed.
+const REMOTE_BLOCKS_PROPOSED: &str = "bolt_sidecar_remote_blocks_proposed";
+/// Counter for the number of inclusion commitments received.
+const INCLUSION_COMMITMENTS_RECEIVED: &str = "bolt_sidecar_inclusion_commitments_received";
+/// Counter for the number of inclusion commitments accepted.
+const INCLUSION_COMMITMENTS_ACCEPTED: &str = "bolt_sidecar_inclusion_commitments_accepted";
+/// Counter for the number of transactions preconfirmed
+const TRANSACTIONS_PRECONFIRMED: &str = "bolt_sidecar_transactions_preconfirmed";
+/// Counter for the number of validation errors; to spot most the most common ones
+const VALIDATION_ERRORS: &str = "bolt_sidecar_validation_errors";
+
+//  Gauges ------------------------------------------------------------------
+/// Gauge for the latest slot number
+const LATEST_HEAD: &str = "bolt_sidecar_latest_head";
+
+//  Histograms --------------------------------------------------------------
+/// Histogram for the total duration of HTTP requests in seconds.
+const HTTP_REQUESTS_DURATION_SECONDS: &str = "bolt_sidecar_http_requests_duration_seconds";
+
 /// Metrics for the commitments API.
 #[derive(Debug, Clone, Copy)]
 pub struct ApiMetrics;
 
 #[allow(missing_docs)]
 impl ApiMetrics {
-    pub fn start() {
-        ApiMetricType::describe_all();
+    pub fn describe_all() {
+        // Counters
+        describe_counter!(HTTP_REQUESTS_TOTAL, "Total number of HTTP requests received");
+        describe_counter!(LOCAL_BLOCKS_PROPOSED, "Local blocks proposed");
+        describe_counter!(REMOTE_BLOCKS_PROPOSED, "Remote blocks proposed");
+        describe_counter!(INCLUSION_COMMITMENTS_ACCEPTED, "Inclusion commitments");
+        describe_counter!(INCLUSION_COMMITMENTS_ACCEPTED, "Inclusion commitments accepted");
+        describe_counter!(TRANSACTIONS_PRECONFIRMED, "Transactions preconfirmed");
+        describe_counter!(VALIDATION_ERRORS, "Validation errors");
+
+        // Gauges
+        describe_gauge!(LATEST_HEAD, "Latest slot number");
+
+        // Histograms
+        describe_histogram!(
+            HTTP_REQUESTS_DURATION_SECONDS,
+            "Total duration of HTTP requests in seconds"
+        );
     }
 
     /// Counters ----------------------------------------------------------------
 
     pub fn increment_total_http_requests(method: String, path: String, status: String) {
         counter!(
-            ApiMetricType::HttpRequestsTotal.name(),
+            HTTP_REQUESTS_DURATION_SECONDS,
             &[("method", method), ("path", path), ("status", status)]
         )
         .increment(1);
     }
 
     pub fn increment_local_blocks_proposed() {
-        counter!(ApiMetricType::LocalBlocksProposed.name()).increment(1);
+        counter!(LOCAL_BLOCKS_PROPOSED).increment(1);
     }
 
     pub fn increment_remote_blocks_proposed() {
-        counter!(ApiMetricType::RemoteBlocksProposed.name()).increment(1);
+        counter!(REMOTE_BLOCKS_PROPOSED).increment(1);
     }
 
     pub fn increment_inclusion_commitments_received() {
-        counter!(ApiMetricType::InclusionCommitmentsReceived.name()).increment(1);
+        counter!(INCLUSION_COMMITMENTS_RECEIVED).increment(1);
     }
 
     pub fn increment_inclusion_commitments_accepted() {
-        counter!(ApiMetricType::InclusionCommitmentsAccepted.name()).increment(1);
+        counter!(INCLUSION_COMMITMENTS_ACCEPTED).increment(1);
     }
 
     pub fn increment_transactions_preconfirmed(tx_type: TxType) {
-        counter!(ApiMetricType::TransactionsPreconfirmed.name(), &[("type", tx_type_str(tx_type))])
-            .increment(1);
+        counter!(TRANSACTIONS_PRECONFIRMED, &[("type", tx_type_str(tx_type))]).increment(1);
     }
 
     pub fn increment_validation_errors(err_type: String) {
-        counter!(ApiMetricType::ValidationErrors.name(), &[("type", err_type)]).increment(1);
+        counter!(VALIDATION_ERRORS, &[("type", err_type)]).increment(1);
     }
 
     /// Gauges ----------------------------------------------------------------
 
     pub fn set_latest_head(slot: u32) {
-        gauge!(ApiMetricType::LatestHead.name()).set(slot);
+        gauge!(LATEST_HEAD).set(slot);
     }
 
     /// Mixed ----------------------------------------------------------------
@@ -62,92 +101,7 @@ impl ApiMetrics {
     /// and incrementing the total number of HTTP requests received.
     pub fn observe_http_request(duration: Duration, method: String, path: String, status: String) {
         let labels = [("method", method), ("path", path), ("status", status)];
-        counter!(ApiMetricType::HttpRequestsTotal.name(), &labels).increment(1);
-        histogram!(ApiMetricType::HttpRequestsDurationSeconds.name(), &labels,)
-            .record(duration.as_secs_f64());
-    }
-}
-
-/// Prometheus metrics for the Bolt Sidecar.
-#[derive(Debug, Clone, Copy)]
-enum ApiMetricType {
-    //  Counters ----------------------------------------------------------------
-    /// Counter for the total number of HTTP requests received.
-    HttpRequestsTotal,
-    /// Counter for the number of local blocks proposed.
-    LocalBlocksProposed,
-    /// Counter for the number of remote blocks proposed.
-    RemoteBlocksProposed,
-    /// Counter for the number of inclusion commitments received.
-    InclusionCommitmentsReceived,
-    /// Counter for the number of inclusion commitments accepted.
-    InclusionCommitmentsAccepted,
-    /// Counter for the number of transactions preconfirmed
-    TransactionsPreconfirmed,
-    /// Counter for the number of validation errors, to spot most the most common ones
-    ValidationErrors,
-
-    //  Gauges ------------------------------------------------------------------
-    /// Gauge for the latest slot number
-    LatestHead,
-
-    //  Histograms --------------------------------------------------------------
-    /// Histogram for the total duration of HTTP requests in seconds.
-    HttpRequestsDurationSeconds,
-}
-
-impl ApiMetricType {
-    /// Returns the name of the metric.
-    const fn name(&self) -> &'static str {
-        match self {
-            ApiMetricType::LocalBlocksProposed => "bolt_sidecar_local_blocks_proposed",
-            ApiMetricType::RemoteBlocksProposed => "bolt_sidecar_remote_blocks_proposed",
-            ApiMetricType::InclusionCommitmentsReceived => {
-                "bolt_sidecar_inclusion_commitments_received"
-            }
-            ApiMetricType::InclusionCommitmentsAccepted => {
-                "bolt_sidecar_inclusion_commitments_accepted"
-            }
-            ApiMetricType::HttpRequestsTotal => "bolt_sidecar_http_requests_total",
-            ApiMetricType::LatestHead => "bolt_sidecar_latest_head",
-            ApiMetricType::HttpRequestsDurationSeconds => {
-                "bolt_sidecar_http_requests_duration_seconds"
-            }
-            ApiMetricType::TransactionsPreconfirmed => "bolt_sidecar_transactions_preconfirmed",
-            ApiMetricType::ValidationErrors => "bolt_sidecar_validation_errors",
-        }
-    }
-
-    /// Describes all metrics with a help string.
-    fn describe_all() {
-        // Counters
-        describe_counter!(
-            ApiMetricType::HttpRequestsTotal.name(),
-            "Total number of HTTP requests received"
-        );
-        describe_counter!(ApiMetricType::LocalBlocksProposed.name(), "Local blocks proposed");
-        describe_counter!(ApiMetricType::RemoteBlocksProposed.name(), "Remote blocks proposed");
-        describe_counter!(
-            ApiMetricType::InclusionCommitmentsReceived.name(),
-            "Inclusion commitments"
-        );
-        describe_counter!(
-            ApiMetricType::InclusionCommitmentsAccepted.name(),
-            "Inclusion commitments accepted"
-        );
-        describe_counter!(
-            ApiMetricType::TransactionsPreconfirmed.name(),
-            "Transactions preconfirmed"
-        );
-        describe_counter!(ApiMetricType::ValidationErrors.name(), "Validation errors");
-
-        // Gauges
-        describe_gauge!(ApiMetricType::LatestHead.name(), "Latest slot number");
-
-        // Histograms
-        describe_histogram!(
-            ApiMetricType::HttpRequestsDurationSeconds.name(),
-            "Total duration of HTTP requests in seconds"
-        );
+        counter!(HTTP_REQUESTS_TOTAL, &labels).increment(1);
+        histogram!(HTTP_REQUESTS_DURATION_SECONDS, &labels,).record(duration.as_secs_f64());
     }
 }

--- a/bolt-sidecar/src/telemetry/metrics.rs
+++ b/bolt-sidecar/src/telemetry/metrics.rs
@@ -6,6 +6,14 @@ pub enum BoltMetrics {
     //  Counters ----------------------------------------------------------------
     /// Counter for the total number of HTTP requests received.
     HttpRequestsTotal,
+    /// Counter for the number of local blocks proposed.
+    LocalBlocksProposed,
+    /// Counter for the number of remote blocks proposed.
+    RemoteBlocksProposed,
+    /// Counter for the number of inclusion commitments received.
+    InclusionCommitmentsReceived,
+    /// Counter for the number of inclusion commitments accepted.
+    InclusionCommitmentsAccepted,
 
     //  Gauges ------------------------------------------------------------------
     /// Gauge for the latest slot number
@@ -18,8 +26,12 @@ pub enum BoltMetrics {
 
 impl BoltMetrics {
     /// Returns the name of the metric.
-    pub fn name(&self) -> &str {
+    pub const fn name(&self) -> &'static str {
         match self {
+            BoltMetrics::LocalBlocksProposed => "local_blocks_proposed",
+            BoltMetrics::RemoteBlocksProposed => "remote_blocks_proposed",
+            BoltMetrics::InclusionCommitmentsReceived => "inclusion_commitments",
+            BoltMetrics::InclusionCommitmentsAccepted => "inclusion_commitments_accepted",
             BoltMetrics::HttpRequestsTotal => "http_requests_total",
             BoltMetrics::LatestHead => "latest_head",
             BoltMetrics::HttpRequestsDurationSeconds => "http_requests_duration_seconds",
@@ -32,6 +44,16 @@ impl BoltMetrics {
         describe_counter!(
             BoltMetrics::HttpRequestsTotal.name(),
             "Total number of HTTP requests received"
+        );
+        describe_counter!(BoltMetrics::LocalBlocksProposed.name(), "Local blocks proposed");
+        describe_counter!(BoltMetrics::RemoteBlocksProposed.name(), "Remote blocks proposed");
+        describe_counter!(
+            BoltMetrics::InclusionCommitmentsReceived.name(),
+            "Inclusion commitments"
+        );
+        describe_counter!(
+            BoltMetrics::InclusionCommitmentsAccepted.name(),
+            "Inclusion commitments accepted"
         );
 
         // Gauges

--- a/bolt-sidecar/src/telemetry/metrics.rs
+++ b/bolt-sidecar/src/telemetry/metrics.rs
@@ -70,7 +70,7 @@ impl ApiMetrics {
 
 /// Prometheus metrics for the Bolt Sidecar.
 #[derive(Debug, Clone, Copy)]
-pub enum ApiMetricType {
+enum ApiMetricType {
     //  Counters ----------------------------------------------------------------
     /// Counter for the total number of HTTP requests received.
     HttpRequestsTotal,

--- a/bolt-sidecar/src/telemetry/metrics.rs
+++ b/bolt-sidecar/src/telemetry/metrics.rs
@@ -1,0 +1,46 @@
+use metrics::{describe_counter, describe_gauge, describe_histogram};
+
+/// Prometheus metrics for the Bolt Sidecar.
+#[derive(Debug, Clone, Copy)]
+pub enum BoltMetrics {
+    //  Counters ----------------------------------------------------------------
+    /// Counter for the total number of HTTP requests received.
+    HttpRequestsTotal,
+
+    //  Gauges ------------------------------------------------------------------
+    /// Gauge for the latest slot number
+    LatestHead,
+
+    //  Histograms --------------------------------------------------------------
+    /// Histogram for the total duration of HTTP requests in seconds.
+    HttpRequestsDurationSeconds,
+}
+
+impl BoltMetrics {
+    /// Returns the name of the metric.
+    pub fn name(&self) -> &str {
+        match self {
+            BoltMetrics::HttpRequestsTotal => "http_requests_total",
+            BoltMetrics::LatestHead => "latest_head",
+            BoltMetrics::HttpRequestsDurationSeconds => "http_requests_duration_seconds",
+        }
+    }
+
+    /// Describes all metrics with a help string.
+    pub fn describe_all() {
+        // Counters
+        describe_counter!(
+            BoltMetrics::HttpRequestsTotal.name(),
+            "Total number of HTTP requests received"
+        );
+
+        // Gauges
+        describe_gauge!(BoltMetrics::LatestHead.name(), "Latest slot number");
+
+        // Histograms
+        describe_histogram!(
+            BoltMetrics::HttpRequestsDurationSeconds.name(),
+            "Total duration of HTTP requests in seconds"
+        );
+    }
+}

--- a/bolt-sidecar/src/telemetry/metrics.rs
+++ b/bolt-sidecar/src/telemetry/metrics.rs
@@ -30,7 +30,7 @@ impl BoltMetrics {
         match self {
             BoltMetrics::LocalBlocksProposed => "local_blocks_proposed",
             BoltMetrics::RemoteBlocksProposed => "remote_blocks_proposed",
-            BoltMetrics::InclusionCommitmentsReceived => "inclusion_commitments",
+            BoltMetrics::InclusionCommitmentsReceived => "inclusion_commitments_received",
             BoltMetrics::InclusionCommitmentsAccepted => "inclusion_commitments_accepted",
             BoltMetrics::HttpRequestsTotal => "http_requests_total",
             BoltMetrics::LatestHead => "latest_head",

--- a/bolt-sidecar/src/telemetry/metrics.rs
+++ b/bolt-sidecar/src/telemetry/metrics.rs
@@ -1,8 +1,17 @@
 use metrics::{describe_counter, describe_gauge, describe_histogram};
 
+#[derive(Debug, Clone, Copy)]
+pub struct ApiMetrics;
+
+impl ApiMetrics {
+    pub fn start() {
+        ApiMetricType::describe_all();
+    }
+}
+
 /// Prometheus metrics for the Bolt Sidecar.
 #[derive(Debug, Clone, Copy)]
-pub enum BoltMetrics {
+pub enum ApiMetricType {
     //  Counters ----------------------------------------------------------------
     /// Counter for the total number of HTTP requests received.
     HttpRequestsTotal,
@@ -28,57 +37,57 @@ pub enum BoltMetrics {
     HttpRequestsDurationSeconds,
 }
 
-impl BoltMetrics {
+impl ApiMetricType {
     /// Returns the name of the metric.
     pub const fn name(&self) -> &'static str {
         match self {
-            BoltMetrics::LocalBlocksProposed => "bolt_sidecar_local_blocks_proposed",
-            BoltMetrics::RemoteBlocksProposed => "bolt_sidecar_remote_blocks_proposed",
-            BoltMetrics::InclusionCommitmentsReceived => {
+            ApiMetricType::LocalBlocksProposed => "bolt_sidecar_local_blocks_proposed",
+            ApiMetricType::RemoteBlocksProposed => "bolt_sidecar_remote_blocks_proposed",
+            ApiMetricType::InclusionCommitmentsReceived => {
                 "bolt_sidecar_inclusion_commitments_received"
             }
-            BoltMetrics::InclusionCommitmentsAccepted => {
+            ApiMetricType::InclusionCommitmentsAccepted => {
                 "bolt_sidecar_inclusion_commitments_accepted"
             }
-            BoltMetrics::HttpRequestsTotal => "bolt_sidecar_http_requests_total",
-            BoltMetrics::LatestHead => "bolt_sidecar_latest_head",
-            BoltMetrics::HttpRequestsDurationSeconds => {
+            ApiMetricType::HttpRequestsTotal => "bolt_sidecar_http_requests_total",
+            ApiMetricType::LatestHead => "bolt_sidecar_latest_head",
+            ApiMetricType::HttpRequestsDurationSeconds => {
                 "bolt_sidecar_http_requests_duration_seconds"
             }
-            BoltMetrics::TransactionsPreconfirmed => "bolt_sidecar_transactions_preconfirmed",
-            BoltMetrics::ValidationErrors => "bolt_sidecar_validation_errors",
+            ApiMetricType::TransactionsPreconfirmed => "bolt_sidecar_transactions_preconfirmed",
+            ApiMetricType::ValidationErrors => "bolt_sidecar_validation_errors",
         }
     }
 
     /// Describes all metrics with a help string.
-    pub fn describe_all() {
+    fn describe_all() {
         // Counters
         describe_counter!(
-            BoltMetrics::HttpRequestsTotal.name(),
+            ApiMetricType::HttpRequestsTotal.name(),
             "Total number of HTTP requests received"
         );
-        describe_counter!(BoltMetrics::LocalBlocksProposed.name(), "Local blocks proposed");
-        describe_counter!(BoltMetrics::RemoteBlocksProposed.name(), "Remote blocks proposed");
+        describe_counter!(ApiMetricType::LocalBlocksProposed.name(), "Local blocks proposed");
+        describe_counter!(ApiMetricType::RemoteBlocksProposed.name(), "Remote blocks proposed");
         describe_counter!(
-            BoltMetrics::InclusionCommitmentsReceived.name(),
+            ApiMetricType::InclusionCommitmentsReceived.name(),
             "Inclusion commitments"
         );
         describe_counter!(
-            BoltMetrics::InclusionCommitmentsAccepted.name(),
+            ApiMetricType::InclusionCommitmentsAccepted.name(),
             "Inclusion commitments accepted"
         );
         describe_counter!(
-            BoltMetrics::TransactionsPreconfirmed.name(),
+            ApiMetricType::TransactionsPreconfirmed.name(),
             "Transactions preconfirmed"
         );
-        describe_counter!(BoltMetrics::ValidationErrors.name(), "Validation errors");
+        describe_counter!(ApiMetricType::ValidationErrors.name(), "Validation errors");
 
         // Gauges
-        describe_gauge!(BoltMetrics::LatestHead.name(), "Latest slot number");
+        describe_gauge!(ApiMetricType::LatestHead.name(), "Latest slot number");
 
         // Histograms
         describe_histogram!(
-            BoltMetrics::HttpRequestsDurationSeconds.name(),
+            ApiMetricType::HttpRequestsDurationSeconds.name(),
             "Total duration of HTTP requests in seconds"
         );
     }

--- a/bolt-sidecar/src/telemetry/metrics.rs
+++ b/bolt-sidecar/src/telemetry/metrics.rs
@@ -14,6 +14,10 @@ pub enum BoltMetrics {
     InclusionCommitmentsReceived,
     /// Counter for the number of inclusion commitments accepted.
     InclusionCommitmentsAccepted,
+    /// Counter for the number of transactions preconfirmed
+    TransactionsPreconfirmed,
+    /// Counter for the number of validation errors, to spot most the most common ones
+    ValidationErrors,
 
     //  Gauges ------------------------------------------------------------------
     /// Gauge for the latest slot number
@@ -28,13 +32,21 @@ impl BoltMetrics {
     /// Returns the name of the metric.
     pub const fn name(&self) -> &'static str {
         match self {
-            BoltMetrics::LocalBlocksProposed => "local_blocks_proposed",
-            BoltMetrics::RemoteBlocksProposed => "remote_blocks_proposed",
-            BoltMetrics::InclusionCommitmentsReceived => "inclusion_commitments_received",
-            BoltMetrics::InclusionCommitmentsAccepted => "inclusion_commitments_accepted",
-            BoltMetrics::HttpRequestsTotal => "http_requests_total",
-            BoltMetrics::LatestHead => "latest_head",
-            BoltMetrics::HttpRequestsDurationSeconds => "http_requests_duration_seconds",
+            BoltMetrics::LocalBlocksProposed => "bolt_sidecar_local_blocks_proposed",
+            BoltMetrics::RemoteBlocksProposed => "bolt_sidecar_remote_blocks_proposed",
+            BoltMetrics::InclusionCommitmentsReceived => {
+                "bolt_sidecar_inclusion_commitments_received"
+            }
+            BoltMetrics::InclusionCommitmentsAccepted => {
+                "bolt_sidecar_inclusion_commitments_accepted"
+            }
+            BoltMetrics::HttpRequestsTotal => "bolt_sidecar_http_requests_total",
+            BoltMetrics::LatestHead => "bolt_sidecar_latest_head",
+            BoltMetrics::HttpRequestsDurationSeconds => {
+                "bolt_sidecar_http_requests_duration_seconds"
+            }
+            BoltMetrics::TransactionsPreconfirmed => "bolt_sidecar_transactions_preconfirmed",
+            BoltMetrics::ValidationErrors => "bolt_sidecar_validation_errors",
         }
     }
 
@@ -55,6 +67,11 @@ impl BoltMetrics {
             BoltMetrics::InclusionCommitmentsAccepted.name(),
             "Inclusion commitments accepted"
         );
+        describe_counter!(
+            BoltMetrics::TransactionsPreconfirmed.name(),
+            "Transactions preconfirmed"
+        );
+        describe_counter!(BoltMetrics::ValidationErrors.name(), "Validation errors");
 
         // Gauges
         describe_gauge!(BoltMetrics::LatestHead.name(), "Latest slot number");

--- a/bolt-sidecar/src/telemetry/mod.rs
+++ b/bolt-sidecar/src/telemetry/mod.rs
@@ -39,7 +39,7 @@ pub fn init_telemetry_stack(metrics_port: Option<u16>) -> Result<()> {
             );
         }
 
-        ApiMetrics::start();
+        ApiMetrics::describe_all();
     };
 
     Ok(())

--- a/bolt-sidecar/src/telemetry/mod.rs
+++ b/bolt-sidecar/src/telemetry/mod.rs
@@ -1,7 +1,6 @@
 use std::net::SocketAddr;
 
 use eyre::{bail, Result};
-use metrics::ApiMetrics;
 use metrics_exporter_prometheus::PrometheusBuilder;
 use tracing::info;
 use tracing_subscriber::{
@@ -10,7 +9,7 @@ use tracing_subscriber::{
 };
 
 mod metrics;
-pub use metrics::ApiMetricType;
+pub use metrics::ApiMetrics;
 
 /// Initialize the tracing stack and Prometheus metrics recorder.
 ///

--- a/bolt-sidecar/src/telemetry/mod.rs
+++ b/bolt-sidecar/src/telemetry/mod.rs
@@ -1,0 +1,41 @@
+use std::net::SocketAddr;
+
+use eyre::{bail, Result};
+use metrics_exporter_prometheus::PrometheusBuilder;
+use tracing::info;
+use tracing_subscriber::{
+    fmt::Layer as FmtLayer, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer,
+    Registry,
+};
+
+mod metrics;
+pub use metrics::BoltMetrics;
+
+/// Initialize the tracing stack and Prometheus metrics recorder.
+///
+/// **This function should be called at the beginning of the program.**
+pub fn init_telemetry_stack(metrics_port: u16) -> Result<()> {
+    // 1. Initialize tracing to stdout
+    let std_layer = FmtLayer::default().with_writer(std::io::stdout).with_filter(
+        EnvFilter::builder()
+            .with_default_directive("bolt_sidecar=info".parse()?)
+            .from_env_lossy()
+            .add_directive("reqwest=error".parse()?)
+            .add_directive("alloy_transport_http=error".parse()?),
+    );
+    Registry::default().with(std_layer).try_init()?;
+
+    // 2. Initialize metrics recorder and start the Prometheus server
+    let prometheus_addr = SocketAddr::from(([0, 0, 0, 0], metrics_port));
+    let builder = PrometheusBuilder::new().with_http_listener(prometheus_addr);
+
+    if let Err(e) = builder.install() {
+        bail!("failed to install Prometheus recorder: {:?}", e);
+    } else {
+        info!("Telemetry initialized. Serving Prometheus metrics at: http://{}", prometheus_addr);
+    }
+
+    BoltMetrics::describe_all();
+
+    Ok(())
+}

--- a/bolt-sidecar/src/telemetry/mod.rs
+++ b/bolt-sidecar/src/telemetry/mod.rs
@@ -1,6 +1,7 @@
 use std::net::SocketAddr;
 
 use eyre::{bail, Result};
+use metrics::ApiMetrics;
 use metrics_exporter_prometheus::PrometheusBuilder;
 use tracing::info;
 use tracing_subscriber::{
@@ -9,7 +10,7 @@ use tracing_subscriber::{
 };
 
 mod metrics;
-pub use metrics::BoltMetrics;
+pub use metrics::ApiMetricType;
 
 /// Initialize the tracing stack and Prometheus metrics recorder.
 ///
@@ -39,7 +40,7 @@ pub fn init_telemetry_stack(metrics_port: Option<u16>) -> Result<()> {
             );
         }
 
-        BoltMetrics::describe_all();
+        ApiMetrics::start();
     };
 
     Ok(())

--- a/scripts/kurtosis_config.yaml
+++ b/scripts/kurtosis_config.yaml
@@ -15,7 +15,7 @@ additional_services:
   # - el_forkmon
   # - beacon_metrics_gazer
   # - full_beaconchain_explorer
-  # - prometheus_grafana
+  - prometheus_grafana
   # - blobscan
 
 mev_type: full

--- a/scripts/start-devnet.sh
+++ b/scripts/start-devnet.sh
@@ -3,7 +3,7 @@
 echo "Starting the devnet..."
 
 # spin up the kurtosis devnet
-kurtosis run --enclave bolt-devnet github.com/chainbound/ethereum-package@feat/mev-boost-proxy --args-file ./scripts/kurtosis_config.yaml
+kurtosis run --enclave bolt-devnet github.com/chainbound/ethereum-package@bolt --args-file ./scripts/kurtosis_config.yaml
 echo "Devnet online! Waiting for the RPC to be available..."
 sleep 5
 


### PR DESCRIPTION
Closes #116. 
Introduces telemetry and metrics into the Bolt sidecar, which are enabled using the `metrics` flag, by spinning up a Prometheus server and basic Grafana dashboard, which are available also for the devnet (see https://github.com/chainbound/ethereum-package/pull/7).

The integration with Promtail and Loki will be addressed in a future PR if needed.

NOTE:
- the docker compose setup using the `telemetry.compose.yml` is currently non-tested on Helder. Main testing has been done with devnet data.
- needs to be merged along with https://github.com/chainbound/ethereum-package/pull/7

Lastly, most of the code is heavily inspired by the work of @merklefruit and @namn-grg on https://github.com/chainbound/bolt-rpc, so thanks a lot for the guideline!

![image](https://github.com/user-attachments/assets/9e6a5f8d-b079-4c0b-b4e7-14eb4b87dabf)

