### PR TITLE
chore: version bump: `0.3.0-alpha`

### DIFF
--- a/bolt-boost/Cargo.lock
+++ b/bolt-boost/Cargo.lock
@@ -1057,7 +1057,7 @@ dependencies = [
 
 [[package]]
 name = "bolt-boost"
-version = "0.1.0"
+version = "0.3.0-alpha"
 dependencies = [
  "alloy",
  "alloy-rlp",

--- a/bolt-boost/Cargo.toml
+++ b/bolt-boost/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bolt-boost"
-version = "0.1.0"
+version = "0.3.0-alpha"
 edition = "2021"
 
 [dependencies]

--- a/bolt-cli/Cargo.lock
+++ b/bolt-cli/Cargo.lock
@@ -1163,7 +1163,7 @@ dependencies = [
 
 [[package]]
 name = "bolt"
-version = "0.1.0"
+version = "0.3.0-alpha"
 dependencies = [
  "alloy",
  "blst",

--- a/bolt-cli/Cargo.toml
+++ b/bolt-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bolt"
-version = "0.1.0"
+version = "0.3.0-alpha"
 edition = "2021"
 
 [dependencies]

--- a/bolt-sidecar/Cargo.lock
+++ b/bolt-sidecar/Cargo.lock
@@ -2119,7 +2119,7 @@ dependencies = [
 
 [[package]]
 name = "bolt-sidecar"
-version = "0.2.1-alpha"
+version = "0.3.0-alpha"
 dependencies = [
  "account_utils",
  "alloy 0.6.4",

--- a/bolt-sidecar/Cargo.toml
+++ b/bolt-sidecar/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bolt-sidecar"
-version = "0.2.1-alpha"
+version = "0.3.0-alpha"
 edition = "2021"
 default-run = "bolt-sidecar"
 


### PR DESCRIPTION
Prior to creating a release, bump Cargo versions of packages in the monorepo to `0.3.0-alpha`.