### PR TITLE
fix(bolt-boost): `generalized_indeces` -> `generalized_indexes`

### DIFF
--- a/bolt-boost/src/proofs.rs
+++ b/bolt-boost/src/proofs.rs
@@ -27,7 +27,7 @@ pub fn verify_multiproofs(
     root: B256,
 ) -> Result<(), ProofError> {
     // Check if the length of the leaves and indices match
-    if proofs.transaction_hashes.len() != proofs.generalized_indeces.len() {
+    if proofs.transaction_hashes.len() != proofs.generalized_indexes.len() {
         return Err(ProofError::LengthMismatch);
     }
 
@@ -68,7 +68,7 @@ pub fn verify_multiproofs(
     ssz_rs::multiproofs::verify_merkle_multiproof(
         &leaves,
         &proofs.merkle_hashes,
-        &proofs.generalized_indeces,
+        &proofs.generalized_indexes,
         root,
     )
     .map_err(|_| ProofError::VerificationFailed)?;

--- a/bolt-boost/src/types.rs
+++ b/bolt-boost/src/types.rs
@@ -188,8 +188,8 @@ pub struct InclusionProofs {
     /// The transaction hashes these inclusion proofs are for. The hash tree roots of
     /// these transactions are the leaves of the transactions tree.
     pub transaction_hashes: Vec<TxHash>,
-    /// The generalized indeces of the nodes in the transactions tree.
-    pub generalized_indeces: Vec<usize>,
+    /// The generalized indexes of the nodes in the transactions tree.
+    pub generalized_indexes: Vec<usize>,
     /// The proof hashes for the transactions tree.
     pub merkle_hashes: Vec<B256>,
 }

--- a/bolt-boost/src/types.rs
+++ b/bolt-boost/src/types.rs
@@ -173,8 +173,10 @@ pub struct RevocationMessage {
     pub delegatee_pubkey: BlsPublicKey,
 }
 
+/// Reference: https://docs.boltprotocol.xyz/technical-docs/api/builder#get_header_with_proofs
 pub type GetHeaderWithProofsResponse = VersionedResponse<SignedExecutionPayloadHeaderWithProofs>;
 
+/// Reference: https://docs.boltprotocol.xyz/technical-docs/api/builder#get_header_with_proofs
 #[derive(Debug, Default, Clone, Serialize, Deserialize)]
 pub struct SignedExecutionPayloadHeaderWithProofs {
     #[serde(flatten)]
@@ -183,6 +185,7 @@ pub struct SignedExecutionPayloadHeaderWithProofs {
     pub proofs: InclusionProofs,
 }
 
+/// Reference: https://docs.boltprotocol.xyz/technical-docs/api/builder#get_header_with_proofs
 #[derive(Debug, Default, Clone, Serialize, Deserialize, Encode, Decode)]
 pub struct InclusionProofs {
     /// The transaction hashes these inclusion proofs are for. The hash tree roots of


### PR DESCRIPTION
This typo was causing some deserialization issues.