### PR TITLE
`enable-unsafe-lookahead` flag

### DIFF
--- a/bolt-sidecar/bin/sidecar.rs
+++ b/bolt-sidecar/bin/sidecar.rs
@@ -40,6 +40,4 @@ async fn main() -> Result<()> {
             }
         }
     }
-
-    Ok(())
 }

--- a/bolt-sidecar/src/builder/signature.rs
+++ b/bolt-sidecar/src/builder/signature.rs
@@ -122,25 +122,25 @@ mod tests {
     fn test_compute_builder_domain() {
         let mainnet = ChainConfig::mainnet();
         assert_eq!(
-            compute_builder_domain(mainnet.fork_version(), None),
+            compute_builder_domain(mainnet.chain.fork_version(), None),
             mainnet.application_builder_domain()
         );
 
         let holesky = ChainConfig::holesky();
         assert_eq!(
-            compute_builder_domain(holesky.fork_version(), None),
+            compute_builder_domain(holesky.chain.fork_version(), None),
             holesky.application_builder_domain()
         );
 
         let kurtosis = ChainConfig::kurtosis(0, 0);
         assert_eq!(
-            compute_builder_domain(kurtosis.fork_version(), None),
+            compute_builder_domain(kurtosis.chain.fork_version(), None),
             kurtosis.application_builder_domain()
         );
 
         let helder = ChainConfig::helder();
         assert_eq!(
-            compute_builder_domain(helder.fork_version(), None),
+            compute_builder_domain(helder.chain.fork_version(), None),
             helder.application_builder_domain()
         );
     }

--- a/bolt-sidecar/src/driver.rs
+++ b/bolt-sidecar/src/driver.rs
@@ -176,6 +176,7 @@ impl<C: StateFetcher, ECDSA: SignerECDSA> SidecarDriver<C, ECDSA> {
             beacon_client,
             opts.validator_indexes.clone(),
             opts.chain.commitment_deadline(),
+            opts.chain.enable_unsafe_lookahead,
         );
 
         let (payload_requests_tx, payload_requests_rx) = mpsc::channel(16);

--- a/bolt-sidecar/src/state/consensus.rs
+++ b/bolt-sidecar/src/state/consensus.rs
@@ -107,8 +107,8 @@ impl ConsensusState {
         }
 
         // If the request is for the next slot, check if it's within the commitment deadline
-        if req.slot == self.latest_slot + 1 &&
-            self.latest_slot_timestamp + self.commitment_deadline_duration < Instant::now()
+        if req.slot == self.latest_slot + 1
+            && self.latest_slot_timestamp + self.commitment_deadline_duration < Instant::now()
         {
             return Err(ConsensusError::DeadlineExceeded);
         }

--- a/bolt-sidecar/src/state/consensus.rs
+++ b/bolt-sidecar/src/state/consensus.rs
@@ -64,7 +64,7 @@ pub struct ConsensusState {
     pub commitment_deadline: CommitmentDeadline,
     /// The duration of the commitment deadline.
     commitment_deadline_duration: Duration,
-    /// If commitment requests should be validated against also against the unsafe lookahead
+    /// If commitment requests should be validated also against the unsafe lookahead
     pub unsafe_lookahead_enabled: bool,
 }
 


### PR DESCRIPTION
Introduces a new `enable-unsafe-lookahead` flag in configuration that allows to validate commitment requests along two consecutive epochs instead of just the current one.