### PR TITLE
chore(holesky): pin lighthouse image, change docs

### DIFF
--- a/testnets/holesky/README.md
+++ b/testnets/holesky/README.md
@@ -12,33 +12,33 @@ This document provides instructions for running Bolt on the Holesky testnet.
 
 <!-- vim-markdown-toc GFM -->
 
-- [Prerequisites](#prerequisites)
-- [On-Chain Registration](#on-chain-registration)
-  - [Validator Registration](#validator-registration)
-    - [Registration Steps](#registration-steps)
-  - [Bolt Network Entrypoint](#bolt-network-entrypoint)
-  - [Operator Registration](#operator-registration)
-    - [Symbiotic Registration Steps](#symbiotic-registration-steps)
-    - [EigenLayer Registration Steps](#eigenlayer-registration-steps)
-- [Off-Chain Setup](#off-chain-setup)
-  - [Docker Mode (recommended)](#docker-mode-recommended)
-  - [Commit-Boost Mode](#commit-boost-mode)
-  - [Native Mode (advanced)](#native-mode-advanced)
-    - [Building and running the MEV-Boost fork binary](#building-and-running-the-mev-boost-fork-binary)
-    - [Building and running the Bolt sidecar binary](#building-and-running-the-bolt-sidecar-binary)
-      - [Configuration file](#configuration-file)
-    - [Observability](#observability)
-    - [Firewall Configuration](#firewall-configuration)
-- [Reference](#reference)
-  - [Supported RPC nodes](#supported-rpc-nodes)
-  - [Supported Relays](#supported-relays)
-  - [Command-line options](#command-line-options)
-  - [Delegations and signing options for Native and Docker Compose Mode](#delegations-and-signing-options-for-native-and-docker-compose-mode)
-    - [`bolt` CLI](#bolt-cli)
-      - [Installation and usage](#installation-and-usage)
-    - [Using a private key directly](#using-a-private-key-directly)
-    - [Using a ERC-2335 Keystore](#using-a-erc-2335-keystore)
-  - [Avoid restarting the beacon node](#avoid-restarting-the-beacon-node)
+* [Prerequisites](#prerequisites)
+* [On-Chain Registration](#on-chain-registration)
+  * [Validator Registration](#validator-registration)
+    * [Registration Steps](#registration-steps)
+  * [Bolt Network Entrypoint](#bolt-network-entrypoint)
+  * [Operator Registration](#operator-registration)
+    * [Symbiotic Registration Steps](#symbiotic-registration-steps)
+    * [EigenLayer Registration Steps](#eigenlayer-registration-steps)
+* [Off-Chain Setup](#off-chain-setup)
+  * [Docker Mode (recommended)](#docker-mode-recommended)
+  * [Commit-Boost Mode](#commit-boost-mode)
+  * [Native Mode (advanced)](#native-mode-advanced)
+    * [Building and running the MEV-Boost fork binary](#building-and-running-the-mev-boost-fork-binary)
+    * [Building and running the Bolt sidecar binary](#building-and-running-the-bolt-sidecar-binary)
+      * [Configuration file](#configuration-file)
+    * [Observability](#observability)
+    * [Firewall Configuration](#firewall-configuration)
+* [Reference](#reference)
+  * [Supported RPC nodes](#supported-rpc-nodes)
+  * [Supported Relays](#supported-relays)
+  * [Command-line options](#command-line-options)
+  * [Delegations and signing options for Native and Docker Compose Mode](#delegations-and-signing-options-for-native-and-docker-compose-mode)
+    * [`bolt` CLI](#bolt-cli)
+      * [Installation and usage](#installation-and-usage)
+    * [Using a private key directly](#using-a-private-key-directly)
+    * [Using a ERC-2335 Keystore](#using-a-erc-2335-keystore)
+  * [Avoid restarting the beacon node](#avoid-restarting-the-beacon-node)
 
 <!-- vim-markdown-toc -->
 
@@ -71,21 +71,15 @@ client implementations to download and run them.
 
 > [!IMPORTANT]
 > In order to correctly run the Bolt sidecar and avoid commitment faults the
-> beacon node must be configured so that:
+> beacon node and the validator client must be configured so that:
 >
 > 1. the node's `builder-api` (or equivalent flag) must point to the Bolt
 >    Sidecar API.
-> 2. the node will always prefer the builder payload. For instance, in
->    Lighthouse this can be achieved by providing the following flags:
->
->    ```text
->    --always-prefer-builder-payload
->    --builder-fallback-disable-checks
->    ```
->
-> In other clients like Vouch, the same can be achieved by setting the
-> `builder-boost-factor` to a large value like `18446744073709551615` (`2**64 -
-1`).
+> 2. the node and the validator client will always prefer the builder payload,
+>    and try to use the builder API. For instance, in Lighthouse this can be
+>    done by setting the `builder-fallback-disabled-checks` flag and the
+>    `builder-boost-factor` to a large value like `18446744073709551615`
+>    (`2**64 - 1`).
 >
 > It might be necessary to restart your beacon node depending on your existing
 > setup. See the [Avoid Restarting the Beacon

--- a/testnets/holesky/README.md
+++ b/testnets/holesky/README.md
@@ -77,7 +77,7 @@ client implementations to download and run them.
 >    Sidecar API.
 > 2. the node and the validator client will always prefer the builder payload,
 >    and try to use the builder API. For instance, in Lighthouse this can be
->    done by setting the `builder-fallback-disabled-checks` flag and the
+>    done by setting the `builder-fallback-disable-checks` flag and the
 >    `builder-boost-factor` to a large value like `18446744073709551615`
 >    (`2**64 - 1`).
 >

--- a/testnets/holesky/docker-compose.pbs.yml
+++ b/testnets/holesky/docker-compose.pbs.yml
@@ -51,7 +51,7 @@ services:
       ]
 
   beacon:
-    image: sigp/lighthouse:latest
+    image: sigp/lighthouse:v5.3.0
     restart: unless-stopped
     volumes:
       - "chaindata:/var/lib/chaindata"


### PR DESCRIPTION
Minor changes to reflect the new Lighthouse release that removes the `always-prefer-builder-payload` flag. The image is now pinned, and docs have been changed a bit.

The section on what flags to provide is a bit generic but it's okay for now. Ideally we should add a comprehensive guide on which flags to enable on all beacon clients/validators clients.