### PR TITLE
chore: Bolt-Boost and Helix images for devnet

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -137,6 +137,7 @@ build-images:
 	@just _build-relay
 	@just _build-sidecar
 	@just _build-mevboost
+	@just _build-bolt-boost
 
 # build the docker image for the bolt builder
 _build-builder:
@@ -153,6 +154,10 @@ _build-sidecar:
 # build the docker image for the bolt mev-boost sidecar
 _build-mevboost:
 	cd mev-boost && docker buildx build -t ghcr.io/chainbound/bolt-mev-boost:0.1.0 . --load
+
+# build the docker image for bolt-boost
+_build-bolt-boost:
+	cd bolt-boost && docker buildx build -t ghcr.io/chainbound/bolt-boost:0.1.0 . --load
 
 # deploy the bolt sidecar to the dev server
 deploy-sidecar-dev:

--- a/Justfile
+++ b/Justfile
@@ -38,7 +38,7 @@ inspect:
 
 # show the logs for the bolt devnet relay
 relay-logs:
-    @id=$(docker ps -n 100 | grep mev-relay-api | awk -F' ' '{print $1}') && \
+    @id=$(docker ps -n 100 | grep helix-relay | awk -F' ' '{print $1}') && \
     docker logs -f $id
 
 # show the logs for the bolt devnet builder

--- a/bolt-boost/src/metrics.rs
+++ b/bolt-boost/src/metrics.rs
@@ -24,7 +24,7 @@ lazy_static! {
 
     /// The size of the constraints cache
     pub static ref CONSTRAINTS_CACHE_SIZE: IntGauge = register_int_gauge_with_registry!(
-        "bolt_boost.constraints_cache_size",
+        "constraints_cache_size",
         "size of the constraints cache",
         BOLT_BOOST_METRICS
     )

--- a/scripts/kurtosis_config.yaml
+++ b/scripts/kurtosis_config.yaml
@@ -1,5 +1,6 @@
 network_params:
   seconds_per_slot: 2 # 2 seconds are the minimum for testing
+  genesis_delay: 0 # Apparently it seems needed to avoid timestamp issues on Helix
 tx_spammer_params:
   tx_spammer_extra_args: ["--slot-time=1", "--accounts=10", "--txcount=1"]
 

--- a/scripts/kurtosis_config.yaml
+++ b/scripts/kurtosis_config.yaml
@@ -23,6 +23,7 @@ mev_type: full
 mev_params:
   mev_builder_cl_image: sigp/lighthouse:latest
   # Bolt-specific images:
+  helix_relay_image: ghcr.io/chainbound/helix:0.1.0
   mev_relay_image: ghcr.io/chainbound/bolt-relay:0.1.0
   mev_builder_image: ghcr.io/chainbound/bolt-builder:0.1.0
   mev_boost_image: ghcr.io/chainbound/bolt-mev-boost:0.1.0

--- a/scripts/kurtosis_config.yaml
+++ b/scripts/kurtosis_config.yaml
@@ -24,6 +24,7 @@ mev_type: full
 mev_params:
   mev_builder_cl_image: sigp/lighthouse:latest
   # Bolt-specific images:
+  bolt_boost_image: ghcr.io/chainbound/bolt-boost:0.1.0
   helix_relay_image: ghcr.io/chainbound/helix:0.1.0
   mev_relay_image: ghcr.io/chainbound/bolt-relay:0.1.0
   mev_builder_image: ghcr.io/chainbound/bolt-builder:0.1.0


### PR DESCRIPTION
This PR introduces the changes needed by https://github.com/chainbound/ethereum-package/pull/9 in order to properly spin up the devnet.