### PR TITLE
chore(sidecar): update constraint api

### DIFF
--- a/bolt-sidecar/src/crypto/bls.rs
+++ b/bolt-sidecar/src/crypto/bls.rs
@@ -157,14 +157,10 @@ mod tests {
             delegatee_pubkey: PublicKey::try_from(delegatee_pk.to_bytes().as_slice()).expect("Failed to convert delegatee public key"),
         };
 
-        let delegation_bytes = serde_json::to_vec(&delegation_msg).unwrap();
-        let temp = delegation_bytes.as_slice();
-        let mut data = [0u8; 32];
-        data.copy_from_slice(&temp[..32]);
-        let msg = TestSignableData { data };
+        let digest = SignableBLS::digest(&delegation_msg);
 
         // Sign the Delegation message
-        let delegation_signature = SignerBLS::sign(&signer, &msg.digest()).await.unwrap();
+        let delegation_signature = SignerBLS::sign(&signer, &digest).await.unwrap();
 
         // Create SignedDelegation
         let signed_delegation = SignedDelegation {
@@ -181,14 +177,10 @@ mod tests {
             delegatee_pubkey: PublicKey::try_from(delegatee_pk.to_bytes().as_slice()).expect("Failed to convert delegatee public key"),
         };
 
-        let revocation_bytes = serde_json::to_vec(&revocation_msg).unwrap();
-        let temp = revocation_bytes.as_slice();
-        let mut data = [0u8; 32];
-        data.copy_from_slice(&temp[..32]);
-        let msg = TestSignableData { data };
+        let digest = SignableBLS::digest(&revocation_msg);
 
         // Sign the Revocation message
-        let revocation_signature = SignerBLS::sign(&signer, &msg.digest()).await.unwrap();
+        let revocation_signature = SignerBLS::sign(&signer, &digest).await.unwrap();
 
         // Create SignedRevocation
         let signed_revocation = SignedRevocation {
@@ -199,23 +191,20 @@ mod tests {
         // Output SignedRevocation
         println!("{}", serde_json::to_string_pretty(&signed_revocation).unwrap());
 
-        let constraints = random_constraints(2);
+        let transactions = random_constraints(2);
 
         // Prepare a ConstraintsMessage
         let constraints_msg = ConstraintsMessage {
             pubkey: PublicKey::try_from(pk.to_bytes().as_slice()).expect("Failed to convert validator public key"),
-            slot: 1,
-            top: true,
-            constraints,
+            slot: 2,
+            top: false,
+            transactions,
         };
 
-        let constraints_bytes = serde_json::to_vec(&constraints_msg).unwrap();
-        let temp = constraints_bytes.as_slice();
-        let mut data = [0u8; 32];
-        data.copy_from_slice(&temp[..32]);
+        let digest = SignableBLS::digest(&constraints_msg);
 
         // Sign the ConstraintsMessage
-        let constraints_signature = SignerBLS::sign(&signer, &data).await.unwrap();
+        let constraints_signature = SignerBLS::sign(&signer, &digest).await.unwrap();
 
         // Create SignedConstraints
         let signed_constraints = SignedConstraints {

--- a/bolt-sidecar/src/crypto/bls.rs
+++ b/bolt-sidecar/src/crypto/bls.rs
@@ -102,10 +102,11 @@ fn sign_with_prefix(key: &BlsSecretKey, data: &[u8]) -> Signature {
 #[cfg(test)]
 mod tests {
     use crate::{
-        crypto::bls::{SignableBLS, Signer, SignerBLS},
-        test_util::{test_bls_secret_key, TestSignableData},
+        crypto::bls::{SignableBLS, Signer, SignerBLS}, primitives::{ConstraintsMessage, DelegationMessage, FullTransaction, InclusionRequest, RevocationMessage, SignedConstraints, SignedDelegation, SignedRevocation}, test_util::{test_bls_secret_key, TestSignableData}
     };
 
+    use blst::min_pk::SecretKey;
+    use ethereum_consensus::crypto::{PublicKey, Signature};
     use rand::Rng;
 
     #[tokio::test]
@@ -123,5 +124,106 @@ mod tests {
         let signature = SignerBLS::sign(&signer, &msg.digest()).await.unwrap();
         let sig = blst::min_pk::Signature::from_bytes(signature.as_ref()).unwrap();
         assert!(signer.verify(&msg, &sig, &pubkey));
+    }
+
+    fn random_constraints(count: usize) -> Vec<FullTransaction> {
+        // Random inclusion request
+        let json_req = r#"{
+            "slot": 10,
+            "txs": ["0x02f86c870c72dd9d5e883e4d0183408f2382520894d2e2adf7177b7a8afddbc12d1634cf23ea1a71020180c001a08556dcfea479b34675db3fe08e29486fe719c2b22f6b0c1741ecbbdce4575cc6a01cd48009ccafd6b9f1290bbe2ceea268f94101d1d322c787018423ebcbc87ab4"]
+        }"#;
+
+        let req: InclusionRequest = serde_json::from_str(json_req).unwrap();
+
+        (0..count).map(|_| req.txs.first().unwrap().clone()).collect()
+    }
+
+    #[tokio::test]
+    async fn generate_test_data() {
+        let sk = test_bls_secret_key();
+        let pk = sk.sk_to_pk();
+        let signer = Signer::new(sk);
+
+        println!("Validator Public Key: {}", hex::encode(pk.to_bytes()));
+
+        // Generate a delegatee's BLS secret key and public key
+        let delegatee_ikm: [u8; 32] = rand::thread_rng().gen();
+        let delegatee_sk = SecretKey::key_gen(&delegatee_ikm, &[]).expect("Failed to generate delegatee secret key");
+        let delegatee_pk = delegatee_sk.sk_to_pk();
+
+        // Prepare a Delegation message
+        let delegation_msg = DelegationMessage {
+            validator_pubkey: PublicKey::try_from(pk.to_bytes().as_slice()).expect("Failed to convert validator public key"),
+            delegatee_pubkey: PublicKey::try_from(delegatee_pk.to_bytes().as_slice()).expect("Failed to convert delegatee public key"),
+        };
+
+        let delegation_bytes = serde_json::to_vec(&delegation_msg).unwrap();
+        let temp = delegation_bytes.as_slice();
+        let mut data = [0u8; 32];
+        data.copy_from_slice(&temp[..32]);
+        let msg = TestSignableData { data };
+
+        // Sign the Delegation message
+        let delegation_signature = SignerBLS::sign(&signer, &msg.digest()).await.unwrap();
+
+        // Create SignedDelegation
+        let signed_delegation = SignedDelegation {
+            message: delegation_msg,
+            signature: Signature::try_from(delegation_signature.as_ref()).expect("Failed to convert delegation signature"),
+        };
+
+        // Output SignedDelegation
+        println!("{}", serde_json::to_string_pretty(&signed_delegation).unwrap());
+
+        // Prepare a revocation message
+        let revocation_msg = RevocationMessage {
+            validator_pubkey: PublicKey::try_from(pk.to_bytes().as_slice()).expect("Failed to convert validator public key"),
+            delegatee_pubkey: PublicKey::try_from(delegatee_pk.to_bytes().as_slice()).expect("Failed to convert delegatee public key"),
+        };
+
+        let revocation_bytes = serde_json::to_vec(&revocation_msg).unwrap();
+        let temp = revocation_bytes.as_slice();
+        let mut data = [0u8; 32];
+        data.copy_from_slice(&temp[..32]);
+        let msg = TestSignableData { data };
+
+        // Sign the Revocation message
+        let revocation_signature = SignerBLS::sign(&signer, &msg.digest()).await.unwrap();
+
+        // Create SignedRevocation
+        let signed_revocation = SignedRevocation {
+            message: revocation_msg,
+            signature: Signature::try_from(revocation_signature.as_ref()).expect("Failed to convert revocation signature"),
+        };
+
+        // Output SignedRevocation
+        println!("{}", serde_json::to_string_pretty(&signed_revocation).unwrap());
+
+        let constraints = random_constraints(2);
+
+        // Prepare a ConstraintsMessage
+        let constraints_msg = ConstraintsMessage {
+            pubkey: PublicKey::try_from(pk.to_bytes().as_slice()).expect("Failed to convert validator public key"),
+            slot: 1,
+            top: true,
+            constraints,
+        };
+
+        let constraints_bytes = serde_json::to_vec(&constraints_msg).unwrap();
+        let temp = constraints_bytes.as_slice();
+        let mut data = [0u8; 32];
+        data.copy_from_slice(&temp[..32]);
+
+        // Sign the ConstraintsMessage
+        let constraints_signature = SignerBLS::sign(&signer, &data).await.unwrap();
+
+        // Create SignedConstraints
+        let signed_constraints = SignedConstraints {
+            message: constraints_msg,
+            signature: constraints_signature,
+        };
+
+        // Output SignedConstraints
+        println!("{}", serde_json::to_string_pretty(&signed_constraints).unwrap());
     }
 }

--- a/bolt-sidecar/src/driver.rs
+++ b/bolt-sidecar/src/driver.rs
@@ -231,7 +231,7 @@ impl<C: StateFetcher, BLS: SignerBLS, ECDSA: SignerECDSA> SidecarDriver<C, BLS, 
         };
 
         // Track the number of transactions preconfirmed considering their type
-        signed_constraints.message.constraints.iter().for_each(|full_tx| {
+        signed_constraints.message.transactions.iter().for_each(|full_tx| {
             ApiMetrics::increment_transactions_preconfirmed(full_tx.tx_type());
         });
         self.execution.add_constraint(slot, signed_constraints);

--- a/bolt-sidecar/src/primitives/constraint.rs
+++ b/bolt-sidecar/src/primitives/constraint.rs
@@ -79,8 +79,8 @@ impl SignableBLS for ConstraintsMessage {
         hasher.update(self.slot.to_le_bytes());
         hasher.update((self.top as u8).to_le_bytes());
 
-        for constraint in &self.transactions {
-            hasher.update(constraint.hash());
+        for tx in &self.transactions {
+            hasher.update(tx.hash());
         }
 
         hasher.finalize().into()

--- a/bolt-sidecar/src/primitives/mod.rs
+++ b/bolt-sidecar/src/primitives/mod.rs
@@ -8,7 +8,7 @@ use std::{
 
 use alloy::{
     primitives::{Address, U256},
-    signers::k256::sha2::{Digest, Sha256}
+    signers::k256::sha2::{Digest, Sha256},
 };
 use ethereum_consensus::{
     crypto::KzgCommitment,
@@ -440,7 +440,7 @@ impl SignableBLS for DelegationMessage {
         let mut hasher = Sha256::new();
         hasher.update(&self.validator_pubkey.to_vec());
         hasher.update(&self.delegatee_pubkey.to_vec());
-        
+
         hasher.finalize().into()
     }
 }
@@ -462,7 +462,7 @@ impl SignableBLS for RevocationMessage {
         let mut hasher = Sha256::new();
         hasher.update(&self.validator_pubkey.to_vec());
         hasher.update(&self.delegatee_pubkey.to_vec());
-        
+
         hasher.finalize().into()
     }
 }

--- a/bolt-sidecar/src/primitives/mod.rs
+++ b/bolt-sidecar/src/primitives/mod.rs
@@ -6,7 +6,10 @@ use std::{
     sync::{atomic::AtomicU64, Arc},
 };
 
-use alloy::primitives::{Address, U256};
+use alloy::{
+    primitives::{Address, U256},
+    signers::k256::sha2::{Digest, Sha256}
+};
 use ethereum_consensus::{
     crypto::KzgCommitment,
     deneb::{
@@ -35,6 +38,8 @@ pub use commitment::{CommitmentRequest, InclusionRequest};
 pub mod constraint;
 pub use constraint::{BatchedSignedConstraints, ConstraintsMessage, SignedConstraints};
 use tracing::{error, info};
+
+use crate::crypto::SignableBLS;
 
 /// An alias for a Beacon Chain slot number
 pub type Slot = u64;
@@ -430,6 +435,16 @@ pub struct DelegationMessage {
     pub delegatee_pubkey: BlsPublicKey,
 }
 
+impl SignableBLS for DelegationMessage {
+    fn digest(&self) -> [u8; 32] {
+        let mut hasher = Sha256::new();
+        hasher.update(&self.validator_pubkey.to_vec());
+        hasher.update(&self.delegatee_pubkey.to_vec());
+        
+        hasher.finalize().into()
+    }
+}
+
 #[derive(Debug, Clone, Serialize)]
 pub struct SignedRevocation {
     pub message: RevocationMessage,
@@ -440,4 +455,14 @@ pub struct SignedRevocation {
 pub struct RevocationMessage {
     pub validator_pubkey: BlsPublicKey,
     pub delegatee_pubkey: BlsPublicKey,
+}
+
+impl SignableBLS for RevocationMessage {
+    fn digest(&self) -> [u8; 32] {
+        let mut hasher = Sha256::new();
+        hasher.update(&self.validator_pubkey.to_vec());
+        hasher.update(&self.delegatee_pubkey.to_vec());
+        
+        hasher.finalize().into()
+    }
 }


### PR DESCRIPTION
This PR -
- renames the `constraints` field to `transactions` 
- adds a test data generator for testing