### PR TITLE
chore: deploy EL middleware upgrade script

### DIFF
--- a/bolt-contracts/script/holesky/admin/Upgrade.s.sol
+++ b/bolt-contracts/script/holesky/admin/Upgrade.s.sol
@@ -28,6 +28,7 @@ contract UpgradeBolt is Script {
         address eigenLayerAVSDirectory;
         address eigenLayerDelegationManager;
         address eigenLayerStrategyManager;
+        address eigenLayerMiddleware;
         address[] supportedStrategies;
     }
 
@@ -79,12 +80,6 @@ contract UpgradeBolt is Script {
 
         string memory upgradeTo = "BoltEigenLayerMiddlewareV2.sol";
 
-        string memory root = vm.projectRoot();
-        string memory path = string.concat(root, "/config/holesky/deployments.json");
-        string memory json = vm.readFile(path);
-
-        address middlewareV1 = vm.parseJsonAddress(json, ".eigenLayer.middleware");
-
         Deployments memory deployments = _readDeployments();
 
         bytes memory initEigenLayerMiddleware = abi.encodeCall(
@@ -101,7 +96,7 @@ contract UpgradeBolt is Script {
 
         vm.startBroadcast(admin);
 
-        Upgrades.upgradeProxy(middlewareV1, upgradeTo, initEigenLayerMiddleware, opts);
+        Upgrades.upgradeProxy(deployments.eigenLayerMiddleware, upgradeTo, initEigenLayerMiddleware, opts);
 
         vm.stopBroadcast();
 
@@ -125,6 +120,7 @@ contract UpgradeBolt is Script {
             eigenLayerAVSDirectory: vm.parseJsonAddress(json, ".eigenLayer.avsDirectory"),
             eigenLayerDelegationManager: vm.parseJsonAddress(json, ".eigenLayer.delegationManager"),
             eigenLayerStrategyManager: vm.parseJsonAddress(json, ".eigenLayer.strategyManager"),
+            eigenLayerMiddleware: vm.parseJsonAddress(json, ".eigenLayer.middleware"),
             supportedStrategies: vm.parseJsonAddressArray(json, ".eigenLayer.supportedStrategies")
         });
     }

--- a/bolt-contracts/script/holesky/admin/Upgrade.s.sol
+++ b/bolt-contracts/script/holesky/admin/Upgrade.s.sol
@@ -83,7 +83,7 @@ contract UpgradeBolt is Script {
         Deployments memory deployments = _readDeployments();
 
         bytes memory initEigenLayerMiddleware = abi.encodeCall(
-            BoltEigenLayerMiddlewareV2.initialize,
+            BoltEigenLayerMiddlewareV2.initializeV2,
             (
                 admin,
                 deployments.boltParameters,

--- a/bolt-contracts/src/contracts/BoltEigenLayerMiddlewareV1.sol
+++ b/bolt-contracts/src/contracts/BoltEigenLayerMiddlewareV1.sol
@@ -23,7 +23,7 @@ import {AVSDirectoryStorage} from "@eigenlayer/src/contracts/core/AVSDirectorySt
 import {DelegationManagerStorage} from "@eigenlayer/src/contracts/core/DelegationManagerStorage.sol";
 import {StrategyManagerStorage} from "@eigenlayer/src/contracts/core/StrategyManagerStorage.sol";
 
-/// @title Bolt Manager
+/// @title Bolt EigenLayer Middleware contract.
 /// @notice This contract is responsible for interfacing with the EigenLayer restaking protocol.
 /// @dev This contract is upgradeable using the UUPSProxy pattern. Storage layout remains fixed across upgrades
 /// with the use of storage gaps.

--- a/bolt-contracts/src/contracts/BoltEigenLayerMiddlewareV2.sol
+++ b/bolt-contracts/src/contracts/BoltEigenLayerMiddlewareV2.sol
@@ -24,7 +24,7 @@ import {AVSDirectoryStorage} from "@eigenlayer/src/contracts/core/AVSDirectorySt
 import {DelegationManagerStorage} from "@eigenlayer/src/contracts/core/DelegationManagerStorage.sol";
 import {StrategyManagerStorage} from "@eigenlayer/src/contracts/core/StrategyManagerStorage.sol";
 
-/// @title Bolt Manager
+/// @title Bolt EigenLayer Middleware contract.
 /// @notice This contract is responsible for interfacing with the EigenLayer restaking protocol.
 /// @dev This contract is upgradeable using the UUPSProxy pattern. Storage layout remains fixed across upgrades
 /// with the use of storage gaps.

--- a/bolt-contracts/src/contracts/BoltEigenLayerMiddlewareV2.sol
+++ b/bolt-contracts/src/contracts/BoltEigenLayerMiddlewareV2.sol
@@ -107,6 +107,25 @@ contract BoltEigenLayerMiddlewareV2 is IBoltMiddlewareV1, IServiceManager, Ownab
         NAME_HASH = keccak256("EIGENLAYER");
     }
 
+    function initializeV2(
+        address _owner,
+        address _parameters,
+        address _manager,
+        address _eigenlayerAVSDirectory,
+        address _eigenlayerDelegationManager,
+        address _eigenlayerStrategyManager
+    ) public reinitializer(2) {
+        __Ownable_init(_owner);
+        parameters = IBoltParametersV1(_parameters);
+        manager = IBoltManagerV1(_manager);
+        START_TIMESTAMP = Time.timestamp();
+
+        AVS_DIRECTORY = IAVSDirectory(_eigenlayerAVSDirectory);
+        DELEGATION_MANAGER = DelegationManagerStorage(_eigenlayerDelegationManager);
+        STRATEGY_MANAGER = StrategyManagerStorage(_eigenlayerStrategyManager);
+        NAME_HASH = keccak256("EIGENLAYER");
+    }
+
     function _authorizeUpgrade(
         address newImplementation
     ) internal override onlyOwner {}


### PR DESCRIPTION
Added script to deploy a new version of the EigenLayer middleware contract.

Since storage layouts are the same, the upgrade has been carried out on Holesky.
Contract deployed at `0xA053dedd4F94DeD42B30487fFD6ABb9d2C4EB17F`

```text
❯ forge inspect BoltEigenLayerMiddlewareV1 storage-layout --pretty
| Name               | Type                                  | Slot | Offset | Bytes | Contract                                                                |
|--------------------|---------------------------------------|------|--------|-------|-------------------------------------------------------------------------|
| START_TIMESTAMP    | uint48                                | 0    | 0      | 6     | src/contracts/BoltEigenLayerMiddlewareV1.sol:BoltEigenLayerMiddlewareV1 |
| parameters         | contract IBoltParametersV1            | 0    | 6      | 20    | src/contracts/BoltEigenLayerMiddlewareV1.sol:BoltEigenLayerMiddlewareV1 |
| manager            | contract IBoltManagerV1               | 1    | 0      | 20    | src/contracts/BoltEigenLayerMiddlewareV1.sol:BoltEigenLayerMiddlewareV1 |
| strategies         | struct EnumerableMap.AddressToUintMap | 2    | 0      | 96    | src/contracts/BoltEigenLayerMiddlewareV1.sol:BoltEigenLayerMiddlewareV1 |
| AVS_DIRECTORY      | contract IAVSDirectory                | 5    | 0      | 20    | src/contracts/BoltEigenLayerMiddlewareV1.sol:BoltEigenLayerMiddlewareV1 |
| DELEGATION_MANAGER | contract DelegationManagerStorage     | 6    | 0      | 20    | src/contracts/BoltEigenLayerMiddlewareV1.sol:BoltEigenLayerMiddlewareV1 |
| STRATEGY_MANAGER   | contract StrategyManagerStorage       | 7    | 0      | 20    | src/contracts/BoltEigenLayerMiddlewareV1.sol:BoltEigenLayerMiddlewareV1 |
| NAME_HASH          | bytes32                               | 8    | 0      | 32    | src/contracts/BoltEigenLayerMiddlewareV1.sol:BoltEigenLayerMiddlewareV1 |
| __gap              | uint256[41]                           | 9    | 0      | 1312  | src/contracts/BoltEigenLayerMiddlewareV1.sol:BoltEigenLayerMiddlewareV1 |

❯ forge inspect BoltEigenLayerMiddlewareV2 storage-layout --pretty
| Name               | Type                                  | Slot | Offset | Bytes | Contract                                                                |
|--------------------|---------------------------------------|------|--------|-------|-------------------------------------------------------------------------|
| START_TIMESTAMP    | uint48                                | 0    | 0      | 6     | src/contracts/BoltEigenLayerMiddlewareV2.sol:BoltEigenLayerMiddlewareV2 |
| parameters         | contract IBoltParametersV1            | 0    | 6      | 20    | src/contracts/BoltEigenLayerMiddlewareV2.sol:BoltEigenLayerMiddlewareV2 |
| manager            | contract IBoltManagerV1               | 1    | 0      | 20    | src/contracts/BoltEigenLayerMiddlewareV2.sol:BoltEigenLayerMiddlewareV2 |
| strategies         | struct EnumerableMap.AddressToUintMap | 2    | 0      | 96    | src/contracts/BoltEigenLayerMiddlewareV2.sol:BoltEigenLayerMiddlewareV2 |
| AVS_DIRECTORY      | contract IAVSDirectory                | 5    | 0      | 20    | src/contracts/BoltEigenLayerMiddlewareV2.sol:BoltEigenLayerMiddlewareV2 |
| DELEGATION_MANAGER | contract DelegationManagerStorage     | 6    | 0      | 20    | src/contracts/BoltEigenLayerMiddlewareV2.sol:BoltEigenLayerMiddlewareV2 |
| STRATEGY_MANAGER   | contract StrategyManagerStorage       | 7    | 0      | 20    | src/contracts/BoltEigenLayerMiddlewareV2.sol:BoltEigenLayerMiddlewareV2 |
| NAME_HASH          | bytes32                               | 8    | 0      | 32    | src/contracts/BoltEigenLayerMiddlewareV2.sol:BoltEigenLayerMiddlewareV2 |
| __gap              | uint256[41]                           | 9    | 0      | 1312  | src/contracts/BoltEigenLayerMiddlewareV2.sol:BoltEigenLayerMiddlewareV2 |
```