### PR TITLE
chore(bolt-sidecar): replace deprecated default_features with default…

### DIFF
--- a/bolt-sidecar/Cargo.toml
+++ b/bolt-sidecar/Cargo.toml
@@ -33,7 +33,7 @@ alloy = { version = "0.6.4", features = [
   "rpc-types-beacon",
   "rpc-types-engine",
 ] }
-alloy-rpc-types-engine = { version = "0.6.4", default_features = false, features = [
+alloy-rpc-types-engine = { version = "0.6.4", default-features = false, features = [
   "jwt",
 ] }
 


### PR DESCRIPTION
…-features

Silence warning:
```
warning: `default_features` is deprecated in favor of `default-features` and will not work in the 2024 edition
(in the `alloy-rpc-types-engine` dependency)
```