### PR TITLE
Integrate with the Bolt registry to check if pubkeys are registered

### DIFF
--- a/.github/.linkspector.yml
+++ b/.github/.linkspector.yml
@@ -6,3 +6,7 @@ excludedDirs:
   - testnets/helder
 
 useGitIgnore: true
+
+ignorePatterns:
+  - pattern: "^https://.*etherscan.io/.*$"
+

--- a/bolt-sidecar/src/chain_io/manager.rs
+++ b/bolt-sidecar/src/chain_io/manager.rs
@@ -97,16 +97,15 @@ impl BoltManager {
             },
         };
 
-        if matches!(error, BoltManagerContractErrors::ValidatorDoesNotExist(_)) {
-            // TODO: improve this error message once https://github.com/chainbound/bolt/issues/338
-            // is solved
-            bail!("not all validators are registered in Bolt");
-        } else {
-            Err(SolError::custom(format!(
+        match error {
+            BoltManagerContractErrors::ValidatorDoesNotExist(pubkey_hash) => {
+                bail!("validator with public key hash {:?} is not registered in Bolt", pubkey_hash);
+            }
+            e => Err(SolError::custom(format!(
                 "unexpected Solidity error selector: {:?}",
-                error.selector()
+                e.selector()
             ))
-            .into())
+            .into()),
         }
     }
 }
@@ -130,6 +129,7 @@ sol! {
         function isOperator(address operator) external view returns (bool isOperator);
 
         error InvalidQuery();
-        error ValidatorDoesNotExist();
+        #[derive(Debug)]
+        error ValidatorDoesNotExist(bytes20 pubkeyHash);
     }
 }

--- a/bolt-sidecar/src/chain_io/manager.rs
+++ b/bolt-sidecar/src/chain_io/manager.rs
@@ -64,12 +64,11 @@ impl BoltManager {
                             status.pubkeyHash
                         );
                     } else if status.operator != commitment_signer_pubkey {
-                        bail!(
-                            "mismatch between commitment signer public key and authorized operator address for validator with public key hash {:?} in Bolt.\n - commitment signer public key: {:?}\n - authorized operator address: {:?}",
+                        bail!(generate_operator_keys_mismatch_error(
                             status.pubkeyHash,
                             commitment_signer_pubkey,
                             status.operator
-                        );
+                        ));
                     }
                 }
 
@@ -101,13 +100,26 @@ impl BoltManager {
     }
 }
 
