### PR TITLE
chore(holesky/pbs): update helix config

### DIFF
--- a/testnets/holesky/helix-config.yml
+++ b/testnets/holesky/helix-config.yml
@@ -4,6 +4,8 @@ postgres:
   db_name: helixdb
   user: postgres
   password: postgres
+  region: 1
+  region_name: "eu-central"
 
 redis:
   url: redis://redis:6379
@@ -13,5 +15,16 @@ simulator:
 
 beacon_clients:
   - url: http://beacon:4000
+
+builders:
+  - pub_key: "aa1488eae4b06a1fff840a2b6db167afc520758dc2c8af0dfb57037954df3431b747e2f900fe8805f05d635e9a29717b"
+    builder_info:
+      collateral: "0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF"
+      is_optimistic: false
+      builder_id: "Bolt Builder"
+
+# If empty, all routes are enabled
+router_config:
+  enabled_routes: []
 
 network_config: !Holesky


### PR DESCRIPTION
Updates the Holesky configuration as required for the code in the https://github.com/chainbound/helix/tree/constraints-api-v0  branch.