### PR TITLE
feat(sidecar): sign messages using the correct signing domain

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,6 @@
 *_dump.log
 target/
+.vscode
+.idea
+.DS_Store
+.env

--- a/bolt-boost/src/server.rs
+++ b/bolt-boost/src/server.rs
@@ -25,7 +25,9 @@ use cb_common::{
     config::PbsConfig,
     constants::APPLICATION_BUILDER_DOMAIN,
     pbs::{
-        error::{PbsError, ValidationError}, GetHeaderResponse, RelayClient, SignedExecutionPayloadHeader, EMPTY_TX_ROOT_HASH, HEADER_SLOT_UUID_KEY, HEADER_START_TIME_UNIX_MS
+        error::{PbsError, ValidationError},
+        GetHeaderResponse, RelayClient, SignedExecutionPayloadHeader, EMPTY_TX_ROOT_HASH,
+        HEADER_SLOT_UUID_KEY, HEADER_START_TIME_UNIX_MS,
     },
     signature::verify_signed_message,
     types::Chain,

--- a/bolt-sidecar/src/builder/mod.rs
+++ b/bolt-sidecar/src/builder/mod.rs
@@ -83,7 +83,7 @@ impl LocalBuilder {
             payload_and_bid: None,
             fallback_builder: FallbackPayloadBuilder::new(config, beacon_api_client, genesis_time),
             secret_key: config.builder_private_key.clone(),
-            chain: config.chain.clone(),
+            chain: config.chain,
         }
     }
 

