### PR TITLE
fix(sidecar): don't mutate `account_state` on template refresh

### DIFF
--- a/bolt-sidecar/src/state/execution.rs
+++ b/bolt-sidecar/src/state/execution.rs
@@ -505,16 +505,16 @@ impl<C: StateFetcher> ExecutionState<C> {
     /// transactions by checking the nonce and balance of the account after applying the state
     /// diffs.
     fn refresh_templates(&mut self) {
-        for (address, (account_state, _)) in self.account_states.iter_mut() {
+        for (address, mut account_state) in self.account_states.iter().map(|(a, (s, _))| (*a, *s)) {
             trace!(%address, ?account_state, "Refreshing template...");
             // Iterate over all block templates and apply the state diff
             for template in self.block_templates.values_mut() {
                 // Retain only signed constraints where transactions are still valid based on the
                 // canonical account states.
-                template.retain(*address, *account_state);
+                template.retain(address, account_state);
 
                 // Update the account state with the remaining state diff for the next iteration.
-                if let Some((nonce_diff, balance_diff)) = template.get_diff(address) {
+                if let Some((nonce_diff, balance_diff)) = template.get_diff(&address) {
                     // Nonce will always be increased
                     account_state.transaction_count += nonce_diff;
                     // Balance will always be decreased


### PR DESCRIPTION
Closes #505.

The problem wasn't related to missed slot this time but the logic of refreshing templates.

https://github.com/chainbound/bolt/blob/edaec2964dac70cfcf3bcfad73bd75c62810805d/bolt-sidecar/src/state/execution.rs#L507-L525

It should not `iter_mut` over the `account_states` but rather copying it, which is cheap since it `AccountState` implements `Copy`. 
By mutating it, if two inclusion requests are made for the same `target_slot` but during different slots, then the validation fails because the account state has wrong nonce due to adding block templates nonce and balance diffs to it.

A test to cover this case has been introduced.
Tested on devnet as well