+fn generate_operator_keys_mismatch_error(
+    pubkey_hash: CompressedHash,
+    commitment_signer_pubkey: Address,
+    operator: Address,
+) -> String {
+    format!(
+        "mismatch between commitment signer public key and authorized operator address for validator with public key hash {:?} in Bolt.\n - commitment signer public key: {:?}\n - authorized operator address: {:?}",
+        pubkey_hash,
+        commitment_signer_pubkey,
+        operator
+    )
+}
+
 sol! {
     #[allow(missing_docs)]
     #[sol(rpc)]
     interface BoltManagerContract {
         #[derive(Debug, Default, Serialize)]
         struct ProposerStatus {
-            bytes32 pubkeyHash;
+            bytes20 pubkeyHash;
             bool active;
             address operator;
             string operatorRPC;
@@ -115,7 +127,7 @@ sol! {
             uint256[] amounts;
         }
 
-        function getProposerStatuses(bytes32[] calldata pubkeyHashes) public view returns (ProposerStatus[] memory statuses);
+        function getProposerStatuses(bytes20[] calldata pubkeyHashes) public view returns (ProposerStatus[] memory statuses);
 
         function isOperator(address operator) external view returns (bool isOperator);
 

--- a/bolt-sidecar/src/chain_io/manager.rs
+++ b/bolt-sidecar/src/chain_io/manager.rs
@@ -2,7 +2,7 @@ use std::str::FromStr;
 
 use alloy::{
     contract::Error as ContractError,
-    primitives::{Address, Bytes, B256, B512},
+    primitives::{Address, Bytes},
     providers::{ProviderBuilder, RootProvider},
     sol,
     sol_types::{Error as SolError, SolInterface},
@@ -11,33 +11,23 @@ use alloy::{
 use ethereum_consensus::primitives::BlsPublicKey;
 use eyre::bail;
 use reqwest::{Client, Url};
-use reth_primitives::keccak256;
 use serde::Serialize;
 
 use BoltManagerContract::{BoltManagerContractErrors, BoltManagerContractInstance, ProposerStatus};
 
 use crate::config::chain::Chain;
 
+use super::utils;
+
 /// A wrapper over a BoltManagerContract that exposes various utility methods.
 #[derive(Debug, Clone)]
 pub struct BoltManager(BoltManagerContractInstance<Http<Client>, RootProvider<Http<Client>>>);
 
 impl BoltManager {
-    /// Returns the address of the canonical BoltManager contract for a given chain, if present
-    pub fn address(chain: Chain) -> Option<Address> {
-        match chain {
-            Chain::Holesky => Some(
-                Address::from_str("0x440202829b493F9FF43E730EB5e8379EEa3678CF")
-                    .expect("valid address"),
-            ),
-            _ => None,
-        }
-    }
-
     /// Creates a new BoltRegistry instance. Returns `None` if a canonical BoltManager contract is
     /// not deployed on such chain.
     pub fn from_chain<U: Into<Url>>(execution_client_url: U, chain: Chain) -> Option<Self> {
-        let address = Self::address(chain)?;
+        let address = chain.manager_address()?;
         Some(Self::from_address(execution_client_url, address))
     }
 
@@ -66,7 +56,7 @@ impl BoltManager {
         &self,
         keys: &[BlsPublicKey],
     ) -> eyre::Result<Vec<ProposerStatus>> {
-        let hashes = BoltValidators::pubkey_hashes(keys);
+        let hashes = utils::pubkey_hashes(keys);
 
         let returndata = self.0.getProposerStatuses(hashes).call().await;
 
@@ -110,37 +100,8 @@ impl BoltManager {
     }
 }
 
-/// Utility functions related to the BoltValidators contract
-pub struct BoltValidators;
-
-impl BoltValidators {
-    /// Hash the public keys of the proposers. This follows the same
-    /// implementation done on-chain in the BoltValidators contract.
-    pub fn pubkey_hashes(keys: &[BlsPublicKey]) -> Vec<B256> {
-        keys.iter().map(Self::pubkey_hash).collect()
-    }
-
-    /// Hash the public key of the proposer. This follows the same
-    /// implementation done on-chain in the BoltValidators contract.
-    pub fn pubkey_hash(key: &BlsPublicKey) -> B256 {
-        let digest = Self::pubkey_hash_digest(key);
-        keccak256(digest)
-    }
-
-    fn pubkey_hash_digest(key: &BlsPublicKey) -> B512 {
-        let mut onchain_pubkey_repr = B512::ZERO;
-
-        // copy the pubkey bytes into the rightmost 48 bytes of the 512-bit buffer.
-        // the result should look like this:
-        //
-        // 0x00000000000000000000000000000000b427fd179b35ef085409e4a98fb3ab84ee29c689df5c64020eab0b20a4f91170f610177db172dc091682df627c9f4021
-        // |<---------- 16 bytes ---------->||<----------------------------------------- 48 bytes ----------------------------------------->|
-        onchain_pubkey_repr[16..].copy_from_slice(key);
-        onchain_pubkey_repr
-    }
-}
-
 sol! {
+    #[allow(missing_docs)]
     #[sol(rpc)]
     interface BoltManagerContract {
         #[derive(Debug, Default, Serialize)]

--- a/bolt-sidecar/src/chain_io/mod.rs
+++ b/bolt-sidecar/src/chain_io/mod.rs
@@ -1,0 +1,5 @@
+/// Wrapper over the BoltManager contract
+pub mod manager;
+
+/// Utilities and functions used in the Bolt contracts
+pub mod utils;

--- a/bolt-sidecar/src/chain_io/utils.rs
+++ b/bolt-sidecar/src/chain_io/utils.rs
@@ -4,7 +4,7 @@ use reth_primitives::keccak256;
 
 /// A 20-byte compressed hash of a BLS public key.
 ///
-/// Reference: https://github.com/chainbound/bolt/blob/lore/feat/holesky-launch/bolt-contracts/script/holesky/validators/registervalidators.s.sol#l65-l69.
+/// Reference: https://github.com/chainbound/bolt/blob/bec46baae6d7c16dddd81e5e72710ca8e3064f82/bolt-contracts/script/holesky/validators/RegisterValidators.s.sol#L65-L69
 pub(crate) type CompressedHash = FixedBytes<20>;
 
 /// Hash the public keys of the proposers. This follows the same
@@ -16,11 +16,11 @@ pub fn pubkey_hashes(keys: &[BlsPublicKey]) -> Vec<CompressedHash> {
 /// Hash the public key of the proposer. This follows the same
 /// implementation done on-chain in the BoltValidators contract.
 ///
-/// Reference: https://github.com/chainbound/bolt/blob/lore/feat/holesky-launch/bolt-contracts/script/holesky/validators/registervalidators.s.sol#l65-l69
+/// Reference: https://github.com/chainbound/bolt/blob/bec46baae6d7c16dddd81e5e72710ca8e3064f82/bolt-contracts/script/holesky/validators/RegisterValidators.s.sol#L65-L69
 pub fn pubkey_hash(key: &BlsPublicKey) -> CompressedHash {
     let digest = pubkey_hash_digest(key);
     let hash = keccak256(digest);
-    FixedBytes::<20>::from_slice(hash.get(0..20).expect("hash is longer than 20 bytes"))
+    CompressedHash::from_slice(hash.get(0..20).expect("hash is longer than 20 bytes"))
 }
 
 fn pubkey_hash_digest(key: &BlsPublicKey) -> B512 {

--- a/bolt-sidecar/src/chain_io/utils.rs
+++ b/bolt-sidecar/src/chain_io/utils.rs
@@ -1,18 +1,26 @@
-use alloy::primitives::{B256, B512};
+use alloy::primitives::{FixedBytes, B512};
 use ethereum_consensus::primitives::BlsPublicKey;
 use reth_primitives::keccak256;
 
+/// A 20-byte compressed hash of a BLS public key.
+///
+/// Reference: https://github.com/chainbound/bolt/blob/lore/feat/holesky-launch/bolt-contracts/script/holesky/validators/registervalidators.s.sol#l65-l69.
+type CompressedHash = FixedBytes<20>;
+
 /// Hash the public keys of the proposers. This follows the same
 /// implementation done on-chain in the BoltValidators contract.
-pub fn pubkey_hashes(keys: &[BlsPublicKey]) -> Vec<B256> {
+pub fn pubkey_hashes(keys: &[BlsPublicKey]) -> Vec<CompressedHash> {
     keys.iter().map(pubkey_hash).collect()
 }
 
 /// Hash the public key of the proposer. This follows the same
 /// implementation done on-chain in the BoltValidators contract.
-pub fn pubkey_hash(key: &BlsPublicKey) -> B256 {
+///
+/// Reference: https://github.com/chainbound/bolt/blob/lore/feat/holesky-launch/bolt-contracts/script/holesky/validators/registervalidators.s.sol#l65-l69
+pub fn pubkey_hash(key: &BlsPublicKey) -> CompressedHash {
     let digest = pubkey_hash_digest(key);
-    keccak256(digest)
+    let hash = keccak256(digest);
+    FixedBytes::<20>::from_slice(hash.get(0..20).expect("hash is longer than 20 bytes"))
 }
 
 fn pubkey_hash_digest(key: &BlsPublicKey) -> B512 {
@@ -25,4 +33,20 @@ fn pubkey_hash_digest(key: &BlsPublicKey) -> B512 {
     // |<---------- 16 bytes ---------->||<----------------------------------------- 48 bytes ----------------------------------------->|
     onchain_pubkey_repr[16..].copy_from_slice(key);
     onchain_pubkey_repr
+}
+
+#[cfg(test)]
+mod tests {
+    use alloy::hex;
+    use ethereum_consensus::primitives::BlsPublicKey;
+
+    use super::pubkey_hash;
+
+    #[test]
+    fn test_public_key_hash() {
+        let bytes = hex!("87cbbfe6f08a0fd424507726cfcf5b9df2b2fd6b78a65a3d7bb6db946dca3102eb8abae32847d5a9a27e414888414c26").as_ref();
+        let bls_public_key = BlsPublicKey::try_from(bytes).expect("valid bls public key");
+        let hash = pubkey_hash(&bls_public_key);
+        assert_eq!(hex::encode(hash.as_slice()), "cf44d8bca49d695164be6796108cf788d8d056e1");
+    }
 }

--- a/bolt-sidecar/src/chain_io/utils.rs
+++ b/bolt-sidecar/src/chain_io/utils.rs
@@ -1,0 +1,28 @@
+use alloy::primitives::{B256, B512};
+use ethereum_consensus::primitives::BlsPublicKey;
+use reth_primitives::keccak256;
+
+/// Hash the public keys of the proposers. This follows the same
+/// implementation done on-chain in the BoltValidators contract.
+pub fn pubkey_hashes(keys: &[BlsPublicKey]) -> Vec<B256> {
+    keys.iter().map(pubkey_hash).collect()
+}
+
+/// Hash the public key of the proposer. This follows the same
+/// implementation done on-chain in the BoltValidators contract.
+pub fn pubkey_hash(key: &BlsPublicKey) -> B256 {
+    let digest = pubkey_hash_digest(key);
+    keccak256(digest)
+}
+
+fn pubkey_hash_digest(key: &BlsPublicKey) -> B512 {
+    let mut onchain_pubkey_repr = B512::ZERO;
+
+    // copy the pubkey bytes into the rightmost 48 bytes of the 512-bit buffer.
+    // the result should look like this:
+    //
+    // 0x00000000000000000000000000000000b427fd179b35ef085409e4a98fb3ab84ee29c689df5c64020eab0b20a4f91170f610177db172dc091682df627c9f4021
+    // |<---------- 16 bytes ---------->||<----------------------------------------- 48 bytes ----------------------------------------->|
+    onchain_pubkey_repr[16..].copy_from_slice(key);
+    onchain_pubkey_repr
+}

--- a/bolt-sidecar/src/chain_io/utils.rs
+++ b/bolt-sidecar/src/chain_io/utils.rs
@@ -5,7 +5,7 @@ use reth_primitives::keccak256;
 /// A 20-byte compressed hash of a BLS public key.
 ///
 /// Reference: https://github.com/chainbound/bolt/blob/lore/feat/holesky-launch/bolt-contracts/script/holesky/validators/registervalidators.s.sol#l65-l69.
-type CompressedHash = FixedBytes<20>;
+pub(crate) type CompressedHash = FixedBytes<20>;
 
 /// Hash the public keys of the proposers. This follows the same
 /// implementation done on-chain in the BoltValidators contract.

--- a/bolt-sidecar/src/config/chain.rs
+++ b/bolt-sidecar/src/config/chain.rs
@@ -1,11 +1,10 @@
 use core::fmt;
-use std::str::FromStr;
 use std::{
     fmt::{Display, Formatter},
     time::Duration,
 };
 
-use alloy::primitives::Address;
+use alloy::primitives::{address, Address};
 use clap::{Args, ValueEnum};
 use ethereum_consensus::deneb::{compute_fork_data_root, Root};
 use serde::Deserialize;
@@ -32,6 +31,11 @@ pub const DEFAULT_CHAIN_CONFIG: ChainConfig = ChainConfig {
     slot_time: DEFAULT_SLOT_TIME_IN_SECONDS,
     enable_unsafe_lookahead: false,
 };
+
+/// The address of the canonical BoltManager contract for the Holesky chain.
+///
+/// https://holesky.etherscan.io/address/0x440202829b493F9FF43E730EB5e8379EEa3678CF
+pub const MANAGER_ADDRESS_HOLESKY: Address = address!("440202829b493F9FF43E730EB5e8379EEa3678CF");
 
 /// Configuration for the chain the sidecar is running on.
 #[derive(Debug, Clone, Copy, Args, Deserialize)]
@@ -106,12 +110,9 @@ impl Chain {
     }
 
     /// Returns the address of the canonical BoltManager contract for a given chain, if present
-    pub fn manager_address(&self) -> Option<Address> {
+    pub const fn manager_address(&self) -> Option<Address> {
         match self {
-            Chain::Holesky => Some(
-                Address::from_str("0x440202829b493F9FF43E730EB5e8379EEa3678CF")
-                    .expect("valid address"),
-            ),
+            Chain::Holesky => Some(MANAGER_ADDRESS_HOLESKY),
             _ => None,
         }
     }

--- a/bolt-sidecar/src/config/chain.rs
+++ b/bolt-sidecar/src/config/chain.rs
@@ -1,9 +1,11 @@
 use core::fmt;
+use std::str::FromStr;
 use std::{
     fmt::{Display, Formatter},
     time::Duration,
 };
 
+use alloy::primitives::Address;
 use clap::{Args, ValueEnum};
 use ethereum_consensus::deneb::{compute_fork_data_root, Root};
 use serde::Deserialize;
@@ -100,6 +102,17 @@ impl Chain {
             Chain::Holesky => [1, 1, 112, 0],
             Chain::Helder => [16, 0, 0, 0],
             Chain::Kurtosis => [16, 0, 0, 56],
+        }
+    }
+
+    /// Returns the address of the canonical BoltManager contract for a given chain, if present
+    pub fn manager_address(&self) -> Option<Address> {
+        match self {
+            Chain::Holesky => Some(
+                Address::from_str("0x440202829b493F9FF43E730EB5e8379EEa3678CF")
+                    .expect("valid address"),
+            ),
+            _ => None,
         }
     }
 }

--- a/bolt-sidecar/src/crypto/ecdsa.rs
+++ b/bolt-sidecar/src/crypto/ecdsa.rs
@@ -1,6 +1,9 @@
 use std::fmt::Debug;
 
-use alloy::signers::{local::PrivateKeySigner, Signature as AlloySignature, Signer};
+use alloy::{
+    primitives::Address,
+    signers::{local::PrivateKeySigner, Signature as AlloySignature, Signer},
+};
 use secp256k1::{ecdsa::Signature, Message, PublicKey, SecretKey};
 
 /// Trait for any types that can be signed and verified with ECDSA.
@@ -57,12 +60,18 @@ impl ECDSASigner {
 /// A generic signing trait to generate ECDSA signatures.
 #[async_trait::async_trait]
 pub trait SignerECDSA: Send + Debug {
+    /// Returns the public key of the signer.
+    fn public_key(&self) -> Address;
     /// Sign the given hash and return the signature.
     async fn sign_hash(&self, hash: &[u8; 32]) -> eyre::Result<AlloySignature>;
 }
 
 #[async_trait::async_trait]
 impl SignerECDSA for PrivateKeySigner {
+    fn public_key(&self) -> Address {
+        self.address()
+    }
+
     async fn sign_hash(&self, hash: &[u8; 32]) -> eyre::Result<AlloySignature> {
         Ok(Signer::sign_hash(self, hash.into()).await?)
     }

--- a/bolt-sidecar/src/driver.rs
+++ b/bolt-sidecar/src/driver.rs
@@ -166,9 +166,13 @@ impl<C: StateFetcher, ECDSA: SignerECDSA> SidecarDriver<C, ECDSA> {
         if let Some(bolt_manager) =
             BoltManager::from_chain(opts.execution_api_url.clone(), opts.chain.chain)
         {
-            bolt_manager.verify_operator(commitment_signer.public_key()).await?;
+            let commitment_signer_pubkey = commitment_signer.public_key();
+            bolt_manager.verify_operator(commitment_signer_pubkey).await?;
             bolt_manager
-                .verify_validator_pubkeys(&Vec::from_iter(constraint_signer.available_pubkeys()))
+                .verify_validator_pubkeys(
+                    &Vec::from_iter(constraint_signer.available_pubkeys()),
+                    commitment_signer_pubkey,
+                )
                 .await?;
         }
 

--- a/bolt-sidecar/src/driver.rs
+++ b/bolt-sidecar/src/driver.rs
@@ -17,6 +17,7 @@ use tracing::{debug, error, info, warn};
 
 use crate::{
     builder::payload_fetcher::LocalPayloadFetcher,
+    chain_io::manager::BoltManager,
     commitments::{
         server::{CommitmentsApiServer, Event as CommitmentEvent},
         spec::Error as CommitmentError,
@@ -30,8 +31,8 @@ use crate::{
     start_builder_proxy_server,
     state::{fetcher::StateFetcher, ConsensusState, ExecutionState, HeadTracker, StateClient},
     telemetry::ApiMetrics,
-    BoltManager, BuilderProxyConfig, CommitBoostSigner, ConstraintsApi, ConstraintsClient,
-    LocalBuilder, Opts, SignerBLS,
+    BuilderProxyConfig, CommitBoostSigner, ConstraintsApi, ConstraintsClient, LocalBuilder, Opts,
+    SignerBLS,
 };
 
 /// The driver for the sidecar, responsible for managing the main event loop.

--- a/bolt-sidecar/src/driver.rs
+++ b/bolt-sidecar/src/driver.rs
@@ -162,9 +162,9 @@ impl<C: StateFetcher, ECDSA: SignerECDSA> SidecarDriver<C, ECDSA> {
         fetcher: C,
     ) -> eyre::Result<Self> {
         // Verify the operator and validator keys with the bolt manager
-        let bolt_manager =
-            BoltManager::from_chain(opts.execution_api_url.clone(), opts.chain.chain);
-        if let Some(bolt_manager) = bolt_manager {
+        if let Some(bolt_manager) =
+            BoltManager::from_chain(opts.execution_api_url.clone(), opts.chain.chain)
+        {
             bolt_manager.verify_operator(commitment_signer.public_key()).await?;
             bolt_manager
                 .verify_validator_pubkeys(&Vec::from_iter(constraint_signer.available_pubkeys()))

--- a/bolt-sidecar/src/driver.rs
+++ b/bolt-sidecar/src/driver.rs
@@ -167,7 +167,6 @@ impl<C: StateFetcher, ECDSA: SignerECDSA> SidecarDriver<C, ECDSA> {
             BoltManager::from_chain(opts.execution_api_url.clone(), opts.chain.chain)
         {
             let commitment_signer_pubkey = commitment_signer.public_key();
-            bolt_manager.verify_operator(commitment_signer_pubkey).await?;
             bolt_manager
                 .verify_validator_pubkeys(
                     &Vec::from_iter(constraint_signer.available_pubkeys()),

--- a/bolt-sidecar/src/lib.rs
+++ b/bolt-sidecar/src/lib.rs
@@ -48,6 +48,9 @@ pub mod state;
 mod signer;
 pub use signer::{commit_boost::CommitBoostSigner, SignerBLS};
 
+mod onchain_registry;
+pub use onchain_registry::BoltManager;
+
 /// Utilities for testing
 #[cfg(test)]
 mod test_util;

--- a/bolt-sidecar/src/lib.rs
+++ b/bolt-sidecar/src/lib.rs
@@ -48,8 +48,8 @@ pub mod state;
 mod signer;
 pub use signer::{commit_boost::CommitBoostSigner, SignerBLS};
 
-mod onchain_registry;
-pub use onchain_registry::BoltManager;
+/// Utilities and contracts wrappers for interacting with the Bolt registry
+pub mod chain_io;
 
 /// Utilities for testing
 #[cfg(test)]

--- a/bolt-sidecar/src/onchain_registry.rs
+++ b/bolt-sidecar/src/onchain_registry.rs
@@ -1,0 +1,156 @@
+use std::str::FromStr;
+
+use alloy::{
+    contract::{Error as ContractError, Result as ContractResult},
+    primitives::{Address, Bytes},
+    providers::{ProviderBuilder, RootProvider},
+    sol,
+    sol_types::{Error as SolError, SolInterface},
+    transports::{http::Http, TransportError},
+};
+use reqwest::{Client, Url};
+use reth_primitives::B256;
+use serde::Serialize;
+
+use BoltManagerContract::{BoltManagerContractErrors, BoltManagerContractInstance, ProposerStatus};
+
+/// A wrapper over a BoltManagerContract that exposes various utility methods.
+#[derive(Debug, Clone)]
+pub struct BoltManager(BoltManagerContractInstance<Http<Client>, RootProvider<Http<Client>>>);
+
+impl BoltManager {
+    /// Creates a new BoltRegistry instance.
+    pub fn new<U: Into<Url>>(execution_client_url: U, manager_address: Address) -> Self {
+        let provider = ProviderBuilder::new().on_http(execution_client_url.into());
+        let registry = BoltManagerContract::new(manager_address, provider);
+
+        Self(registry)
+    }
+
+    /// Gets the sidecar RPC URL for a given validator index.
+    ///
+    /// Returns Ok(None) if the operator is not found in the registry.
+    pub async fn get_sidecar_rpc_url_for_validator(
+        &self,
+        pubkey_hash: B256,
+    ) -> ContractResult<Option<String>> {
+        let registrant = self.get_proposer_status(pubkey_hash).await?;
+        Ok(registrant.and_then(|r| if r.active { Some(r.operatorRPC) } else { None }))
+    }
+
+    /// Gets the proposer status for a given pubkeyhash.
+    ///
+    /// Returns Ok(None) if the proposer is not found in the registry.
+    pub async fn get_proposer_status(
+        &self,
+        pubkey_hash: B256,
+    ) -> ContractResult<Option<ProposerStatus>> {
+        let returndata = self.0.getProposerStatus(pubkey_hash).call().await;
+
+        // TODO: clean this after https://github.com/alloy-rs/alloy/issues/787 is merged
+        let error = match returndata.map(|data| data._0) {
+            Ok(proposer) => return Ok(Some(proposer)),
+            Err(error) => match error {
+                ContractError::TransportError(TransportError::ErrorResp(err)) => {
+                    let data = err.data.unwrap_or_default();
+                    let data = data.get().trim_matches('"');
+                    let data = Bytes::from_str(data).unwrap_or_default();
+
+                    BoltManagerContractErrors::abi_decode(&data, true)?
+                }
+                e => return Err(e),
+            },
+        };
+
+        if matches!(error, BoltManagerContractErrors::ValidatorDoesNotExist(_)) {
+            Ok(None)
+        } else {
+            Err(SolError::custom(format!(
+                "unexpected Solidity error selector: {:?}",
+                error.selector()
+            ))
+            .into())
+        }
+    }
+}
+
+sol! {
+    #[sol(rpc)]
+    interface BoltManagerContract {
+        #[derive(Debug, Default, Serialize)]
+        struct ProposerStatus {
+            bytes32 pubkeyHash;
+            bool active;
+            address operator;
+            string operatorRPC;
+            address[] collaterals;
+            uint256[] amounts;
+        }
+
+        function getProposerStatus(bytes32 pubkeyHash) external view returns (ProposerStatus memory);
+
+        error InvalidQuery();
+        error ValidatorDoesNotExist();
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::str::FromStr;
+
+    use alloy::primitives::U256;
+
+    use super::*;
+
+    #[tokio::test]
+    async fn test_get_operators_helder() -> eyre::Result<()> {
+        let registry = BoltManager::new(
+            Url::parse("http://remotebeast:4485")?,
+            Address::from_str("0xdF11D829eeC4C192774F3Ec171D822f6Cb4C14d9")?,
+        );
+
+        let sample_pubkey = B256::from_str("0xsamplepubkeyhash").expect("invalid pubkey");
+
+        let registrant = registry.get_proposer_status(sample_pubkey).await;
+        assert!(matches!(registrant, Ok(None)));
+
+        let invalid_pubkey = B256::from_str("0xinvalidsamplepubkeyhash").expect("invalid pubkey");
+        let registrant = match registry.get_proposer_status(invalid_pubkey).await {
+            Ok(Some(registrant)) => registrant,
+            e => panic!("unexpected error reading from registry: {:?}", e),
+        };
+
+        let expected = ProposerStatus {
+            pubkeyHash: sample_pubkey,
+            active: true,
+            operator: Address::from_str("0xad3cd1b81c80f4a495d6552ae6423508492a27f8")?,
+            operatorRPC: "http://sampleoperatorrpc:8000".to_string(),
+            collaterals: vec![Address::from_str("0xsamplecollateral1")?],
+            amounts: vec![U256::from(10000000000000000000u128)],
+        };
+
+        assert_eq!(registrant.pubkeyHash, expected.pubkeyHash);
+        assert_eq!(registrant.active, expected.active);
+        assert_eq!(registrant.operator, expected.operator);
+        assert_eq!(registrant.operatorRPC, expected.operatorRPC);
+        assert_eq!(registrant.collaterals, expected.collaterals);
+        assert_eq!(registrant.amounts, expected.amounts);
+
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_check_validator_helder() -> eyre::Result<()> {
+        let registry = BoltManager::new(
+            Url::parse("http://remotebeast:4485")?,
+            Address::from_str("0xdF11D829eeC4C192774F3Ec171D822f6Cb4C14d9")?,
+        );
+
+        let pubkey_hash = B256::from_str("0xsamplepubkeyhash").expect("invalid pubkey");
+        let registrant = registry.get_sidecar_rpc_url_for_validator(pubkey_hash).await?;
+        assert!(registrant.is_some());
+
+        dbg!(&registrant);
+        Ok(())
+    }
+}

--- a/bolt-sidecar/src/onchain_registry.rs
+++ b/bolt-sidecar/src/onchain_registry.rs
@@ -72,6 +72,13 @@ impl BoltManager {
             .into())
         }
     }
+
+    /// Checks if an address is an operator registered in Bolt.
+    pub async fn is_operator(&self, operator: Address) -> ContractResult<bool> {
+        let returndata = self.0.isOperator(operator).call().await;
+
+        returndata.map(|data| data._0)
+    }
 }
 
 sol! {
@@ -88,6 +95,8 @@ sol! {
         }
 
         function getProposerStatus(bytes32 pubkeyHash) external view returns (ProposerStatus memory);
+
+        function isOperator( address operator) external view returns (bool);
 
         error InvalidQuery();
         error ValidatorDoesNotExist();

--- a/bolt-sidecar/src/signer/commit_boost.rs
+++ b/bolt-sidecar/src/signer/commit_boost.rs
@@ -1,6 +1,6 @@
 use std::{str::FromStr, sync::Arc};
 
-use alloy::{rpc::types::beacon::BlsSignature, signers::Signature};
+use alloy::{primitives::Address, rpc::types::beacon::BlsSignature, signers::Signature};
 use cb_common::{
     commit::{client::SignerClient, error::SignerClientError, request::SignConsensusRequest},
     signer::EcdsaPublicKey,
@@ -142,6 +142,10 @@ impl CommitBoostSigner {
 
 #[async_trait::async_trait]
 impl SignerECDSA for CommitBoostSigner {
+    fn public_key(&self) -> Address {
+        Address::try_from(self.get_proxy_ecdsa_pubkey().as_ref()).expect("valid address")
+    }
+
     async fn sign_hash(&self, hash: &[u8; 32]) -> eyre::Result<Signature> {
         let request = SignProxyRequest::builder(
             *self.proxy_ecdsa.read().first().expect("proxy ecdsa key loaded"),

--- a/bolt-sidecar/src/signer/keystore.rs
+++ b/bolt-sidecar/src/signer/keystore.rs
@@ -203,8 +203,8 @@ mod tests {
     const KEYSTORES_DEFAULT_PATH_TEST: &str = "test_data/keys";
     const KEYSTORES_SECRETS_DEFAULT_PATH_TEST: &str = "test_data/secrets";
 
-    /// If `path` is `Some`, returns a clone of it. Otherwise, returns the path to the `fallback_relative_path`
-    /// starting from the root of the cargo project.
+    /// If `path` is `Some`, returns a clone of it. Otherwise, returns the path to the
+    /// `fallback_relative_path` starting from the root of the cargo project.
     fn make_path(relative_path: &str) -> PathBuf {
         let project_root = env!("CARGO_MANIFEST_DIR");
         Path::new(project_root).join(relative_path)
@@ -302,7 +302,8 @@ mod tests {
         let keystore_path = PathBuf::from(keystore_path);
 
         for test_keystore_json in tests_keystore_json {
-            // 1. Write the keystore in a `test-voting-keystore.json` file so we test both scrypt and PBDKF2
+            // 1. Write the keystore in a `test-voting-keystore.json` file so we test both scrypt
+            //    and PBDKF2
 
             let mut tmp_keystore_file =
                 File::create(keystore_path.join("test-voting-keystore.json"))

--- a/bolt-sidecar/src/state/consensus.rs
+++ b/bolt-sidecar/src/state/consensus.rs
@@ -117,8 +117,8 @@ impl ConsensusState {
         }
 
         // If the request is for the next slot, check if it's within the commitment deadline
-        if req.slot == self.latest_slot + 1
-            && self.latest_slot_timestamp + self.commitment_deadline_duration < Instant::now()
+        if req.slot == self.latest_slot + 1 &&
+            self.latest_slot_timestamp + self.commitment_deadline_duration < Instant::now()
         {
             return Err(ConsensusError::DeadlineExceeded);
         }
@@ -161,7 +161,8 @@ impl ConsensusState {
         Ok(())
     }
 
-    /// Fetch proposer duties for the given epoch and the next one if the unsafe lookahead flag is set
+    /// Fetch proposer duties for the given epoch and the next one if the unsafe lookahead flag is
+    /// set
     async fn fetch_proposer_duties(&mut self, epoch: u64) -> Result<(), ConsensusError> {
         let duties = if self.unsafe_lookahead_enabled {
             let two_epoch_duties = join!(
@@ -200,9 +201,9 @@ impl ConsensusState {
     /// Returns the furthest slot for which a commitment request is considered valid, whether in
     /// the current epoch or next epoch (if unsafe lookahead is enabled)
     fn furthest_slot(&self) -> u64 {
-        self.epoch.start_slot
-            + SLOTS_PER_EPOCH
-            + if self.unsafe_lookahead_enabled { SLOTS_PER_EPOCH } else { 0 }
+        self.epoch.start_slot +
+            SLOTS_PER_EPOCH +
+            if self.unsafe_lookahead_enabled { SLOTS_PER_EPOCH } else { 0 }
     }
 }
 
@@ -324,8 +325,8 @@ mod tests {
         };
 
         let epoch =
-            state.beacon_api_client.get_beacon_header(BlockId::Head).await?.header.message.slot
-                / SLOTS_PER_EPOCH;
+            state.beacon_api_client.get_beacon_header(BlockId::Head).await?.header.message.slot /
+                SLOTS_PER_EPOCH;
 
         state.fetch_proposer_duties(epoch).await?;
         assert_eq!(state.epoch.proposer_duties.len(), SLOTS_PER_EPOCH as usize * 2);


### PR DESCRIPTION
Closes #332.

Introduces new checks for both the commitment signer key and the validator public keys which should correspond to an active operator and validator respectively in the `BoltManager` contract.

The check is performed at startup, when creating the `SidecarDriver::from_components`. This is a good spot because both signers (ECDSA, BLS) are abstracted via traits so the check can be safely done in a single pace.

 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
	- Introduced `public_key` method in the `SignerECDSA` trait and its implementations, allowing retrieval of the public key as an address.
	- Added `BoltManager` for enhanced key verification in the `SidecarDriver`.
	- Launched the `onchain_registry` module, expanding on-chain management capabilities.
	- Implemented various utility methods in `BoltManager` for address retrieval and operator/validator verification.

- **Bug Fixes**
	- Improved readability of conditional statements and return formats in several methods.

- **Documentation**
	- Enhanced comments for clarity in the `make_path` and `test_keystore_signer` functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->