### PR TITLE
Document on-chain registration

### DIFF
--- a/testnets/holesky/README.md
+++ b/testnets/holesky/README.md
@@ -67,6 +67,9 @@ client implementations to download and run them.
 >    --builder-fallback-disable-checks
 >    ```
 >
+> In other clients like Vouch, the same can be achieved by setting the `builder-boost-factor` to a large value
+> like 18446744073709551615.
+>
 > It might be necessary to restart your beacon node depending on your existing
 > setup. See the [Avoid Restarting the Beacon
 > Node](#avoid-restarting-the-beacon-node) for more details.
@@ -124,17 +127,20 @@ containing the necessary environment variables:
    cp ./bolt-sidecar/Config.example.toml ./testnets/holesky/bolt-sidecar.toml
    ```
 
-   For proper configuration of the signing
-   options, please refer to the [Delegations and
+   Next up, fill out all the values that are required. For proper configuration
+   of the signing options, please refer to the [Delegations and
    Signing](#delegations-and-signing-options-for-native-and-docker-compose-mode)
    section of this guide.
 
 2. **MEV-Boost Configuration:**
 
-   Similarly, create a `mev-boost.env` file in the
-   `testnets/holesky` folder to configure the MEV-Boost service. If you need a
-   reference, you can use the `.env.example` file in the `mev-boost` directory as a
-   starting point.
+   Copy over the example environment file:
+
+   ```bash
+   cp ../../mev-boost/.env.example mev-boost.env
+   ```
+
+   Then configure the file accordingly.
 
    ```bash
    cp ./mev-boost/.env.example ./testnets/holesky/mev-boost.env

--- a/testnets/holesky/README.md
+++ b/testnets/holesky/README.md
@@ -104,7 +104,7 @@ First, make sure to have both [Docker](https://docs.docker.com/engine/install/),
 Then clone the Bolt repository by running:
 
 ```bash
-git clone --branch v0.3.0 htts://github.com/chainbound/bolt.git && cd bolt
+git clone --branch v0.3.0-alpha htts://github.com/chainbound/bolt.git && cd bolt
 ```
 
 The Docker Compose setup will spin up the Bolt sidecar along with the Bolt

--- a/testnets/holesky/README.md
+++ b/testnets/holesky/README.md
@@ -443,8 +443,9 @@ directory.
 
 - Next up, decide on a controller account and save the key in an environment
   variable: `export CONTROLLER_KEY=0x...`. This controller key will be used to run
-  the script and will mark the corresponding account as the controller account for
-  these validators.
+  the script and will mark the corresponding account as the [controller
+  account](https://github.com/chainbound/bolt/blob/06bdd8e75d759d91f6178ad73f962b1f4ad43fd8/bolt-contracts/src/interfaces/IBoltValidatorsV1.sol#L18-L19)
+  for these validators.
 
 - Finally, run the script:
 

--- a/testnets/holesky/README.md
+++ b/testnets/holesky/README.md
@@ -5,7 +5,7 @@ This document provides instructions for running the Bolt sidecar on the Holesky 
 <!-- vim-markdown-toc Marked -->
 
 * [Prerequisites](#prerequisites)
-* [Setup](#setup)
+* [Off-Chain Setup](#off-chain-setup)
   * [Docker Mode (recommended)](#docker-mode-(recommended))
   * [Commit-Boost Mode](#commit-boost-mode)
   * [Native Mode (advanced)](#native-mode-(advanced))
@@ -13,7 +13,7 @@ This document provides instructions for running the Bolt sidecar on the Holesky 
     * [Building and running the Bolt sidecar binary](#building-and-running-the-bolt-sidecar-binary)
       * [Configuration file](#configuration-file)
     * [Observability](#observability)
-* [Register your validators on-chain on the Bolt Registry](#register-your-validators-on-chain-on-the-bolt-registry)
+* [On-Chain Registration](#on-chain-registration)
   * [Validator Registration](#validator-registration)
   * [Bolt Network Entrypoint](#bolt-network-entrypoint)
     * [Symbiotic Integration guide for Staking Pools](#symbiotic-integration-guide-for-staking-pools)
@@ -33,7 +33,7 @@ This document provides instructions for running the Bolt sidecar on the Holesky 
 
 # Prerequisites
 
-In order to run Bolt you need some components already installed and running in
+In order to run Bolt you need some components already installed and running on
 your system.
 
 **A synced Geth client:**
@@ -76,13 +76,7 @@ client implementations to download and run them.
 The Bolt sidecar requires signing keys from active Ethereum validators, or
 authorized delegates acting on their behalf, to issue and sign preconfirmations.
 
-**LST collateral:**
-
-For Holesky in order to provide credible proposer commitments it is necessary to
-restake 1 ether worth of ETH derivatives per validator in either the Symbiotic
-or the EigenLayer protocol.
-
-# Setup
+# Off-Chain Setup
 
 There are various way to run the Bolt Sidecar depending on what infrastructure
 you want to use and your preferred signing methods:
@@ -157,8 +151,7 @@ cd testnets/holesky && docker compose up -d
 ```
 
 The docker compose setup comes with various observability tools, such as
-Prometheus and Grafana. It also comes with some pre-built dashboards, which can
-be found in the `grafana` directory.
+Prometheus and Grafana. It also comes with some pre-built dashboards which you can find at `http://localhost:3000`.
 
 ## Commit-Boost Mode
 
@@ -344,7 +337,7 @@ To update these dashboards, run the following command:
 In this directory, you can also find a Bolt dashboard, which will be launched
 alongside the other dashboards.
 
-# Register your validators on-chain on the Bolt Registry
+# On-Chain Registration
 
 Once you are successfully running the Bolt sidecar you need to register on-chain
 on the Bolt Registry to successfully receive preconfirmation requests from users


### PR DESCRIPTION
Provides the steps required for the on-chain registration of Validators and Operators in the Holesky guide.