### PR TITLE
fix: individual package cross dockerfiles

### DIFF
--- a/bolt-boost/Cross.Dockerfile
+++ b/bolt-boost/Cross.Dockerfile
@@ -1,0 +1,24 @@
+# This image is meant to enable cross-architecture builds.
+# It assumes the binary has already been compiled for `$TARGETPLATFORM` and is
+# locatable in `./dist/bin/$TARGETARCH/$BINARY`.
+
+# We need ubuntu 20.04 because more recent versions come with openssl3 
+# and our binary depends on openssl 1.1.1 and installing 1.1.1 on new
+# ubuntu versions is highly discouraged.
+FROM --platform=$TARGETPLATFORM ubuntu:20.04
+
+LABEL org.opencontainers.image.source=https://github.com/chainbound/bolt
+LABEL org.opencontainers.image.licenses="MIT"
+
+# Filled by docker buildx
+ARG TARGETARCH
+
+# Should be set by the caller when building the image
+ARG BINARY
+
+# We need to install ca-certificates to make HTTPS requests (only with ubuntu 20.04)
+RUN apt-get update && apt-get install -y ca-certificates
+
+COPY ./dist/bin/$TARGETARCH/$BINARY /usr/local/bin/bolt-boost
+
+ENTRYPOINT ["/usr/local/bin/bolt-boost"]

--- a/bolt-sidecar/Cross.Dockerfile
+++ b/bolt-sidecar/Cross.Dockerfile
@@ -13,6 +13,6 @@ ARG TARGETARCH
 # Should be set by the caller when building the image
 ARG BINARY
 
-COPY ./dist/bin/$TARGETARCH/$BINARY /usr/local/bin/bolt
+COPY ./dist/bin/$TARGETARCH/$BINARY /usr/local/bin/bolt-sidecar
 
-ENTRYPOINT ["/usr/local/bin/bolt"]
+ENTRYPOINT ["/usr/local/bin/bolt-sidecar"]

--- a/justfile
+++ b/justfile
@@ -186,7 +186,7 @@ build-and-push-image package tag:
 
     docker buildx build \
       --build-arg BINARY={{package}} \
-      --file ./scripts/cross.Dockerfile \
+      --file ./{{package}}/Cross.Dockerfile \
       --platform linux/amd64,linux/arm64 \
       --tag ghcr.io/chainbound/{{package}}:{{tag}} \
       --push .


### PR DESCRIPTION
A single cross.Dockerfile for all our packages won't work since bolt-boost now requires building 
on a different version of Ubuntu (due to cross itself using version 20.04). 

When cross will release version 0.4 and update their base images to 24.04, we can revert to one single file.
This is tracked here: https://github.com/cross-rs/cross/pull/973#issuecomment-1451731430