### PR TITLE
feat: run devnet with configurable environments

### DIFF
--- a/justfile
+++ b/justfile
@@ -15,9 +15,9 @@ demo:
 	./scripts/start-demo.sh
 
 # spin up the bolt devnet
-up:
+up env='latest':
 	chmod +x ./scripts/start-devnet.sh
-	./scripts/start-devnet.sh
+	./scripts/start-devnet.sh {{env}}
 
 # turn down the bolt devnet and remove the enclave
 down:

--- a/scripts/.gitignore
+++ b/scripts/.gitignore
@@ -1,0 +1,1 @@
+kurtosis_config.yaml

--- a/scripts/kurtosis_config.template.yaml
+++ b/scripts/kurtosis_config.template.yaml
@@ -9,15 +9,7 @@ additional_services:
   - tx_spammer
   - blockscout
   - dora
-  # - assertoor
-  # - blob_spammer
-  # - custom_flood
-  # - goomy_blob
-  # - el_forkmon
-  # - beacon_metrics_gazer
-  # - full_beaconchain_explorer
   - prometheus_grafana
-  # - blobscan
 
 mev_type: full
 
@@ -26,12 +18,12 @@ mev_params:
   # Bolt-specific images:
   # Adding the `bolt_boost_image` will start the devnet with Bolt-Boost
   # instead of MEV-Boost by Flashbots
-  bolt_boost_image: ghcr.io/chainbound/bolt-boost:0.1.0
-  bolt_sidecar_image: ghcr.io/chainbound/bolt-sidecar:0.1.0
-  helix_relay_image: ghcr.io/chainbound/helix:0.1.0
-  mev_relay_image: ghcr.io/chainbound/bolt-relay:0.1.0
-  mev_builder_image: ghcr.io/chainbound/bolt-builder:0.1.0
-  mev_boost_image: ghcr.io/chainbound/bolt-mev-boost:0.1.0
+  bolt_boost_image: ghcr.io/chainbound/bolt-boost:$TAG
+  bolt_sidecar_image: ghcr.io/chainbound/bolt-sidecar:$TAG
+  helix_relay_image: ghcr.io/chainbound/helix:$TAG
+  mev_relay_image: ghcr.io/chainbound/bolt-relay:$TAG
+  mev_builder_image: ghcr.io/chainbound/bolt-builder:$TAG
+  mev_boost_image: ghcr.io/chainbound/bolt-mev-boost:$TAG
 
   mev_boost_args: []
   mev_relay_api_extra_args: []

--- a/scripts/start-devnet.sh
+++ b/scripts/start-devnet.sh
@@ -1,26 +1,18 @@
 #!/bin/bash
 
-echo "Starting the devnet..."
+ENV=$1
+
+if [ -z "$ENV" ]; then
+  echo "Usage: start-devnet.sh <ENV>"
+  exit 1
+fi
+
+echo "Starting the devnet on $ENV..."
+
+# the environment needs to match the image tags in the kurtosis config file
+sed "s/\$TAG/$ENV/g" ./scripts/kurtosis_config.template.yaml > ./scripts/kurtosis_config.yaml
 
 # spin up the kurtosis devnet
 kurtosis run --enclave bolt-devnet github.com/chainbound/ethereum-package@bolt --args-file ./scripts/kurtosis_config.yaml
-echo "Devnet online! Waiting for the RPC to be available..."
-sleep 5
 
-RPC=$(kurtosis port print bolt-devnet el-1-geth-lighthouse rpc)
-PK="bcdf20249abf0ed6d944c0288fad489e33f66b3960d9e6229c1cd214ed3bbe31"
-echo "RPC endpoint: $RPC"
-
-# wait for the rpc to be available
-while ! curl -s -X POST --data '{"jsonrpc":"2.0","method":"eth_blockNumber","params":[],"id":1}' "$RPC" >/dev/null; do
-	sleep 1
-done
-
-# TODO: re-add after new registry, challenger and staking contracts are available
-# deploy the contracts
-# (
-# 	cd ./bolt-contracts || exit
-# 	forge build # make sure the contracts are compiled before deploying
-# 	forge script script/DeployOnDevnet.s.sol --broadcast --rpc-url "$RPC" --private-key "$PK"
-# )
-# echo "Contracts deployed!"
+echo "Devnet started!"


### PR DESCRIPTION
This PR tries to address a shortcoming: running the Bolt devnet with all of its components locally can be difficult as we don't have all the components in the same repository.

Right now we require building helix, mev-boost, and builder as external images, and we assume users trying to run the devnet are also doing that themselves. 

This is not robust. A better solution is to add a parameter to the `just up` recipe, defaulting to "latest" meaning that the kurtosis devnet will try to use the latest released version of all images and components. 

Then, we can set it to something like "local" (e.g. `just up local`) to specify that we want to use locally-built images tagged with `:local` instead of `:latest`.

The next step in terms of UX is to add a simple way to explain what images one needs to build each time, but this will be restricted to devs actively working on those components instead of anyone trying to just get up and running.