### PR TITLE
chore(bolt-sidecar): fix lints

### DIFF
--- a/bolt-sidecar/src/builder/payload_builder.rs
+++ b/bolt-sidecar/src/builder/payload_builder.rs
@@ -145,12 +145,12 @@ impl FallbackPayloadBuilder {
             latest_block.header.gas_limit,
             latest_block.header.base_fee_per_gas.unwrap_or_default(),
             BaseFeeParams::ethereum(),
-        ) as u64;
+        );
 
         let excess_blob_gas = calc_excess_blob_gas(
             latest_block.header.excess_blob_gas.unwrap_or_default(),
             latest_block.header.blob_gas_used.unwrap_or_default(),
-        ) as u64;
+        );
 
         let blob_gas_used =
             transactions.iter().fold(0, |acc, tx| acc + tx.blob_gas_used().unwrap_or_default());

--- a/bolt-sidecar/src/signer/commit_boost.rs
+++ b/bolt-sidecar/src/signer/commit_boost.rs
@@ -210,15 +210,12 @@ mod test {
     async fn test_bls_commit_boost_signer() -> eyre::Result<()> {
         let _ = dotenvy::dotenv();
 
-        let (signer_server_address, jwt_hex) = match (
+        let (Some(signer_server_address), Ok(jwt_hex)) = (
             std::env::var("BOLT_SIDECAR_CB_SIGNER_URL").ok(),
             std::env::var("BOLT_SIDECAR_CB_JWT_HEX"),
-        ) {
-            (Some(address), Ok(hex)) => (address, hex),
-            _ => {
-                warn!("skipping test: commit-boost inputs are not set");
-                return Ok(());
-            }
+        ) else {
+            warn!("skipping test: commit-boost inputs are not set");
+            return Ok(());
         };
         let signer = CommitBoostSigner::new(signer_server_address.parse()?, &jwt_hex).unwrap();
 
@@ -240,15 +237,12 @@ mod test {
     async fn test_ecdsa_commit_boost_signer() -> eyre::Result<()> {
         let _ = dotenvy::dotenv();
 
-        let (signer_server_address, jwt_hex) = match (
+        let (Some(signer_server_address), Ok(jwt_hex)) = (
             std::env::var("BOLT_SIDECAR_CB_SIGNER_URL").ok(),
             std::env::var("BOLT_SIDECAR_CB_JWT_HEX"),
-        ) {
-            (Some(address), Ok(hex)) => (address, hex),
-            _ => {
-                warn!("skipping test: commit-boost inputs are not set");
-                return Ok(());
-            }
+        ) else {
+            warn!("skipping test: commit-boost inputs are not set");
+            return Ok(());
         };
         let signer = CommitBoostSigner::new(signer_server_address.parse()?, &jwt_hex).unwrap();
         let pubkey = signer.get_proxy_ecdsa_pubkey();


### PR DESCRIPTION
Ran `cargo clippy` locally and CI is running `cargo clippy --all-targets --all-features -- -D warnings`