### PR TITLE
Review logs on commitment deadline

### DIFF
--- a/bolt-sidecar/src/driver.rs
+++ b/bolt-sidecar/src/driver.rs
@@ -374,12 +374,14 @@ impl<C: StateFetcher, ECDSA: SignerECDSA> SidecarDriver<C, ECDSA> {
     /// Handle a commitment deadline event, submitting constraints to the Constraints client service
     /// and starting to build a local payload for the given target slot.
     async fn handle_commitment_deadline(&mut self, slot: u64) {
-        debug!(slot, "Commitment deadline reached, building local block");
-
         let Some(template) = self.execution.get_block_template(slot) else {
-            warn!("No block template found for slot {slot} when requested");
+            // Nothing to do then. Block templates are created only when constraints are added,
+            // which means we haven't issued any commitment for this slot because we are
+            // (probably) not the proposer for this block.
             return;
         };
+
+        info!(slot, "Commitment deadline reached, building local block");
 
         if let Err(e) = self.local_builder.build_new_local_payload(slot, template).await {
             error!(err = ?e, "Error while building local payload at deadline for slot {slot}");

--- a/bolt-sidecar/src/state/execution.rs
+++ b/bolt-sidecar/src/state/execution.rs
@@ -432,7 +432,6 @@ impl<C: StateFetcher> ExecutionState<C> {
 
     /// Commits the transaction to the target block. Initializes a new block template
     /// if one does not exist for said block number.
-    /// TODO: remove `pub` modifier once `try_commit` is fully implemented.
     pub fn add_constraint(&mut self, target_slot: u64, signed_constraints: SignedConstraints) {
         if let Some(template) = self.block_templates.get_mut(&target_slot) {
             template.add_constraints(signed_constraints);


### PR DESCRIPTION
The commitment deadline is triggered at every slot regardless of whether we're proposing or not, which was trigger a `WARN` log because the block template could not be found. This not unexpected behaviour, because block templates are created only when accepting commitments, and we do so only when we're the proposer for a block.

This PR reviews the logs in this section of the sidecar.