### PR TITLE
fix(holesky/docker): add environment variable replacement in entrypoint

### DIFF
--- a/bolt-sidecar/bin/sidecar.rs
+++ b/bolt-sidecar/bin/sidecar.rs
@@ -2,11 +2,6 @@ use clap::Parser;
 use eyre::bail;
 use tracing::info;
 
-use tracing_subscriber::{
-    fmt::Layer as FmtLayer, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer,
-    Registry,
-};
-
 use bolt_sidecar::{
     config::{remove_empty_envs, Opts},
     telemetry::init_telemetry_stack,
@@ -24,7 +19,6 @@ const BOLT: &str = r#"
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
     read_env_file()?;
-    init_tracing()?;
 
     let opts = Opts::parse();
 
@@ -56,18 +50,6 @@ async fn main() -> eyre::Result<()> {
             }
         }
     }
-}
-
-fn init_tracing() -> eyre::Result<()> {
-    let std_layer = FmtLayer::default().with_writer(std::io::stdout).with_filter(
-        EnvFilter::builder()
-            .with_default_directive("bolt_sidecar=info".parse()?)
-            .from_env_lossy()
-            .add_directive("reqwest=error".parse()?)
-            .add_directive("alloy_transport_http=error".parse()?),
-    );
-    Registry::default().with(std_layer).try_init()?;
-    Ok(())
 }
 
 fn read_env_file() -> eyre::Result<()> {

--- a/bolt-sidecar/src/config/constraint_signing.rs
+++ b/bolt-sidecar/src/config/constraint_signing.rs
@@ -49,6 +49,7 @@ impl fmt::Debug for ConstraintSigningOpts {
             .field("keystore_password", &"********") // Hides the actual password
             .field("keystore_path", &self.keystore_path)
             .field("keystore_secrets_path", &self.keystore_secrets_path)
+            .field("delegations_path", &self.delegations_path)
             .finish()
     }
 }

--- a/bolt-sidecar/src/telemetry/mod.rs
+++ b/bolt-sidecar/src/telemetry/mod.rs
@@ -3,6 +3,10 @@ use std::net::SocketAddr;
 use eyre::{bail, Result};
 use metrics_exporter_prometheus::PrometheusBuilder;
 use tracing::info;
+use tracing_subscriber::{
+    fmt::Layer as FmtLayer, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer,
+    Registry,
+};
 
 mod metrics;
 pub use metrics::ApiMetrics;
