### PR TITLE
chore(ci): bump actions to remove warnings

### DIFF
--- a/.github/workflows/sidecar_ci.yml
+++ b/.github/workflows/sidecar_ci.yml
@@ -13,7 +13,7 @@ jobs:
 
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Install Rust toolchain
         uses: actions-rs/toolchain@v1
@@ -31,7 +31,7 @@ jobs:
           cache-on-failure: true
 
       - name: Install cargo-nextest
-        uses: baptiste0928/cargo-install@v1
+        uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-nextest
           args: --locked

--- a/.github/workflows/sidecar_ci.yml
+++ b/.github/workflows/sidecar_ci.yml
@@ -2,6 +2,9 @@ name: Bolt-sidecar CI
 
 on: [push, pull_request]
 
+env:
+  CARGO_TERM_COLOR: always
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
@@ -10,17 +13,15 @@ jobs:
   cargo-tests:
     runs-on: ubuntu-latest
     timeout-minutes: 10
+    env:
+      RUST_BACKTRACE: 1
 
     steps:
       - name: Checkout sources
         uses: actions/checkout@v4
 
       - name: Install Rust toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
+        uses: dtolnay/rust-toolchain@stable
 
       - name: Install Foundry
         uses: foundry-rs/foundry-toolchain@v1
@@ -34,7 +35,6 @@ jobs:
         uses: baptiste0928/cargo-install@v3
         with:
           crate: cargo-nextest
-          args: --locked
 
       - name: Run all tests
         run: cd bolt-sidecar && cargo nextest run --workspace --retries 3


### PR DESCRIPTION
Removes warnings from CI like these https://github.com/chainbound/bolt/actions/runs/11100623184
Change logs:
- https://github.com/baptiste0928/cargo-install/releases
- https://github.com/actions/checkout/releases


https://github.com/actions-rs/toolchain has also been deprecated for 4 years btw.