### PR TITLE
chore: update bolt rpc api endpoint according to versioned spec

### DIFF
--- a/bolt-cli/src/cli.rs
+++ b/bolt-cli/src/cli.rs
@@ -79,7 +79,11 @@ pub struct PubkeysCommand {
 #[derive(Debug, Clone, Parser)]
 pub struct SendCommand {
     /// Bolt RPC URL to send requests to and fetch lookahead info from.
-    #[clap(long, env = "BOLT_RPC_URL", default_value = "http://135.181.191.125:58017/rpc")]
+    #[clap(
+        long,
+        env = "BOLT_RPC_URL",
+        default_value = "https://rpc-holesky.bolt.chainbound.io/rpc"
+    )]
     pub bolt_rpc_url: Url,
 
     /// The private key to sign the transaction with.

--- a/bolt-cli/src/commands/send.rs
+++ b/bolt-cli/src/commands/send.rs
@@ -22,7 +22,7 @@ use tracing::info;
 use crate::cli::SendCommand;
 
 /// Path to the lookahead endpoint on the Bolt RPC server.
-const BOLT_LOOKAHEAD_PATH: &str = "proposers/lookahead";
+const BOLT_LOOKAHEAD_PATH: &str = "/api/v1/proposers/lookahead";
 
 impl SendCommand {
     /// Run the `send` command.


### PR DESCRIPTION
Updates the RPC api endpoints according to the `/api/v1` spec.

Note: must be merged after https://github.com/chainbound/bolt-rpc/pull/50 is deployed.