### PR TITLE
feat: added tailscale action to all CI workflows

### DIFF
--- a/.github/workflows/bolt_boost_ci.yml
+++ b/.github/workflows/bolt_boost_ci.yml
@@ -39,6 +39,13 @@ jobs:
         with:
           crate: cargo-nextest
 
+      - name: Install Tailscale
+        uses: tailscale/github-action@v2
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+
       - name: Run bolt-boost tests
         run: cd bolt-boost && cargo nextest run --workspace --retries 3
         env:

--- a/.github/workflows/bolt_cli_ci.yml
+++ b/.github/workflows/bolt_cli_ci.yml
@@ -50,5 +50,12 @@ jobs:
         with:
           version: nightly
 
+      - name: Install Tailscale
+        uses: tailscale/github-action@v2
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+
       - name: Run bolt-cli tests
         run: cd bolt-cli && cargo nextest run --workspace --retries 3

--- a/.github/workflows/bolt_sidecar_ci.yml
+++ b/.github/workflows/bolt_sidecar_ci.yml
@@ -45,6 +45,13 @@ jobs:
         with:
           crate: cargo-nextest
 
+      - name: Install Tailscale
+        uses: tailscale/github-action@v2
+        with:
+          oauth-client-id: ${{ secrets.TS_OAUTH_CLIENT_ID }}
+          oauth-secret: ${{ secrets.TS_OAUTH_SECRET }}
+          tags: tag:ci
+
       - name: Run bolt-sidecar tests
         run: cd bolt-sidecar && cargo nextest run --workspace --retries 3
         env:

--- a/bolt-cli/src/commands/delegate.rs
+++ b/bolt-cli/src/commands/delegate.rs
@@ -402,7 +402,7 @@ mod tests {
     /// --exact --show-output --ignored --nocapture
     /// ```
     #[tokio::test]
-    #[ignore]
+    #[ignore = "Requires Dirk to be installed on the system"]
     async fn test_delegation_dirk() -> eyre::Result<()> {
         let _ = tracing_subscriber::fmt::try_init();
         let (mut dirk, mut dirk_proc) = dirk::test_util::start_dirk_test_server().await?;

--- a/bolt-cli/src/common/dirk.rs
+++ b/bolt-cli/src/common/dirk.rs
@@ -231,7 +231,7 @@ mod tests {
     /// --exact --show-output --ignored
     /// ```
     #[tokio::test]
-    #[ignore]
+    #[ignore = "Requires Dirk to be installed on the system"]
     async fn test_dirk_connection_e2e() -> eyre::Result<()> {
         let (mut dirk, mut dirk_proc) = test_util::start_dirk_test_server().await?;
 

--- a/bolt-sidecar/src/chain_io/manager.rs
+++ b/bolt-sidecar/src/chain_io/manager.rs
@@ -193,9 +193,15 @@ mod tests {
     use super::BoltManager;
 
     #[tokio::test]
-    #[ignore = "requires Chainbound tailnet"]
     async fn test_verify_validator_pubkeys() {
         let url = Url::parse("http://remotebeast:48545").expect("valid url");
+
+        // Skip the test if the tailnet server isn't reachable
+        if reqwest::get(url.clone()).await.is_err_and(|err| err.is_timeout() || err.is_connect()) {
+            eprintln!("Skipping test because remotebeast is not reachable");
+            return;
+        }
+
         let manager =
             BoltManager::from_chain(url, Chain::Holesky).expect("manager deployed on Holesky");
 


### PR DESCRIPTION
Added a Tailscale action that enables us to use our tailnet boxes in tests freely.

Note: when writing tests we should still be mindful of external contributors and implement logic to fall back to other endpoints or skip tests if the server is unreachable.
