### PR TITLE
chore(ci): check instead of build

### DIFF
--- a/.github/workflows/bolt_boost_ci.yml
+++ b/.github/workflows/bolt_boost_ci.yml
@@ -34,11 +34,15 @@ jobs:
         with:
           cache-on-failure: true
 
-      - name: Build
-        run: cd bolt-boost && cargo build
+      - name: Check
+        run: |
+          cd bolt-boost
+          cargo check
 
       - name: Lint Code with Clippy
-        run: cd bolt-boost && cargo clippy --all-targets --all-features -- -D warnings
+        run: |
+          cd bolt-boost
+          cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Install cargo-nextest
         uses: baptiste0928/cargo-install@v3
@@ -53,6 +57,8 @@ jobs:
           tags: tag:ci
 
       - name: Run bolt-boost tests
-        run: cd bolt-boost && cargo nextest run --workspace --retries 3
+        run: |
+          cd bolt-boost
+          cargo nextest run --workspace --retries 3
         env:
           RPC_URL: ${{ secrets.RPC_URL }}

--- a/.github/workflows/bolt_cli_ci.yml
+++ b/.github/workflows/bolt_cli_ci.yml
@@ -40,11 +40,15 @@ jobs:
         with:
           cache-on-failure: true
 
-      - name: Build
-        run: cd bolt-cli && cargo build
+      - name: Check
+        run: |
+          cd bolt-cli
+          cargo check
 
       - name: Lint Code with Clippy
-        run: cd bolt-cli && cargo clippy --all-targets --all-features -- -D warnings
+        run: |
+          cd bolt-cli
+          cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Install cargo-nextest
         uses: baptiste0928/cargo-install@v3
@@ -64,4 +68,6 @@ jobs:
           tags: tag:ci
 
       - name: Run bolt-cli tests
-        run: cd bolt-cli && cargo nextest run --workspace --retries 3
+        run: |
+          cd bolt-cli
+          cargo nextest run --workspace --retries 3

--- a/.github/workflows/bolt_sidecar_ci.yml
+++ b/.github/workflows/bolt_sidecar_ci.yml
@@ -40,11 +40,15 @@ jobs:
         with:
           cache-on-failure: true
 
-      - name: Build
-        run: cd bolt-sidecar && cargo build
+      - name: Check
+        run: |
+          cd bolt-sidecar
+          cargo build
 
       - name: Lint Code with Clippy
-        run: cd bolt-sidecar && cargo clippy --all-targets --all-features -- -D warnings
+        run: |
+          cd bolt-sidecar
+          cargo clippy --all-targets --all-features -- -D warnings
 
       - name: Install cargo-nextest
         uses: baptiste0928/cargo-install@v3
@@ -59,6 +63,8 @@ jobs:
           tags: tag:ci
 
       - name: Run bolt-sidecar tests
-        run: cd bolt-sidecar && cargo nextest run --workspace --retries 3
+        run: |
+          cd bolt-sidecar
+          cargo nextest run --workspace --retries 3
         env:
           RPC_URL: ${{ secrets.RPC_URL }}


### PR DESCRIPTION
Build step takes approximately [5 min](https://github.com/chainbound/bolt/actions/runs/12049068258/job/33595042475)
We don't need to produce an artifact in this pipeline, so we can run `cargo check` instead which is much faster.