### PR TITLE
feat(registry): added max committed gas limit per validator

### DIFF
--- a/bolt-contracts/src/interfaces/IBoltValidators.sol
+++ b/bolt-contracts/src/interfaces/IBoltValidators.sol
@@ -5,19 +5,19 @@ import {BLS12381} from "../lib/bls/BLS12381.sol";
 import {ValidatorProver} from "../lib/ssz/ValidatorProver.sol";
 
 interface IBoltValidators {
-    /// @notice Validator
+    /// @notice Validator info
     struct Validator {
+        // whether the validator exists in the registry
+        bool exists;
         // the incremental sequence number assigned to the validator
         uint64 sequenceNumber;
-        // the entity authorized to deposit collateral for the validator
-        // to add credibility to its commitments
-        address authorizedCollateralProvider;
+        // the maximum amount of gas that the validator can consume with preconfirmations
+        // in a single slot. Operators must respect this limit when making commitments.
+        uint128 maxCommittedGasLimit;
         // the entity authorized to make commitments on behalf of the validator
         address authorizedOperator;
         // the EOA that registered the validator and can update its configuration
         address controller;
-        // whether the validator exists in the registry
-        bool exists;
     }
 
     error InvalidBLSSignature();
@@ -26,6 +26,7 @@ interface IBoltValidators {
     error ValidatorAlreadyExists();
     error ValidatorDoesNotExist();
     error UnsafeRegistrationNotAllowed();
+    error UnauthorizedCaller();
 
     function getAllValidators() external view returns (Validator[] memory);
 
@@ -43,27 +44,29 @@ interface IBoltValidators {
 
     function registerValidatorUnsafe(
         BLS12381.G1Point calldata pubkey,
-        address authorizedCollateralProvider,
+        uint128 maxCommittedGasLimit,
         address authorizedOperator
     ) external;
 
     function registerValidator(
         BLS12381.G1Point calldata pubkey,
         BLS12381.G2Point calldata signature,
-        address authorizedCollateralProvider,
+        uint128 maxCommittedGasLimit,
         address authorizedOperator
     ) external;
 
     function batchRegisterValidators(
         BLS12381.G1Point[] calldata pubkeys,
         BLS12381.G2Point calldata signature,
-        address authorizedCollateralProvider,
+        uint128 maxCommittedGasLimit,
         address authorizedOperator
     ) external;
 
     function batchRegisterValidatorsUnsafe(
         BLS12381.G1Point[] calldata pubkeys,
-        address authorizedCollateralProvider,
+        uint128 maxCommittedGasLimit,
         address authorizedOperator
     ) external;
+
+    function updateMaxCommittedGasLimit(bytes32 pubkeyHash, uint128 maxCommittedGasLimit) external;
 }

--- a/bolt-contracts/test/BoltManager.EigenLayer.t.sol
+++ b/bolt-contracts/test/BoltManager.EigenLayer.t.sol
@@ -27,6 +27,8 @@ contract BoltManagerEigenLayerTest is Test {
     BoltManager public manager;
     EigenLayerDeployer public eigenLayerDeployer;
 
+    uint128 public constant PRECONF_MAX_GAS_LIMIT = 5_000_000;
+
     address staker = makeAddr("staker");
     address validator = makeAddr("validator");
     BLS12381.G1Point validatorPubkey = BLS12381.generatorG1();
@@ -153,10 +155,9 @@ contract BoltManagerEigenLayerTest is Test {
         validatorPubkey = BLS12381.generatorG1();
 
         vm.prank(validator);
-        validators.registerValidatorUnsafe(validatorPubkey, staker, operator);
+        validators.registerValidatorUnsafe(validatorPubkey, PRECONF_MAX_GAS_LIMIT, operator);
         assertEq(validators.getValidatorByPubkey(validatorPubkey).exists, true);
         assertEq(validators.getValidatorByPubkey(validatorPubkey).authorizedOperator, operator);
-        assertEq(validators.getValidatorByPubkey(validatorPubkey).authorizedCollateralProvider, staker);
 
         // 2. --- Operator and strategy registration into BoltManager (middleware) ---
 
@@ -210,7 +211,7 @@ contract BoltManagerEigenLayerTest is Test {
             pubkey.y[0] = pubkey.y[0] + i + 2;
 
             pubkeyHashes[i] = _pubkeyHash(pubkey);
-            validators.registerValidatorUnsafe(pubkey, staker, operator);
+            validators.registerValidatorUnsafe(pubkey, PRECONF_MAX_GAS_LIMIT, operator);
         }
 
         BoltManager.ProposerStatus[] memory statuses = manager.getEigenLayerProposersStatus(pubkeyHashes);

--- a/bolt-contracts/test/BoltManager.Symbiotic.t.sol
+++ b/bolt-contracts/test/BoltManager.Symbiotic.t.sol
@@ -35,6 +35,8 @@ contract BoltManagerTest is Test {
     uint48 public constant EPOCH_DURATION = 1 days;
     uint48 public constant SLASHING_WINDOW = 7 days;
 
+    uint128 public constant PRECONF_MAX_GAS_LIMIT = 5_000_000;
+
     BoltValidators public validators;
     BoltManager public manager;
 
@@ -180,10 +182,9 @@ contract BoltManagerTest is Test {
         BLS12381.G1Point memory pubkey = BLS12381.generatorG1();
 
         vm.prank(validator);
-        validators.registerValidatorUnsafe(pubkey, provider, operator);
+        validators.registerValidatorUnsafe(pubkey, PRECONF_MAX_GAS_LIMIT, operator);
         assertEq(validators.getValidatorByPubkey(pubkey).exists, true);
         assertEq(validators.getValidatorByPubkey(pubkey).authorizedOperator, operator);
-        assertEq(validators.getValidatorByPubkey(pubkey).authorizedCollateralProvider, provider);
 
         // --- Register Operator in Symbiotic, opt-in network and vault ---
 
@@ -327,7 +328,7 @@ contract BoltManagerTest is Test {
             pubkey.y[0] = pubkey.y[0] + i + 2;
 
             pubkeyHashes[i] = _pubkeyHash(pubkey);
-            validators.registerValidatorUnsafe(pubkey, provider, operator);
+            validators.registerValidatorUnsafe(pubkey, PRECONF_MAX_GAS_LIMIT, operator);
         }
 
         vm.warp(block.timestamp + EPOCH_DURATION * 2 + 1);

--- a/bolt-contracts/test/BoltValidators.t.sol
+++ b/bolt-contracts/test/BoltValidators.t.sol
@@ -12,6 +12,8 @@ contract BoltValidatorsTest is Test {
 
     BoltValidators public validators;
 
+    uint128 public constant PRECONF_MAX_GAS_LIMIT = 5_000_000;
+
     address admin = makeAddr("admin");
     address provider = makeAddr("provider");
     address operator = makeAddr("operator");
@@ -26,11 +28,11 @@ contract BoltValidatorsTest is Test {
         BLS12381.G1Point memory pubkey = BLS12381.generatorG1();
 
         vm.prank(validator);
-        validators.registerValidatorUnsafe(pubkey, provider, operator);
+        validators.registerValidatorUnsafe(pubkey, 1_000_000, operator);
 
         BoltValidators.Validator memory registered = validators.getValidatorByPubkey(pubkey);
         assertEq(registered.exists, true);
-        assertEq(registered.authorizedCollateralProvider, provider);
+        assertEq(registered.maxCommittedGasLimit, 1_000_000);
         assertEq(registered.authorizedOperator, operator);
         assertEq(registered.controller, validator);
     }
@@ -39,11 +41,11 @@ contract BoltValidatorsTest is Test {
         BLS12381.G1Point memory pubkey = BLS12381.generatorG1();
 
         vm.prank(validator);
-        validators.registerValidatorUnsafe(pubkey, provider, operator);
+        validators.registerValidatorUnsafe(pubkey, PRECONF_MAX_GAS_LIMIT, operator);
 
         vm.prank(validator);
         vm.expectRevert(IBoltValidators.ValidatorAlreadyExists.selector);
-        validators.registerValidatorUnsafe(pubkey, provider, operator);
+        validators.registerValidatorUnsafe(pubkey, PRECONF_MAX_GAS_LIMIT, operator);
     }
 
     function testUnsafeRegistrationWhenNotAllowed() public {
@@ -54,15 +56,7 @@ contract BoltValidatorsTest is Test {
 
         vm.prank(validator);
         vm.expectRevert(IBoltValidators.UnsafeRegistrationNotAllowed.selector);
-        validators.registerValidatorUnsafe(pubkey, provider, operator);
-    }
-
-    function testUnsafeRegistrationInvalidCollateralProvider() public {
-        BLS12381.G1Point memory pubkey = BLS12381.generatorG1();
-
-        vm.prank(validator);
-        vm.expectRevert(IBoltValidators.InvalidAuthorizedCollateralProvider.selector);
-        validators.registerValidatorUnsafe(pubkey, address(0), operator);
+        validators.registerValidatorUnsafe(pubkey, PRECONF_MAX_GAS_LIMIT, operator);
     }
 
     function testUnsafeRegistrationInvalidOperator() public {
@@ -70,6 +64,6 @@ contract BoltValidatorsTest is Test {
 
         vm.prank(validator);
         vm.expectRevert(IBoltValidators.InvalidAuthorizedOperator.selector);
-        validators.registerValidatorUnsafe(pubkey, provider, address(0));
+        validators.registerValidatorUnsafe(pubkey, PRECONF_MAX_GAS_LIMIT, address(0));
     }
 }


### PR DESCRIPTION
* added missing docs
* removed `Validator.authorizedCollateralProvider` because it wasn't used
* added `Validator.maxCommittedGasLimit`

Note: this PR adds this value to the registry + middleware contracts, but it doesn't update the Challenger or any of the off-chain components reading the registry such as the RPC. That will be done in separate PRs.

- closes #250 