### PR TITLE
chore(bolt-sidecar): extract compute_diffs()

### DIFF
--- a/bolt-sidecar/src/state/execution.rs
+++ b/bolt-sidecar/src/state/execution.rs
@@ -565,13 +565,15 @@ pub struct StateUpdate {
     pub block_number: u64,
 }
 
-// From previous preconfirmations requests retrieve
-// - the nonce difference from the account state.
-// - the balance difference from the account state.
-// - the highest slot number for which the user has requested a preconfirmation.
-//
-// If the templates do not exist, or this is the first request for this sender,
-// its diffs will be zero.
+/// Calculate aggregated diffs for an account, given some block templates.
+/// 
+/// From previous preconfirmations requests retrieve
+/// - the nonce difference from the account state.
+/// - the balance difference from the account state.
+/// - the highest slot number for which the user has requested a preconfirmation.
+///
+/// If the templates do not exist, or this is the first request for this sender,
+/// its diffs will be zero.
 fn compute_diffs(
     block_templates: &HashMap<u64, BlockTemplate>,
     sender: &Address,

--- a/bolt-sidecar/src/state/execution.rs
+++ b/bolt-sidecar/src/state/execution.rs
@@ -633,17 +633,19 @@ mod tests {
 
     #[test]
     fn test_compute_diff_single_template() {
-        let mut block_templates = HashMap::new();
+        // Create a single StateDiff entry
         let sender = Address::random();
-
+        let nonce = 1;
+        let balance_diff = U256::from(2);
         let mut diffs = HashMap::new();
-        diffs.insert(sender.clone(), (1, U256::from(2)));
+        diffs.insert(sender, (nonce, balance_diff));
 
-        let mut state_diff = StateDiff::default();
-        state_diff.diffs = diffs.clone();
+        // Insert StateDiff entry
+        let state_diff = StateDiff { diffs };
 
+        // Create BlockTemplate with StateDiff
+        let mut block_templates = HashMap::new();
         let block_template = BlockTemplate { state_diff, signed_constraints_list: vec![] };
-
         block_templates.insert(10, block_template);
 
         let (nonce_diff, balance_diff, highest_slot) = compute_diffs(&block_templates, &sender);

--- a/bolt-sidecar/src/state/execution.rs
+++ b/bolt-sidecar/src/state/execution.rs
@@ -332,10 +332,6 @@ impl<C: StateFetcher> ExecutionState<C> {
             let (nonce_diff, balance_diff, highest_slot_for_account) =
                 compute_diffs(&self.block_templates, sender);
 
-            // This might be noisy but it is a critical part in validation logic and
-            // hard to debug.
-            trace!(?nonce_diff, ?balance_diff, ?slot, ?sender, "found diffs");
-
             if target_slot < highest_slot_for_account {
                 debug!(%target_slot, %highest_slot_for_account, "There is a request for a higher slot");
                 return Err(ValidationError::SlotTooLow(highest_slot_for_account));
@@ -566,7 +562,7 @@ pub struct StateUpdate {
 }
 
 /// Calculate aggregated diffs for an account, given some block templates.
-/// 
+///
 /// From previous preconfirmations requests retrieve
 /// - the nonce difference from the account state.
 /// - the balance difference from the account state.
@@ -585,6 +581,9 @@ fn compute_diffs(
                 .get_diff(sender)
                 .map(|(nonce, balance)| (nonce, balance, *slot))
                 .unwrap_or((0, U256::ZERO, 0));
+            // This might be noisy but it is a critical part in validation logic and
+            // hard to debug.
+            trace!(?nonce_diff, ?balance_diff, ?slot, ?sender, "found diffs");
 
             (
                 nonce_diff_acc + nonce_diff,


### PR DESCRIPTION
`validate_request()` is very long and hard to follow, so breaking it up and adding tests