### PR TITLE
fix: remove metrics clash with cb client

### DIFF
--- a/bolt-boost/src/constraints.rs
+++ b/bolt-boost/src/constraints.rs
@@ -65,8 +65,8 @@ impl ConstraintsCache {
     }
 
     /// Inserts the constraints for the given slot. Also decodes the raw transactions to save their
-    /// transaction hashes and hash tree roots for later use. Will first check for conflicts, and return
-    /// an error if there are any.
+    /// transaction hashes and hash tree roots for later use. Will first check for conflicts, and
+    /// return an error if there are any.
     pub fn insert(&self, slot: u64, constraints: ConstraintsMessage) -> Result<(), Error> {
         if let Some(conflict) = self.conflicts_with(&slot, &constraints) {
             return Err(conflict.into());
@@ -105,5 +105,37 @@ impl ConstraintsCache {
 
     fn total_constraints(&self) -> usize {
         self.cache.read().values().map(|v| v.len()).sum()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::{primitives::bytes, rpc::types::beacon::BlsPublicKey};
+
+    use super::*;
+
+    #[test]
+    fn test_constraints_cache_conflict() {
+        let cache = ConstraintsCache::new();
+
+        let tx = bytes!("f86481d8088302088a808090435b8080556001015a6161a8106001578718e5bb3abd109fa0ea5ad6553fb67639cec694e6697ac7b718bd7044fcdf5608fa64f6058e67db93a03953b5792d7d9ef7fc602fbe260e7a290760e8adc634f99ab1896e2c0d55afcb");
+
+        let constraints = ConstraintsMessage {
+            pubkey: BlsPublicKey::default(),
+            slot: 0,
+            top: false,
+            transactions: vec![tx],
+        };
+
+        cache.insert(0, constraints.clone()).unwrap();
+
+        assert!(cache.conflicts_with(&0, &constraints).is_none());
+        assert!(cache.conflicts_with(&1, &constraints).is_none());
+
+        cache.insert(0, constraints.clone()).unwrap();
+        assert!(matches!(
+            cache.conflicts_with(&0, &constraints),
+            Some(Conflict::DuplicateTransaction)
+        ));
     }
 }

--- a/bolt-boost/src/metrics.rs
+++ b/bolt-boost/src/metrics.rs
@@ -32,7 +32,7 @@ lazy_static! {
 
     /// Latency by relay by endpoint
     pub static ref RELAY_LATENCY: HistogramVec = register_histogram_vec_with_registry!(
-        "relay_latency",
+        "relay_latency_bolt",
         "HTTP latency by relay",
         &["endpoint", "relay_id"],
         BOLT_BOOST_METRICS
@@ -41,7 +41,7 @@ lazy_static! {
 
     /// Status code received by relay by endpoint
     pub static ref RELAY_STATUS_CODE: IntCounterVec = register_int_counter_vec_with_registry!(
-        "relay_status_code_total",
+        "relay_status_code_total_bolt",
         "HTTP status code received by relay",
         &["http_status_code", "endpoint", "relay_id"],
         BOLT_BOOST_METRICS


### PR DESCRIPTION
bolt-boost in kurtosis had some panics due to already-registered metrics. disambiguated by adding `_bolt`.