### PR TITLE
feat: cross compile bolt-cli tarballs for usage by boltup

### DIFF
--- a/boltup/boltup.sh
+++ b/boltup/boltup.sh
@@ -95,8 +95,7 @@ main() {
   BIN_FILENAME="bolt-cli-${ARCHITECTURE}-${PLATFORM}.$EXT"
   BIN_ARCHIVE_URL="${RELEASE_URL}${BIN_FILENAME}"
 
-  # Download and extract the binaries archive
-  say "downloading latest binary"
+  # Download and extract the tarball.
   if [ "$PLATFORM" = "win32" ]; then
     tmp="$(mktemp -d 2>/dev/null || echo ".")/bolt.zip"
     ensure download "$BIN_ARCHIVE_URL" "$tmp"

--- a/justfile
+++ b/justfile
@@ -184,3 +184,7 @@ build-and-push-image package tag:
 build-and-push-all-images tag='latest':
     @just build-and-push-image bolt-sidecar {{tag}}
     @just build-and-push-image bolt-boost {{tag}}
+
+# Create tarballs for the bolt-cli binaries for all the supported platforms
+create-bolt-cli-tarballs:
+    chmod +x ./scripts/bolt-cli-tarballs.sh && ./scripts/bolt-cli-tarballs.sh

--- a/scripts/bolt-cli-tarballs.sh
+++ b/scripts/bolt-cli-tarballs.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+set -eo pipefail
+
+# Use this script to create tarballs for bolt-cli to be uploaded to each Github release.
+# This is intended to be run locally, and assuming you have cross installed.
+#
+# Note: this will only work when run on MacOS as `cross` does not distribute SDKs for 
+# MacOS due to licensing issues.
+
+# Target tuples for cross compilation. 
+# each tuple is in the format of "target-triple", "short-name".
+TARGETS=(
+    "aarch64-apple-darwin" "arm64-darwin"     # ARM apple chips (M1)
+    "x86_64-apple-darwin" "amd64_64-darwin"   # Intel apple chips
+    "aarch64-unknown-linux-gnu" "arm64-linux" # ARM linux chips
+    "x86_64-unknown-linux-gnu" "amd64-linux"  # x86 linux chips
+)
+
+PROFILE="release"
+
+# Check if cross is installed
+if ! command -v cross &> /dev/null; then
+    echo "cross is not installed. Install it by running 'cargo install cross'"
+    exit 1
+fi
+
+(
+    cd bolt-cli || exit 1
+    mkdir -p dist
+
+    # Iterate over TARGETS in pairs
+    for ((i=0; i<${#TARGETS[@]}; i+=2)); do
+        target="${TARGETS[i]}"
+        short_name="${TARGETS[i+1]}"
+        
+        echo "Building for $target ($short_name)"
+        
+        mkdir -p "dist/$short_name"
+        cross build --$PROFILE --target "$target"
+        cp "target/$target/$PROFILE/bolt" "dist/$short_name/bolt"
+        tar -czf "dist/bolt-cli-$short_name.tar.gz" -C "dist/$short_name" bolt
+        
+        echo "Done building for $target ($short_name)"
+    done   
+
+    echo "Done building all targets."
+    echo "You can find the tarballs in bolt-cli/dist/"
+)
+
+exit 0


### PR DESCRIPTION
Until the CI workflow will work, this is going to be a manual step for every release:

```just
just create-bolt-cli-tarballs
```

And then we'll have to upload the archives to the release assets.