### PR TITLE
feat(sidecar): metadata endpoint

### DIFF
--- a/bolt-sidecar/src/api/commitments/handlers.rs
+++ b/bolt-sidecar/src/api/commitments/handlers.rs
@@ -21,7 +21,7 @@ use super::{
     jsonrpc::{JsonPayload, JsonResponse},
     server::CommitmentsApiInner,
     spec::{
-        CommitmentError, CommitmentsApi, RejectionError, GET_VERSION_METHOD,
+        CommitmentError, CommitmentsApi, RejectionError, GET_METADATA_METHOD, GET_VERSION_METHOD,
         REQUEST_INCLUSION_METHOD,
     },
 };
@@ -43,6 +43,15 @@ pub async fn rpc_entrypoint(
                 result: Value::String(version_string),
                 ..Default::default()
             }))
+        }
+
+        GET_METADATA_METHOD => {
+            let response = JsonResponse {
+                id: payload.id,
+                result: serde_json::to_value(api.limits()).expect("infallible"),
+                ..Default::default()
+            };
+            Ok(Json(response))
         }
 
         REQUEST_INCLUSION_METHOD => {

--- a/bolt-sidecar/src/api/commitments/server.rs
+++ b/bolt-sidecar/src/api/commitments/server.rs
@@ -1,5 +1,4 @@
 use std::{
-    collections::HashSet,
     fmt,
     future::Future,
     net::{SocketAddr, ToSocketAddrs},
@@ -7,7 +6,6 @@ use std::{
     sync::Arc,
 };
 
-use alloy::primitives::Address;
 use axum::{
     middleware,
     routing::{get, post},
@@ -22,6 +20,7 @@ use tracing::{error, info};
 
 use crate::{
     api::commitments::handlers,
+    config::limits::LimitsOpts,
     primitives::{
         commitment::{InclusionCommitment, SignedCommitment},
         CommitmentRequest, InclusionRequest,
@@ -49,15 +48,19 @@ pub struct CommitmentEvent {
 pub struct CommitmentsApiInner {
     /// Event notification channel
     events: mpsc::Sender<CommitmentEvent>,
-    /// Optional whitelist of ECDSA public keys
-    #[allow(unused)]
-    whitelist: Option<HashSet<Address>>,
+    /// The sidecar's operating limits that should be exposed in a metadata endpoint
+    limits: LimitsOpts,
 }
 
 impl CommitmentsApiInner {
-    /// Create a new API server with an optional whitelist of ECDSA public keys.
-    pub fn new(events: mpsc::Sender<CommitmentEvent>) -> Self {
-        Self { events, whitelist: None }
+    /// Creates a new instance of the commitments API handler.
+    pub fn new(events: mpsc::Sender<CommitmentEvent>, limits: LimitsOpts) -> Self {
+        Self { events, limits }
+    }
+
+    /// Returns the operating limits for the sidecar.
+    pub fn limits(&self) -> LimitsOpts {
+        self.limits
     }
 }
 
@@ -119,8 +122,8 @@ impl CommitmentsApiServer {
     }
 
     /// Runs the JSON-RPC server, sending events to the provided channel.
-    pub async fn run(&mut self, events_tx: mpsc::Sender<CommitmentEvent>) {
-        let api = Arc::new(CommitmentsApiInner::new(events_tx));
+    pub async fn run(&mut self, events_tx: mpsc::Sender<CommitmentEvent>, limits: LimitsOpts) {
+        let api = Arc::new(CommitmentsApiInner::new(events_tx, limits));
 
         let router = make_router(api);
 
@@ -188,7 +191,7 @@ mod test {
 
         let (events_tx, _) = mpsc::channel(1);
 
-        server.run(events_tx).await;
+        server.run(events_tx, LimitsOpts::default()).await;
         let addr = server.local_addr();
 
         let sk = SecretKey::random(&mut rand::thread_rng());
@@ -230,7 +233,7 @@ mod test {
 
         let (events_tx, mut events) = mpsc::channel(1);
 
-        server.run(events_tx).await;
+        server.run(events_tx, LimitsOpts::default()).await;
         let addr = server.local_addr();
 
         let sk = SecretKey::random(&mut rand::thread_rng());

--- a/bolt-sidecar/src/api/commitments/spec.rs
+++ b/bolt-sidecar/src/api/commitments/spec.rs
@@ -15,6 +15,8 @@ pub(super) const GET_VERSION_METHOD: &str = "bolt_getVersion";
 
 pub(super) const REQUEST_INCLUSION_METHOD: &str = "bolt_requestInclusion";
 
+pub(super) const GET_METADATA_METHOD: &str = "bolt_metadata";
+
 pub(super) const MAX_REQUEST_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(6);
 
 /// Error type for the commitments API.

--- a/bolt-sidecar/src/config/limits.rs
+++ b/bolt-sidecar/src/config/limits.rs
@@ -1,7 +1,6 @@
 use std::num::NonZero;
 
 use clap::Parser;
-use serde::Deserialize;
 
 /// Default max commitments to accept per block.
 pub const DEFAULT_MAX_COMMITMENTS: usize = 128;
@@ -13,7 +12,8 @@ pub const DEFAULT_MAX_COMMITTED_GAS: u64 = 10_000_000;
 pub const DEFAULT_MIN_PRIORITY_FEE: u128 = 1_000_000_000; // 1 Gwei
 
 /// Limits for the sidecar.
-#[derive(Debug, Parser, Clone, Copy, Deserialize)]
+#[cfg_attr(test, derive(PartialEq))]
+#[derive(Debug, Parser, Clone, Copy, serde::Serialize, serde::Deserialize)]
 pub struct LimitsOpts {
     /// Max number of commitments to accept per block
     #[clap(

--- a/bolt-sidecar/src/driver.rs
+++ b/bolt-sidecar/src/driver.rs
@@ -227,7 +227,7 @@ impl<C: StateFetcher, ECDSA: SignerECDSA> SidecarDriver<C, ECDSA> {
         // start the commitments api server
         let api_addr = format!("0.0.0.0:{}", opts.port);
         let (api_events_tx, api_events_rx) = mpsc::channel(1024);
-        CommitmentsApiServer::new(api_addr).run(api_events_tx).await;
+        CommitmentsApiServer::new(api_addr).run(api_events_tx, opts.limits).await;
 
         let unsafe_skip_consensus_checks = opts.unsafe_disable_consensus_checks;
 


### PR DESCRIPTION
Exposes an endpoint returning the sidecar operating limits in a `metadata` endpoint.

Closes #247 