--- a/bolt-sidecar/src/client/commit_boost.rs
+++ b/bolt-sidecar/src/client/commit_boost.rs
@@ -109,11 +109,11 @@ impl CommitBoostSigner {
 
 #[async_trait::async_trait]
 impl SignerBLS for CommitBoostSigner {
-    async fn sign(&self, data: &[u8; 32]) -> eyre::Result<BlsSignature> {
-        let request = SignConsensusRequest::builder(
-            *self.pubkeys.read().first().expect("consensus pubkey loaded"),
-        )
-        .with_msg(data);
+    async fn sign_commit_boost_root(&self, data: &[u8; 32]) -> eyre::Result<BlsSignature> {
+        let request = SignConsensusRequest {
+            pubkey: *self.pubkeys.read().first().expect("consensus pubkey loaded"),
+            object_root: *data,
+        };
 
         debug!(?request, "Requesting signature from commit_boost");
 
@@ -167,7 +167,7 @@ mod test {
         let mut data = [0u8; 32];
         rng.fill(&mut data);
 
-        let signature = signer.sign(&data).await.unwrap();
+        let signature = signer.sign_commit_boost_root(&data).await.unwrap();
         let sig = blst::min_pk::Signature::from_bytes(signature.as_ref()).unwrap();
         let pubkey = signer.get_consensus_pubkey();
         let bls_pubkey = blst::min_pk::PublicKey::from_bytes(pubkey.as_ref()).unwrap();

--- a/bolt-sidecar/src/crypto/bls.rs
+++ b/bolt-sidecar/src/crypto/bls.rs
@@ -33,10 +33,19 @@ pub trait SignerBLS: Send + Debug {
 }
 
 /// A BLS signer that can sign any type that implements the [`SignableBLS`] trait.
-#[derive(Debug, Clone)]
+#[derive(Clone)]
 pub struct Signer {
     chain: ChainConfig,
     key: BlsSecretKey,
+}
+
+impl Debug for Signer {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("Signer")
+            .field("pubkey", &self.pubkey())
+            .field("chain", &self.chain.name())
+            .finish()
+    }
 }
 
 impl Signer {

--- a/bolt-sidecar/src/crypto/bls.rs
+++ b/bolt-sidecar/src/crypto/bls.rs
@@ -2,10 +2,13 @@ use std::fmt::Debug;
 
 use alloy::primitives::FixedBytes;
 use blst::{min_pk::Signature, BLST_ERROR};
+use ethereum_consensus::deneb::compute_signing_root;
 use rand::RngCore;
 
 pub use blst::min_pk::{PublicKey as BlsPublicKey, SecretKey as BlsSecretKey};
 pub use ethereum_consensus::deneb::BlsSignature;
+
+use crate::ChainConfig;
 
 /// The BLS Domain Separator used in Ethereum 2.0.
 pub const BLS_DST_PREFIX: &[u8] = b"BLS_SIG_BLS12381G2_XMD:SHA-256_SSWU_RO_POP_";
@@ -19,14 +22,6 @@ pub trait SignableBLS {
     /// Returns the digest of the object.
     fn digest(&self) -> [u8; 32];
 
-    /// Sign the object with the given key. Returns the signature.
-    ///
-    /// Note: The default implementation should be used where possible.
-    #[allow(dead_code)]
-    fn sign(&self, key: &BlsSecretKey) -> Signature {
-        sign_with_prefix(key, &self.digest())
-    }
-
     /// Verify the signature of the object with the given public key.
     ///
     /// Note: The default implementation should be used where possible.
@@ -37,31 +32,56 @@ pub trait SignableBLS {
 }
 
 /// A generic signing trait to generate BLS signatures.
+///
+/// Note: we keep this async to allow remote signer implementations.
 #[async_trait::async_trait]
 pub trait SignerBLS: Send + Debug {
     /// Sign the given data and return the signature.
-    async fn sign(&self, data: &[u8; 32]) -> eyre::Result<BLSSig>;
+    async fn sign_commit_boost_root(&self, data: &[u8; 32]) -> eyre::Result<BLSSig>;
 }
 
-/// A BLS signer that can sign any type that implements the `Signable` trait.
+/// A BLS signer that can sign any type that implements the [`SignableBLS`] trait.
 #[derive(Debug, Clone)]
 pub struct Signer {
+    chain: ChainConfig,
     key: BlsSecretKey,
 }
 
 impl Signer {
     /// Create a new signer with the given BLS secret key.
-    pub fn new(key: BlsSecretKey) -> Self {
-        Self { key }
+    pub fn new(key: BlsSecretKey, chain: ChainConfig) -> Self {
+        Self { key, chain }
     }
 
-    /// Create a signer with a random BLS key.
+    /// Create a signer with a random BLS key configured for Mainnet for testing.
+    #[cfg(test)]
     pub fn random() -> Self {
-        Self { key: random_bls_secret() }
+        Self { key: random_bls_secret(), chain: ChainConfig::mainnet() }
+    }
+
+    /// Get the public key of the signer.
+    pub fn pubkey(&self) -> BlsPublicKey {
+        self.key.sk_to_pk()
+    }
+
+    /// Sign an SSZ object root with the Application Builder domain.
+    pub fn sign_application_builder_root(&self, root: [u8; 32]) -> eyre::Result<BLSSig> {
+        self.sign_root(root, self.chain.builder_domain())
+    }
+
+    /// Sign an SSZ object root with the Commit Boost domain.
+    pub fn sign_commit_boost_root(&self, root: [u8; 32]) -> eyre::Result<BLSSig> {
+        self.sign_root(root, self.chain.commit_boost_domain())
+    }
+
+    /// Sign an SSZ object root with the given domain.
+    pub fn sign_root(&self, root: [u8; 32], domain: [u8; 32]) -> eyre::Result<BLSSig> {
+        let signing_root = compute_signing_root(&root, domain)?;
+        let sig = self.key.sign(signing_root.as_slice(), BLS_DST_PREFIX, &[]);
+        Ok(BLSSig::from_slice(&sig.to_bytes()))
     }
 
     /// Verify the signature of the object with the given public key.
-    #[allow(dead_code)]
     pub fn verify<T: SignableBLS>(
         &self,
         obj: &T,
@@ -74,9 +94,8 @@ impl Signer {
 
 #[async_trait::async_trait]
 impl SignerBLS for Signer {
-    async fn sign(&self, data: &[u8; 32]) -> eyre::Result<BLSSig> {
-        let sig = sign_with_prefix(&self.key, data);
-        Ok(BLSSig::from(sig.to_bytes()))
+    async fn sign_commit_boost_root(&self, data: &[u8; 32]) -> eyre::Result<BLSSig> {
+        self.sign_commit_boost_root(*data)
     }
 }
 
@@ -93,26 +112,18 @@ pub fn random_bls_secret() -> BlsSecretKey {
     BlsSecretKey::key_gen(&ikm, &[]).unwrap()
 }
 
-/// Sign the given data with the given BLS secret key.
-#[inline]
-fn sign_with_prefix(key: &BlsSecretKey, data: &[u8]) -> Signature {
-    key.sign(data, BLS_DST_PREFIX, &[])
-}
-
 #[cfg(test)]
 mod tests {
     use crate::{
-        crypto::bls::{SignableBLS, Signer, SignerBLS},
-        test_util::{test_bls_secret_key, TestSignableData},
+        crypto::bls::{SignableBLS, Signer},
+        test_util::TestSignableData,
     };
 
     use rand::Rng;
 
     #[tokio::test]
     async fn test_bls_signer() {
-        let key = test_bls_secret_key();
-        let pubkey = key.sk_to_pk();
-        let signer = Signer::new(key);
+        let signer = Signer::random();
 
         // Generate random data for the test
         let mut rng = rand::thread_rng();
@@ -120,8 +131,8 @@ mod tests {
         rng.fill(&mut data);
         let msg = TestSignableData { data };
 
-        let signature = SignerBLS::sign(&signer, &msg.digest()).await.unwrap();
+        let signature = signer.sign_commit_boost_root(msg.digest()).unwrap();
         let sig = blst::min_pk::Signature::from_bytes(signature.as_ref()).unwrap();
-        assert!(signer.verify(&msg, &sig, &pubkey));
+        assert!(signer.verify(&msg, &sig, &signer.pubkey()));
     }
 }

--- a/bolt-sidecar/src/primitives/constraint.rs
+++ b/bolt-sidecar/src/primitives/constraint.rs
@@ -1,35 +1,13 @@
-use alloy::{
-    primitives::keccak256,
-    signers::k256::sha2::{Digest, Sha256},
-};
+use alloy::signers::k256::sha2::{Digest, Sha256};
 use ethereum_consensus::crypto::PublicKey as BlsPublicKey;
-use secp256k1::Message;
 use serde::{Deserialize, Serialize};
 
 use crate::{
-    crypto::{bls::BLSSig, ecdsa::SignableECDSA, SignableBLS},
+    crypto::{bls::BLSSig, SignableBLS},
     primitives::{deserialize_txs, serialize_txs},
 };
 
 use super::{FullTransaction, InclusionRequest};
-
-/// What the proposer sidecar will need to sign to confirm the inclusion request.
-impl SignableECDSA for ConstraintsMessage {
-    fn digest(&self) -> Message {
-        let mut data = Vec::new();
-        data.extend_from_slice(&self.pubkey.to_vec());
-        data.extend_from_slice(&self.slot.to_le_bytes());
-
-        let mut constraint_bytes = Vec::new();
-        for constraint in &self.transactions {
-            constraint_bytes.extend_from_slice(&constraint.envelope_encoded().0);
-        }
-        data.extend_from_slice(&constraint_bytes);
-
-        let hash = keccak256(data).0;
-        Message::from_digest_slice(&hash).expect("digest")
-    }
-}
 
 /// The inclusion request transformed into an explicit list of signed constraints
 /// that need to be forwarded to the PBS pipeline to inform block production.

--- a/bolt-sidecar/src/state/execution.rs
+++ b/bolt-sidecar/src/state/execution.rs
@@ -542,7 +542,7 @@ mod tests {
     use reth_primitives::constants::GWEI_TO_WEI;
 
     use crate::{
-        crypto::{bls::Signer, SignableBLS, SignerBLS},
+        crypto::{bls::Signer, SignableBLS},
         primitives::{ConstraintsMessage, SignedConstraints},
         state::fetcher,
         test_util::{create_signed_commitment_request, default_test_transaction, launch_anvil},
@@ -736,7 +736,7 @@ mod tests {
             Default::default(),
             request.as_inclusion_request().unwrap().clone(),
         );
-        let signature = signer.sign(&message.digest()).await?;
+        let signature = signer.sign_commit_boost_root(message.digest())?;
         let signed_constraints = SignedConstraints { message, signature };
         state.add_constraint(10, signed_constraints);
 
@@ -987,7 +987,7 @@ mod tests {
 
         let bls_signer = Signer::random();
         let message = ConstraintsMessage::build(Default::default(), inclusion_request);
-        let signature = bls_signer.sign(&message.digest()).await.unwrap();
+        let signature = bls_signer.sign_commit_boost_root(message.digest()).unwrap();
         let signed_constraints = SignedConstraints { message, signature };
 
         state.add_constraint(target_slot, signed_constraints);
@@ -1035,7 +1035,7 @@ mod tests {
 
         let bls_signer = Signer::random();
         let message = ConstraintsMessage::build(Default::default(), inclusion_request);
-        let signature = bls_signer.sign(&message.digest()).await.unwrap();
+        let signature = bls_signer.sign_commit_boost_root(message.digest()).unwrap();
         let signed_constraints = SignedConstraints { message, signature };
 
         state.add_constraint(target_slot, signed_constraints);
@@ -1082,7 +1082,7 @@ mod tests {
 
         let bls_signer = Signer::random();
         let message = ConstraintsMessage::build(Default::default(), inclusion_request);
-        let signature = bls_signer.sign(&message.digest()).await.unwrap();
+        let signature = bls_signer.sign_commit_boost_root(message.digest()).unwrap();
         let signed_constraints = SignedConstraints { message, signature };
 
         state.add_constraint(target_slot, signed_constraints);


### PR DESCRIPTION
Signing and verifying messages with BLS keys now complies to the consensus-layer signing domains spec.
In particular, two signing domains are provided: `APPLICATION_BUILDER` and `COMMIT_BOOST`.

Signers are able to sign() or verify() messages in both domains explicitly to avoid incurring in inconsistencies.

Note: the beacon-chain specs also define signing over SSZ containers via hash_tree_root. We currently don't do that, and have decided to use our own signing digests that are simpler and don't require deriving SSZ. Since this is an out-of-protocol API we are not required to comply to this restriction.