### PR TITLE
fix(cli): update `send` command to new bolt-rpc specs

### DIFF
--- a/bolt-cli/src/cli.rs
+++ b/bolt-cli/src/cli.rs
@@ -79,11 +79,7 @@ pub struct PubkeysCommand {
 #[derive(Debug, Clone, Parser)]
 pub struct SendCommand {
     /// Bolt RPC URL to send requests to and fetch lookahead info from.
-    #[clap(
-        long,
-        env = "BOLT_RPC_URL",
-        default_value = "https://rpc-holesky.bolt.chainbound.io/rpc"
-    )]
+    #[clap(long, env = "BOLT_RPC_URL", default_value = "https://rpc-holesky.bolt.chainbound.io")]
     pub bolt_rpc_url: Url,
 
     /// The private key to sign the transaction with.

--- a/bolt-cli/src/commands/send.rs
+++ b/bolt-cli/src/commands/send.rs
@@ -42,7 +42,7 @@ impl SendCommand {
         let provider = ProviderBuilder::new()
             .with_recommended_fillers()
             .wallet(transaction_signer)
-            .on_http(self.bolt_rpc_url.clone());
+            .on_http(self.bolt_rpc_url.join("/rpc")?);
 
         // Fetch the lookahead info from the Bolt RPC server
         let mut lookahead_url = self.bolt_rpc_url.join(BOLT_LOOKAHEAD_PATH)?;
@@ -50,15 +50,15 @@ impl SendCommand {
         // Note: it's possible for users to override the target sidecar URL
         // for testing and development purposes. In most cases, the sidecar will
         // reject a request for a slot that it is not responsible for.
-        let target_url = if let Some(sidecar_url) = &self.override_bolt_sidecar_url {
+        let target_url = if let Some(sidecar_url) = self.override_bolt_sidecar_url {
             // If using the override URL, we don't need to fetch the active proposers only.
             // we will set the next slot as the target slot.
-            sidecar_url.clone()
+            sidecar_url
         } else {
             // Filter out slots that are not active or in the past, to fetch the next
             // active proposer slot.
             lookahead_url.set_query(Some("activeOnly=true&futureOnly=true"));
-            self.bolt_rpc_url.clone()
+            self.bolt_rpc_url
         };
 
         let lookahead_res = reqwest::get(lookahead_url).await?.json::<Vec<LookaheadSlot>>().await?;

--- a/bolt-cli/src/commands/send.rs
+++ b/bolt-cli/src/commands/send.rs
@@ -58,7 +58,7 @@ impl SendCommand {
             // Filter out slots that are not active or in the past, to fetch the next
             // active proposer slot.
             lookahead_url.set_query(Some("activeOnly=true&futureOnly=true"));
-            self.bolt_rpc_url
+            self.bolt_rpc_url.join("/rpc")?
         };
 
         let lookahead_res = reqwest::get(lookahead_url).await?.json::<Vec<LookaheadSlot>>().await?;


### PR DESCRIPTION
Update adhering to the new [rpc specs](https://rpc-holesky.bolt.chainbound.io/docs/).