### PR TITLE
small fixes

### DIFF
--- a/bolt-cli/src/commands/send.rs
+++ b/bolt-cli/src/commands/send.rs
@@ -5,6 +5,7 @@ use alloy::{
         constants::GWEI_TO_WEI, BlobTransactionSidecar, SidecarBuilder, SimpleCoder, Transaction,
     },
     eips::eip2718::Encodable2718,
+    hex,
     network::{EthereumWallet, TransactionBuilder, TransactionBuilder4844},
     primitives::{keccak256, Address, B256, U256},
     providers::{ProviderBuilder, SendableTx},
@@ -227,9 +228,9 @@ async fn sign_request(
         keccak256(data)
     };
 
-    let signature = hex::encode(wallet.sign_hash(&digest).await?.as_bytes());
+    let signature = hex::encode_prefixed(wallet.sign_hash(&digest).await?.as_bytes());
 
-    Ok(format!("{}:0x{}", wallet.address(), signature))
+    Ok(format!("{}:{}", wallet.address(), signature))
 }
 
 fn prepare_rpc_request(method: &str, params: Value) -> Value {

--- a/bolt-sidecar/src/client/constraints_client.rs
+++ b/bolt-sidecar/src/client/constraints_client.rs
@@ -1,5 +1,6 @@
 use std::collections::HashSet;
 
+use alloy::hex;
 use axum::http::StatusCode;
 use beacon_api_client::VersionedValue;
 use ethereum_consensus::{
@@ -91,6 +92,8 @@ impl ConstraintsClient {
         self.url.as_str()
     }
 
+    /// Joins the given path with the client's URL.
+    /// If the path is invalid, an error is logged and the client's URL is returned.
     fn endpoint(&self, path: &str) -> Url {
         self.url.join(path).unwrap_or_else(|e| {
             error!(err = ?e, "Failed to join path: {} with url: {}", path, self.url);
@@ -136,7 +139,8 @@ impl BuilderApi for ConstraintsClient {
             return Ok(());
         } else {
             let validator_pubkeys =
-                registrations.iter().map(|r| r.message.public_key.clone()).collect::<HashSet<_>>();
+                registrations.iter().map(|r| &r.message.public_key).collect::<HashSet<_>>();
+
             let filtered_delegations = self
                 .delegations
                 .iter()
@@ -157,8 +161,8 @@ impl BuilderApi for ConstraintsClient {
         &self,
         params: GetHeaderParams,
     ) -> Result<SignedBuilderBid, BuilderApiError> {
-        let parent_hash = format!("0x{}", hex::encode(params.parent_hash.as_ref()));
-        let public_key = format!("0x{}", hex::encode(params.public_key.as_ref()));
+        let parent_hash = hex::encode_prefixed(params.parent_hash.as_ref());
+        let public_key = hex::encode_prefixed(params.public_key.as_ref());
 
         let response = self
             .client
@@ -230,8 +234,8 @@ impl ConstraintsApi for ConstraintsClient {
         &self,
         params: GetHeaderParams,
     ) -> Result<VersionedValue<SignedBuilderBid>, BuilderApiError> {
-        let parent_hash = format!("0x{}", hex::encode(params.parent_hash.as_ref()));
-        let public_key = format!("0x{}", hex::encode(params.public_key.as_ref()));
+        let parent_hash = hex::encode_prefixed(params.parent_hash.as_ref());
+        let public_key = hex::encode_prefixed(params.public_key.as_ref());
 
         let response = self
             .client

--- a/bolt-sidecar/src/common.rs
+++ b/bolt-sidecar/src/common.rs
@@ -7,7 +7,7 @@ use std::{
     time::Duration,
 };
 
-use alloy::{primitives::U256, signers::k256::ecdsa::SigningKey};
+use alloy::{hex, primitives::U256, signers::k256::ecdsa::SigningKey};
 use blst::min_pk::SecretKey;
 use rand::{Rng, RngCore};
 use reth_primitives::PooledTransactionsElement;
@@ -144,7 +144,7 @@ impl Deref for BlsSecretKeyWrapper {
 
 impl fmt::Display for BlsSecretKeyWrapper {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "0x{}", hex::encode(self.0.to_bytes()))
+        write!(f, "{}", hex::encode_prefixed(self.0.to_bytes()))
     }
 }
 
@@ -180,7 +180,7 @@ impl From<&str> for EcdsaSecretKeyWrapper {
 
 impl Display for EcdsaSecretKeyWrapper {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
-        write!(f, "0x{}", hex::encode(self.0.to_bytes()))
+        write!(f, "{}", hex::encode_prefixed(self.0.to_bytes()))
     }
 }
 

--- a/bolt-sidecar/src/primitives/commitment.rs
+++ b/bolt-sidecar/src/primitives/commitment.rs
@@ -1,6 +1,9 @@
 use std::str::FromStr;
 
-use alloy::primitives::{keccak256, Address, Signature, B256};
+use alloy::{
+    hex,
+    primitives::{keccak256, Address, Signature, B256},
+};
 use serde::{de, Deserialize, Deserializer, Serialize};
 
 use crate::crypto::SignerECDSA;
@@ -212,7 +215,7 @@ fn serialize_sig<S: serde::Serializer>(sig: &Signature, serializer: S) -> Result
     // As bytes encodes the parity as 27/28, need to change that.
     let mut bytes = sig.as_bytes();
     bytes[bytes.len() - 1] = if parity.y_parity() { 1 } else { 0 };
-    serializer.serialize_str(&format!("0x{}", hex::encode(bytes)))
+    serializer.serialize_str(&hex::encode_prefixed(bytes))
 }
 
 impl InclusionRequest {
@@ -258,7 +261,7 @@ impl ECDSASignatureExt for Signature {
     }
 
     fn to_hex(&self) -> String {
-        format!("0x{}", hex::encode(self.as_bytes_with_parity()))
+        hex::encode_prefixed(self.as_bytes_with_parity())
     }
 }
 

--- a/bolt-sidecar/src/primitives/transaction.rs
+++ b/bolt-sidecar/src/primitives/transaction.rs
@@ -1,6 +1,9 @@
 use std::{borrow::Cow, fmt};
 
-use alloy::primitives::{Address, U256};
+use alloy::{
+    hex,
+    primitives::{Address, U256},
+};
 use reth_primitives::{BlobTransactionSidecar, Bytes, PooledTransactionsElement, TxKind, TxType};
 use serde::{de, ser::SerializeSeq};
 
@@ -233,7 +236,7 @@ pub fn serialize_txs<S: serde::Serializer>(
     let mut seq = serializer.serialize_seq(Some(txs.len()))?;
     for tx in txs {
         let encoded = tx.tx.envelope_encoded();
-        seq.serialize_element(&format!("0x{}", hex::encode(encoded)))?;
+        seq.serialize_element(&hex::encode_prefixed(encoded))?;
     }
     seq.end()
 }

--- a/scripts/kurtosis_config.yaml
+++ b/scripts/kurtosis_config.yaml
@@ -28,7 +28,7 @@ mev_params:
   # instead of MEV-Boost by Flashbots
   bolt_boost_image: ghcr.io/chainbound/bolt-boost:0.1.0
   bolt_sidecar_image: ghcr.io/chainbound/bolt-sidecar:0.1.0
-  helix_relay_image: ghcr.io/chainbound/helix:v0.3.0-alpha.rc3
+  helix_relay_image: ghcr.io/chainbound/helix:0.1.0
   mev_relay_image: ghcr.io/chainbound/bolt-relay:0.1.0
   mev_builder_image: ghcr.io/chainbound/bolt-builder:0.1.0
   mev_boost_image: ghcr.io/chainbound/bolt-mev-boost:0.1.0


### PR DESCRIPTION
Couple small cleanups found while reading part of the codebase for unrelated reasons.

* use `alloy::hex::encode_prefixed` where possible instead of `format!("0x{}", hex::encode())`
* avoid cloning pubkeys unnecessarily in BuilderApi::register_validators
* reverted helix docker tag to `0.1.0` for consistency. Remote versions are still unsupported so far.