@@ -11,6 +15,15 @@ pub use metrics::ApiMetrics;
 ///
 /// **This function should be called at the beginning of the program.**
 pub fn init_telemetry_stack(metrics_port: Option<u16>) -> Result<()> {
+    let std_layer = FmtLayer::default().with_writer(std::io::stdout).with_filter(
+        EnvFilter::builder()
+            .with_default_directive("bolt_sidecar=info".parse()?)
+            .from_env_lossy()
+            .add_directive("reqwest=error".parse()?)
+            .add_directive("alloy_transport_http=error".parse()?),
+    );
+
+    Registry::default().with(std_layer).try_init()?;
     if let Some(metrics_port) = metrics_port {
         let prometheus_addr = SocketAddr::from(([0, 0, 0, 0], metrics_port));
         let builder = PrometheusBuilder::new().with_http_listener(prometheus_addr);

--- a/bolt-sidecar/src/telemetry/mod.rs
+++ b/bolt-sidecar/src/telemetry/mod.rs
@@ -16,7 +16,7 @@ pub fn init_telemetry_stack(metrics_port: Option<u16>) -> Result<()> {
         let builder = PrometheusBuilder::new().with_http_listener(prometheus_addr);
 
         if let Err(e) = builder.install() {
-            bail!("failed to install Prometheus recorder: {:?}", e);
+            bail!("failed to init telemetry stack. Error installing Prometheus recorder: {:?}", e);
         } else {
             info!(
                 "Telemetry initialized. Serving Prometheus metrics at: http://{}",

--- a/bolt-sidecar/src/telemetry/mod.rs
+++ b/bolt-sidecar/src/telemetry/mod.rs
@@ -3,10 +3,6 @@ use std::net::SocketAddr;
 use eyre::{bail, Result};
 use metrics_exporter_prometheus::PrometheusBuilder;
 use tracing::info;
-use tracing_subscriber::{
-    fmt::Layer as FmtLayer, layer::SubscriberExt, util::SubscriberInitExt, EnvFilter, Layer,
-    Registry,
-};
 
 mod metrics;
 pub use metrics::ApiMetrics;
@@ -15,17 +11,6 @@ pub use metrics::ApiMetrics;
 ///
 /// **This function should be called at the beginning of the program.**
 pub fn init_telemetry_stack(metrics_port: Option<u16>) -> Result<()> {
-    // 1. Initialize tracing to stdout
-    let std_layer = FmtLayer::default().with_writer(std::io::stdout).with_filter(
-        EnvFilter::builder()
-            .with_default_directive("bolt_sidecar=info".parse()?)
-            .from_env_lossy()
-            .add_directive("reqwest=error".parse()?)
-            .add_directive("alloy_transport_http=error".parse()?),
-    );
-    Registry::default().with(std_layer).try_init()?;
-
-    // 2. Initialize metrics recorder and start the Prometheus server
     if let Some(metrics_port) = metrics_port {
         let prometheus_addr = SocketAddr::from(([0, 0, 0, 0], metrics_port));
         let builder = PrometheusBuilder::new().with_http_listener(prometheus_addr);

--- a/scripts/kurtosis_config.yaml
+++ b/scripts/kurtosis_config.yaml
@@ -28,7 +28,7 @@ mev_params:
   # instead of MEV-Boost by Flashbots
   bolt_boost_image: ghcr.io/chainbound/bolt-boost:0.1.0
   bolt_sidecar_image: ghcr.io/chainbound/bolt-sidecar:0.1.0
-  helix_relay_image: ghcr.io/chainbound/helix:v0.3.0-alpha.rc2
+  helix_relay_image: ghcr.io/chainbound/helix:v0.3.0-alpha.rc3
   mev_relay_image: ghcr.io/chainbound/bolt-relay:0.1.0
   mev_builder_image: ghcr.io/chainbound/bolt-builder:0.1.0
   mev_boost_image: ghcr.io/chainbound/bolt-mev-boost:0.1.0

--- a/testnets/holesky/README.md
+++ b/testnets/holesky/README.md
@@ -474,7 +474,7 @@ Once the configuration files are in place, make sure you are in the
 `testnets/holesky` directory and then run:
 
 ```bash
-docker compose up -d --env-file bolt-sidecar.env
+docker compose --env-file bolt-sidecar.env up -d
 ```
 
 The docker compose setup comes with various observability tools, such as

--- a/testnets/holesky/docker-compose.yml
+++ b/testnets/holesky/docker-compose.yml
@@ -4,23 +4,17 @@ services:
     container_name: bolt-sidecar-holesky
     restart: unless-stopped
     ports:
-      - "${BOLT_SIDECAR_PORT:-8017}:${BOLT_SIDECAR_PORT:-8017}" # Bolt RPC port (this should be opened on your firewall!)
+      # NOTE: to read these envs, it is necessary to provide them via `--env-file` or having them already set.
+      - "${BOLT_SIDECAR_PORT:-8017}:${BOLT_SIDECAR_PORT:-8017}" # This port should be opened on your firewall!
       - "${BOLT_SIDECAR_CONSTRAINTS_PROXY_PORT:-18550}:${BOLT_SIDECAR_CONSTRAINTS_PROXY_PORT:-18550}"
-    entrypoint: /bin/sh -c /usr/local/bin/bolt-sidecar
-    env_file: ./bolt-sidecar.env
-    environment:
-      # The "+" syntax replaces the environment variable with the alternate valuee only if set
-      # Reference: https://docs.docker.com/compose/how-tos/environment-variables/variable-interpolation/#interpolation-syntax
-      #
-      # NOTE: These enviroment variables take precedence over the ones provided via `env_file`.
-      # Reference: https://docs.docker.com/compose/how-tos/environment-variables/envvars-precedence/
-      BOLT_SIDECAR_DELEGATIONS_PATH: "${BOLT_SIDECAR_DELEGATIONS_PATH+/etc/delegations.json}"
-      BOLT_SIDECAR_KEYSTORE_PATH: "${BOLT_SIDECAR_KEYSTORE_PATH+/etc/keystore}"
-      BOLT_SIDECAR_KEYSTORE_SECRETS_PATH: "${BOLT_SIDECAR_KEYSTORE_SECRETS_PATH+/etc/secrets}"
+    entrypoint: /usr/local/bin/entrypoint.sh
     volumes:
-      - ${BOLT_SIDECAR_DELEGATIONS_PATH:-/dev/null:/etc/delegations.json}
-      - ${BOLT_SIDECAR_KEYSTORE_PATH:-/dev/null:/etc/keystores}
-      - ${BOLT_SIDECAR_KEYSTORE_SECRETS_PATH:-/dev/null:/etc/secrets}
+      - ./entrypoint.sh:/usr/local/bin/entrypoint.sh
+      - ./bolt-sidecar.env:/usr/local/bin/.env
+      # NOTE: to read these envs, it is necessary to provide them via `--env-file` or having them already set.
+      - ${BOLT_SIDECAR_DELEGATIONS_PATH:-/dev/null}:/etc/delegations.json
+      - ${BOLT_SIDECAR_KEYSTORE_PATH:-/dev/null}:/etc/keystores
+      - ${BOLT_SIDECAR_KEYSTORE_SECRETS_PATH:-/dev/null}:/etc/secrets
     networks:
       - bolt-default
 

--- a/testnets/holesky/entrypoint.sh
+++ b/testnets/holesky/entrypoint.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Exit immediately if a command exits with a non-zero status.
+set -e
+
+# Override the environment variables provided by the user.
+#
+# The "+" syntax replaces the environment variable with the alternate valuee
+# only if set.
+# Reference: https://docs.docker.com/compose/how-tos/environment-variables/variable-interpolation/#interpolation-syntax
+
+# Ensure these environment variables are either empty or set with the
+# alternative values, overriding what's provided with the `--env-file` flag in
+# the Docker Compose file and matching the volume mounts.
+export BOLT_SIDECAR_DELEGATIONS_PATH="${BOLT_SIDECAR_DELEGATIONS_PATH+/etc/delegations.json}"
+export BOLT_SIDECAR_KEYSTORE_PATH="${BOLT_SIDECAR_KEYSTORE_PATH+/etc/keystore}"
+export BOLT_SIDECAR_KEYSTORE_SECRETS_PATH="${BOLT_SIDECAR_KEYSTORE_SECRETS_PATH+/etc/secrets}"
+
+/usr/local/bin/bolt-sidecar


### PR DESCRIPTION
Couple things:
- as title says, doing so allows actually removing the empty vars as done in #367. If passed in the `environment` section or via `--env-file` flag they are system-wide inside the container and therefore removing them within the sidecar process doesn't work, because you can't remove a system-wide environment variable via `env::remove_var`.
- removing empty envs is now done even if a `.env` file is not provided
- reading the envs and removing empty ones is done as the first thing in the program, followed by initializing tracing.