### PR TITLE
chore(sidecar): bump alloy version to 0.7.2

### DIFF
--- a/bolt-sidecar/Cargo.lock
+++ b/bolt-sidecar/Cargo.lock
@@ -143,25 +143,25 @@ dependencies = [
 
 [[package]]
 name = "alloy"
-version = "0.6.4"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b5b524b8c28a7145d1fe4950f84360b5de3e307601679ff0558ddc20ea229399"
+checksum = "44ab65cb6104c389b46df77b7990cab08780f57e41b412b46d6d12baf7e8c716"
 dependencies = [
- "alloy-consensus 0.6.4",
+ "alloy-consensus 0.7.2",
  "alloy-contract",
  "alloy-core 0.8.12",
- "alloy-eips 0.6.4",
- "alloy-genesis 0.6.4",
- "alloy-network 0.6.4",
- "alloy-provider 0.6.4",
+ "alloy-eips 0.7.2",
+ "alloy-genesis 0.7.2",
+ "alloy-network 0.7.2",
+ "alloy-provider 0.7.2",
  "alloy-pubsub",
- "alloy-rpc-client 0.6.4",
- "alloy-rpc-types 0.6.4",
- "alloy-serde 0.6.4",
- "alloy-signer 0.6.4",
+ "alloy-rpc-client 0.7.2",
+ "alloy-rpc-types 0.7.2",
+ "alloy-serde 0.7.2",
+ "alloy-signer 0.7.2",
  "alloy-signer-local",
- "alloy-transport 0.6.4",
- "alloy-transport-http 0.6.4",
+ "alloy-transport 0.7.2",
+ "alloy-transport-http 0.7.2",
  "alloy-transport-ipc",
  "alloy-transport-ws",
 ]
@@ -194,14 +194,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-consensus"
-version = "0.6.4"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae09ffd7c29062431dd86061deefe4e3c6f07fa0d674930095f8dcedb0baf02c"
+checksum = "73dd0ab7003dfa3efd252e423873cd3bc241d1456147e752f995cc8aabd1d1f6"
 dependencies = [
- "alloy-eips 0.6.4",
+ "alloy-eips 0.7.2",
  "alloy-primitives 0.8.12",
  "alloy-rlp",
- "alloy-serde 0.6.4",
+ "alloy-serde 0.7.2",
+ "alloy-trie",
  "auto_impl",
  "c-kzg",
  "derive_more 1.0.0",
@@ -210,24 +211,38 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-contract"
-version = "0.6.4"
+name = "alloy-consensus-any"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66430a72d5bf5edead101c8c2f0a24bada5ec9f3cf9909b3e08b6d6899b4803e"
+checksum = "d08234c0eece0e08602db5095a16dc942cad91967cccfcfc2c6a42c25563964f"
+dependencies = [
+ "alloy-consensus 0.7.2",
+ "alloy-eips 0.7.2",
+ "alloy-primitives 0.8.12",
+ "alloy-rlp",
+ "alloy-serde 0.7.2",
+ "serde",
+]
+
+[[package]]
+name = "alloy-contract"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6a01f5593f6878452c6dde102ece391b60cba79801c5f606f8fe898ff57cd5d7"
 dependencies = [
  "alloy-dyn-abi 0.8.12",
  "alloy-json-abi 0.8.12",
- "alloy-network 0.6.4",
- "alloy-network-primitives 0.6.4",
+ "alloy-network 0.7.2",
+ "alloy-network-primitives 0.7.2",
  "alloy-primitives 0.8.12",
- "alloy-provider 0.6.4",
+ "alloy-provider 0.7.2",
  "alloy-pubsub",
- "alloy-rpc-types-eth 0.6.4",
+ "alloy-rpc-types-eth 0.7.2",
  "alloy-sol-types 0.8.12",
- "alloy-transport 0.6.4",
+ "alloy-transport 0.7.2",
  "futures",
  "futures-util",
- "thiserror",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
@@ -332,15 +347,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-eips"
-version = "0.6.4"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b6aa3961694b30ba53d41006131a2fca3bdab22e4c344e46db2c639e7c2dfdd"
+checksum = "50c242de43a1869bcb2fbce3b377130959d10dfd562b87ac7aa2f04d98baac51"
 dependencies = [
  "alloy-eip2930",
  "alloy-eip7702",
  "alloy-primitives 0.8.12",
  "alloy-rlp",
- "alloy-serde 0.6.4",
+ "alloy-serde 0.7.2",
  "c-kzg",
  "derive_more 1.0.0",
  "once_cell",
@@ -361,12 +376,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-genesis"
-version = "0.6.4"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53f7877ded3921d18a0a9556d55bedf84535567198c9edab2aa23106da91855"
+checksum = "9dd39b72f860cb0c542fac925f91d1939c2b14a0970b39d0ae304b5b7574a0ac"
 dependencies = [
  "alloy-primitives 0.8.12",
- "alloy-serde 0.6.4",
+ "alloy-serde 0.7.2",
  "serde",
 ]
 
@@ -404,21 +419,21 @@ dependencies = [
  "alloy-sol-types 0.7.7",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
 ]
 
 [[package]]
 name = "alloy-json-rpc"
-version = "0.6.4"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3694b7e480728c0b3e228384f223937f14c10caef5a4c766021190fc8f283d35"
+checksum = "6c15c11661571a19a06896663c93e804ccf013159275a89a98e892014df514d8"
 dependencies = [
  "alloy-primitives 0.8.12",
  "alloy-sol-types 0.8.12",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.3",
  "tracing",
 ]
 
@@ -440,30 +455,32 @@ dependencies = [
  "async-trait",
  "auto_impl",
  "futures-utils-wasm",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "alloy-network"
-version = "0.6.4"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea94b8ceb5c75d7df0a93ba0acc53b55a22b47b532b600a800a87ef04eb5b0b4"
+checksum = "60dd0b99eaa5e715dd90d42021f7f08a0a70976ea84f41a0ad233770e0c1962b"
 dependencies = [
- "alloy-consensus 0.6.4",
- "alloy-eips 0.6.4",
- "alloy-json-rpc 0.6.4",
- "alloy-network-primitives 0.6.4",
+ "alloy-consensus 0.7.2",
+ "alloy-consensus-any",
+ "alloy-eips 0.7.2",
+ "alloy-json-rpc 0.7.2",
+ "alloy-network-primitives 0.7.2",
  "alloy-primitives 0.8.12",
- "alloy-rpc-types-eth 0.6.4",
- "alloy-serde 0.6.4",
- "alloy-signer 0.6.4",
+ "alloy-rpc-types-any",
+ "alloy-rpc-types-eth 0.7.2",
+ "alloy-serde 0.7.2",
+ "alloy-signer 0.7.2",
  "alloy-sol-types 0.8.12",
  "async-trait",
  "auto_impl",
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
@@ -479,30 +496,30 @@ dependencies = [
 
 [[package]]
 name = "alloy-network-primitives"
-version = "0.6.4"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df9f3e281005943944d15ee8491534a1c7b3cbf7a7de26f8c433b842b93eb5f9"
+checksum = "18abfc73ce48f074c8bc6e05c1f08ef0b1ddc9b04f191a821d0beb9470a42a29"
 dependencies = [
- "alloy-consensus 0.6.4",
- "alloy-eips 0.6.4",
+ "alloy-consensus 0.7.2",
+ "alloy-eips 0.7.2",
  "alloy-primitives 0.8.12",
- "alloy-serde 0.6.4",
+ "alloy-serde 0.7.2",
  "serde",
 ]
 
 [[package]]
 name = "alloy-node-bindings"
-version = "0.6.4"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c9805d126f24be459b958973c0569c73e1aadd27d4535eee82b2b6764aa03616"
+checksum = "f9a04cf8f3a19b024b2bc71b5774d423cd2edda7f67df6029daa1368c5c02da5"
 dependencies = [
- "alloy-genesis 0.6.4",
+ "alloy-genesis 0.7.2",
  "alloy-primitives 0.8.12",
  "k256 0.13.4",
  "rand 0.8.5",
  "serde_json",
  "tempfile",
- "thiserror",
+ "thiserror 2.0.3",
  "tracing",
  "url",
 ]
@@ -594,24 +611,24 @@ dependencies = [
 
 [[package]]
 name = "alloy-provider"
-version = "0.6.4"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c1f9eede27bf4c13c099e8e64d54efd7ce80ef6ea47478aa75d5d74e2dba3b"
+checksum = "4933c761f10e44d5e901804b56efb2ce6e0945e6c57d2fa1e5ace303fae6f74a"
 dependencies = [
  "alloy-chains",
- "alloy-consensus 0.6.4",
- "alloy-eips 0.6.4",
- "alloy-json-rpc 0.6.4",
- "alloy-network 0.6.4",
- "alloy-network-primitives 0.6.4",
+ "alloy-consensus 0.7.2",
+ "alloy-eips 0.7.2",
+ "alloy-json-rpc 0.7.2",
+ "alloy-network 0.7.2",
+ "alloy-network-primitives 0.7.2",
  "alloy-primitives 0.8.12",
  "alloy-pubsub",
- "alloy-rpc-client 0.6.4",
- "alloy-rpc-types-engine 0.6.4",
- "alloy-rpc-types-eth 0.6.4",
+ "alloy-rpc-client 0.7.2",
+ "alloy-rpc-types-engine 0.7.2",
+ "alloy-rpc-types-eth 0.7.2",
  "alloy-rpc-types-trace",
- "alloy-transport 0.6.4",
- "alloy-transport-http 0.6.4",
+ "alloy-transport 0.7.2",
+ "alloy-transport-http 0.7.2",
  "alloy-transport-ipc",
  "alloy-transport-ws",
  "async-stream",
@@ -627,7 +644,7 @@ dependencies = [
  "schnellru",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.3",
  "tokio",
  "tracing",
  "url",
@@ -636,13 +653,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-pubsub"
-version = "0.6.4"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "90f1f34232f77341076541c405482e4ae12f0ee7153d8f9969fc1691201b2247"
+checksum = "808719714bfb2aa24b0eb2a38411ce8e654ba11c0ebf2a6648fcbe9fabfe696d"
 dependencies = [
- "alloy-json-rpc 0.6.4",
+ "alloy-json-rpc 0.7.2",
  "alloy-primitives 0.8.12",
- "alloy-transport 0.6.4",
+ "alloy-transport 0.7.2",
  "bimap",
  "futures",
  "serde",
@@ -698,15 +715,15 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-client"
-version = "0.6.4"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "374dbe0dc3abdc2c964f36b3d3edf9cdb3db29d16bda34aa123f03d810bec1dd"
+checksum = "6ce26c25efb8290b6ba559ae6c40bf6630d337e107ae242e5790501420dba7b7"
 dependencies = [
- "alloy-json-rpc 0.6.4",
+ "alloy-json-rpc 0.7.2",
  "alloy-primitives 0.8.12",
  "alloy-pubsub",
- "alloy-transport 0.6.4",
- "alloy-transport-http 0.6.4",
+ "alloy-transport 0.7.2",
+ "alloy-transport-http 0.7.2",
  "alloy-transport-ipc",
  "alloy-transport-ws",
  "futures",
@@ -737,17 +754,28 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types"
-version = "0.6.4"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c74832aa474b670309c20fffc2a869fa141edab7c79ff7963fad0a08de60bae1"
+checksum = "41080ce2640928f0df45c41d2af629b88db3cb31af3abbe614964ae10001ddac"
 dependencies = [
  "alloy-primitives 0.8.12",
- "alloy-rpc-types-beacon 0.6.4",
- "alloy-rpc-types-engine 0.6.4",
- "alloy-rpc-types-eth 0.6.4",
+ "alloy-rpc-types-beacon 0.7.2",
+ "alloy-rpc-types-engine 0.7.2",
+ "alloy-rpc-types-eth 0.7.2",
  "alloy-rpc-types-trace",
- "alloy-serde 0.6.4",
+ "alloy-serde 0.7.2",
  "serde",
+]
+
+[[package]]
+name = "alloy-rpc-types-any"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "abca110e59f760259e26d0c84912121468008aba48dd227af0f306cfd7bce9ae"
+dependencies = [
+ "alloy-consensus-any",
+ "alloy-rpc-types-eth 0.7.2",
+ "alloy-serde 0.7.2",
 ]
 
 [[package]]
@@ -763,21 +791,22 @@ dependencies = [
  "ethereum_ssz_derive",
  "serde",
  "serde_with",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "alloy-rpc-types-beacon"
-version = "0.6.4"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "922fa76678d2f9f07ea1b19309b5cfbf244c6029dcba3515227b515fdd6ed4a7"
+checksum = "45c8db5fb70d2fece7bc1cd5adf42e72fc8a23547adeff8f558d9063f1e7788c"
 dependencies = [
- "alloy-eips 0.6.4",
+ "alloy-eips 0.7.2",
  "alloy-primitives 0.8.12",
- "alloy-rpc-types-engine 0.6.4",
+ "alloy-rpc-types-engine 0.7.2",
+ "alloy-serde 0.7.2",
  "serde",
  "serde_with",
- "thiserror",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
@@ -797,20 +826,20 @@ dependencies = [
  "jsonwebtoken",
  "rand 0.8.5",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "alloy-rpc-types-engine"
-version = "0.6.4"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f56294dce86af23ad6ee8df46cf8b0d292eb5d1ff67dc88a0886051e32b1faf"
+checksum = "d3b000c7f3469e7faa575ba70207294cf07e91dfd6ce4d04d5d5d8069f974a66"
 dependencies = [
- "alloy-consensus 0.6.4",
- "alloy-eips 0.6.4",
+ "alloy-consensus 0.7.2",
+ "alloy-eips 0.7.2",
  "alloy-primitives 0.8.12",
  "alloy-rlp",
- "alloy-serde 0.6.4",
+ "alloy-serde 0.7.2",
  "derive_more 1.0.0",
  "jsonwebtoken",
  "rand 0.8.5",
@@ -834,21 +863,22 @@ dependencies = [
  "itertools 0.13.0",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "alloy-rpc-types-eth"
-version = "0.6.4"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8a477281940d82d29315846c7216db45b15e90bcd52309da9f54bcf7ad94a11"
+checksum = "3468e7385fbb86b0fde5497d685c02f765ea09d36f7e07c5d1c9a52b077d38e2"
 dependencies = [
- "alloy-consensus 0.6.4",
- "alloy-eips 0.6.4",
- "alloy-network-primitives 0.6.4",
+ "alloy-consensus 0.7.2",
+ "alloy-consensus-any",
+ "alloy-eips 0.7.2",
+ "alloy-network-primitives 0.7.2",
  "alloy-primitives 0.8.12",
  "alloy-rlp",
- "alloy-serde 0.6.4",
+ "alloy-serde 0.7.2",
  "alloy-sol-types 0.8.12",
  "derive_more 1.0.0",
  "itertools 0.13.0",
@@ -858,16 +888,16 @@ dependencies = [
 
 [[package]]
 name = "alloy-rpc-types-trace"
-version = "0.6.4"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ecd8b4877ef520c138af702097477cdd19504a8e1e4675ba37e92ba40f2d3c6f"
+checksum = "7a90be1bc8e3659db1c9512191873a268a917efbc62b8bd39a92c12bf613b193"
 dependencies = [
  "alloy-primitives 0.8.12",
- "alloy-rpc-types-eth 0.6.4",
- "alloy-serde 0.6.4",
+ "alloy-rpc-types-eth 0.7.2",
+ "alloy-serde 0.7.2",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
@@ -883,9 +913,9 @@ dependencies = [
 
 [[package]]
 name = "alloy-serde"
-version = "0.6.4"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4dfa4a7ccf15b2492bb68088692481fd6b2604ccbee1d0d6c44c21427ae4df83"
+checksum = "42de6002e2154b50b3568aea27e26bd9caf7b754658f43065f2e9b6ee0a8c839"
 dependencies = [
  "alloy-primitives 0.8.12",
  "serde",
@@ -903,37 +933,37 @@ dependencies = [
  "auto_impl",
  "elliptic-curve 0.13.8",
  "k256 0.13.4",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
 name = "alloy-signer"
-version = "0.6.4"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e10aec39d60dc27edcac447302c7803d2371946fb737245320a05b78eb2fafd"
+checksum = "f288a9a25e2578dab17845fd8d2be1d32de33565783ed185ded161a65f92381b"
 dependencies = [
  "alloy-primitives 0.8.12",
  "async-trait",
  "auto_impl",
  "elliptic-curve 0.13.8",
  "k256 0.13.4",
- "thiserror",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
 name = "alloy-signer-local"
-version = "0.6.4"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d8396f6dff60700bc1d215ee03d86ff56de268af96e2bf833a14d0bafcab9882"
+checksum = "0d8081f589ddc11a959605e30c723d51cad2562d9072305f8e3ef311f077e5eb"
 dependencies = [
- "alloy-consensus 0.6.4",
- "alloy-network 0.6.4",
+ "alloy-consensus 0.7.2",
+ "alloy-network 0.7.2",
  "alloy-primitives 0.8.12",
- "alloy-signer 0.6.4",
+ "alloy-signer 0.7.2",
  "async-trait",
  "k256 0.13.4",
  "rand 0.8.5",
- "thiserror",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
@@ -1090,7 +1120,7 @@ dependencies = [
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tower 0.4.13",
  "tracing",
@@ -1099,17 +1129,17 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport"
-version = "0.6.4"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f99acddb34000d104961897dbb0240298e8b775a7efffb9fda2a1a3efedd65b3"
+checksum = "90352f4cf78017905c3244f48b38fadc345970bbc9095087c0f985a580550488"
 dependencies = [
- "alloy-json-rpc 0.6.4",
+ "alloy-json-rpc 0.7.2",
  "base64 0.22.1",
  "futures-util",
  "futures-utils-wasm",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 2.0.3",
  "tokio",
  "tower 0.5.1",
  "tracing",
@@ -1134,12 +1164,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-http"
-version = "0.6.4"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dc013132e34eeadaa0add7e74164c1503988bfba8bae885b32e0918ba85a8a6"
+checksum = "7d26c94d51fa8b1aee3d15db113dd0773776c02bb36dbaa2590b900dadd7e7d0"
 dependencies = [
- "alloy-json-rpc 0.6.4",
- "alloy-transport 0.6.4",
+ "alloy-json-rpc 0.7.2",
+ "alloy-transport 0.7.2",
  "reqwest 0.12.9",
  "serde_json",
  "tower 0.5.1",
@@ -1149,13 +1179,13 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ipc"
-version = "0.6.4"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "063edc0660e81260653cc6a95777c29d54c2543a668aa5da2359fb450d25a1ba"
+checksum = "14c498fcdec50650be6b6a22ce7928a1b2738086b4f94f31b132e83498d45bbb"
 dependencies = [
- "alloy-json-rpc 0.6.4",
+ "alloy-json-rpc 0.7.2",
  "alloy-pubsub",
- "alloy-transport 0.6.4",
+ "alloy-transport 0.7.2",
  "bytes",
  "futures",
  "interprocess",
@@ -1168,12 +1198,12 @@ dependencies = [
 
 [[package]]
 name = "alloy-transport-ws"
-version = "0.6.4"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "abd170e600801116d5efe64f74a4fc073dbbb35c807013a7d0a388742aeebba0"
+checksum = "cd7b21335b55c9f715e2acca0228dc1d6880d961756916c13a9ce70f9f413e70"
 dependencies = [
  "alloy-pubsub",
- "alloy-transport 0.6.4",
+ "alloy-transport 0.7.2",
  "futures",
  "http 1.1.0",
  "rustls 0.23.16",
@@ -1724,7 +1754,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "url",
@@ -1895,9 +1925,9 @@ name = "bolt-sidecar"
 version = "0.3.0-alpha"
 dependencies = [
  "account_utils",
- "alloy 0.6.4",
+ "alloy 0.7.2",
  "alloy-node-bindings",
- "alloy-rpc-types-engine 0.6.4",
+ "alloy-rpc-types-engine 0.7.2",
  "async-trait",
  "axum",
  "axum-extra",
@@ -1927,7 +1957,7 @@ dependencies = [
  "serde",
  "serde_json",
  "ssz_rs 0.9.0 (git+https://github.com/ralexstokes/ssz-rs?rev=ec3073e)",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-retry",
  "tower-http",
@@ -1963,12 +1993,6 @@ name = "byte-slice-cast"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3ac9f8b63eca6fd385229b3675f6cc0dc5c8a5c8a54a59d4f52ffd670d87b0c"
-
-[[package]]
-name = "bytemuck"
-version = "1.19.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8334215b81e418a0a7bdb8ef0849474f40bb10c8b71f1c4ed315cff49f32494d"
 
 [[package]]
 name = "byteorder"
@@ -2079,7 +2103,7 @@ dependencies = [
  "serde",
  "serde_json",
  "ssz_types 0.5.4",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "toml 0.8.19",
  "tracing",
@@ -2099,7 +2123,7 @@ dependencies = [
  "cb-common",
  "eyre",
  "prometheus",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
@@ -2122,7 +2146,7 @@ dependencies = [
  "prometheus",
  "reqwest 0.12.9",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "url",
@@ -2145,7 +2169,7 @@ dependencies = [
  "headers",
  "k256 0.13.4",
  "lazy_static",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
  "tree_hash 0.5.2",
@@ -3410,7 +3434,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3 0.9.1",
- "thiserror",
+ "thiserror 1.0.69",
  "uint",
 ]
 
@@ -3427,7 +3451,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha3 0.10.8",
- "thiserror",
+ "thiserror 1.0.69",
  "uint",
 ]
 
@@ -3478,7 +3502,7 @@ dependencies = [
  "serde_yaml 0.8.26",
  "sha2 0.10.8",
  "ssz_rs 0.9.0 (git+https://github.com/ralexstokes/ssz-rs?rev=84ef2b71aa004f6767420badb42c902ad56b8b72)",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
 ]
@@ -3595,7 +3619,7 @@ dependencies = [
  "serde_json",
  "strum",
  "tempfile",
- "thiserror",
+ "thiserror 1.0.69",
  "tiny-keccak",
  "unicode-xid",
 ]
@@ -4954,7 +4978,7 @@ dependencies = [
  "multiaddr 0.18.2",
  "pin-project",
  "rw-stream-sink",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -5002,7 +5026,7 @@ dependencies = [
  "rand 0.8.5",
  "rw-stream-sink",
  "smallvec",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "unsigned-varint 0.8.0",
  "void",
@@ -5024,7 +5048,7 @@ dependencies = [
  "quick-protobuf",
  "rand 0.8.5",
  "sha2 0.10.8",
- "thiserror",
+ "thiserror 1.0.69",
  "tracing",
  "zeroize",
 ]
@@ -5298,7 +5322,7 @@ dependencies = [
  "metrics",
  "metrics-util",
  "quanta",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
@@ -5332,7 +5356,7 @@ dependencies = [
  "reqwest 0.11.27",
  "serde",
  "serde_json",
- "thiserror",
+ "thiserror 1.0.69",
  "tokio",
  "tracing",
 ]
@@ -5706,32 +5730,32 @@ checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "op-alloy-consensus"
-version = "0.6.5"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bff54d1d790eca1f3aedbd666162e9c42eceff90b9f9d24b352ed9c2df1e901a"
+checksum = "77284451ec70602f148f4f3bc6d1106fdfefd57c11ff459c4b2985e400ed1a18"
 dependencies = [
- "alloy-consensus 0.6.4",
- "alloy-eips 0.6.4",
+ "alloy-consensus 0.7.2",
+ "alloy-eips 0.7.2",
  "alloy-primitives 0.8.12",
  "alloy-rlp",
- "alloy-serde 0.6.4",
+ "alloy-serde 0.7.2",
  "derive_more 1.0.0",
  "serde",
- "spin 0.9.8",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
 name = "op-alloy-rpc-types"
-version = "0.6.5"
+version = "0.7.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "981b7f8ab11fe85ba3c1723702f000429b8d0c16b5883c93d577895f262cbac6"
+checksum = "2bdc32eba4d43bbd23f1f16dece7afd991d41ab4ffc2494a72b048e9f38db622"
 dependencies = [
- "alloy-consensus 0.6.4",
- "alloy-eips 0.6.4",
- "alloy-network-primitives 0.6.4",
+ "alloy-consensus 0.7.2",
+ "alloy-eips 0.7.2",
+ "alloy-network-primitives 0.7.2",
  "alloy-primitives 0.8.12",
- "alloy-rpc-types-eth 0.6.4",
- "alloy-serde 0.6.4",
+ "alloy-rpc-types-eth 0.7.2",
+ "alloy-serde 0.7.2",
  "derive_more 1.0.0",
  "op-alloy-consensus",
  "serde",
@@ -6002,7 +6026,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "879952a81a83930934cbf1786752d6dedc3b1f29e8f8fb2ad1d0a36f377cf442"
 dependencies = [
  "memchr",
- "thiserror",
+ "thiserror 1.0.69",
  "ucd-trie",
 ]
 
@@ -6187,7 +6211,7 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e17d47ce914bf4de440332250b0edd23ce48c005f59fab39d3335866b114f11a"
 dependencies = [
- "thiserror",
+ "thiserror 1.0.69",
  "toml 0.5.11",
 ]
 
@@ -6267,7 +6291,7 @@ dependencies = [
  "memchr",
  "parking_lot 0.12.3",
  "protobuf",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6489,7 +6513,7 @@ checksum = "ba009ff324d1fc1b900bd1fdb31564febe58a8ccc8a6fdbb93b543d33b13ca43"
 dependencies = [
  "getrandom 0.2.15",
  "libredox",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -6627,24 +6651,25 @@ dependencies = [
 
 [[package]]
 name = "reth-codecs"
-version = "1.1.1"
-source = "git+https://github.com/paradigmxyz/reth#c326708ffc14f1dae63419521884b0a90b3e037d"
+version = "1.1.2"
+source = "git+https://github.com/paradigmxyz/reth#bedc68e8f4bd26927c1285e64e1cc652a0d839ff"
 dependencies = [
- "alloy-consensus 0.6.4",
- "alloy-eips 0.6.4",
- "alloy-genesis 0.6.4",
+ "alloy-consensus 0.7.2",
+ "alloy-eips 0.7.2",
+ "alloy-genesis 0.7.2",
  "alloy-primitives 0.8.12",
  "alloy-trie",
  "bytes",
  "modular-bitfield",
+ "op-alloy-consensus",
  "reth-codecs-derive",
  "serde",
 ]
 
 [[package]]
 name = "reth-codecs-derive"
-version = "1.1.1"
-source = "git+https://github.com/paradigmxyz/reth#c326708ffc14f1dae63419521884b0a90b3e037d"
+version = "1.1.2"
+source = "git+https://github.com/paradigmxyz/reth#bedc68e8f4bd26927c1285e64e1cc652a0d839ff"
 dependencies = [
  "convert_case 0.6.0",
  "proc-macro2",
@@ -6654,8 +6679,8 @@ dependencies = [
 
 [[package]]
 name = "reth-ethereum-forks"
-version = "1.1.1"
-source = "git+https://github.com/paradigmxyz/reth#c326708ffc14f1dae63419521884b0a90b3e037d"
+version = "1.1.2"
+source = "git+https://github.com/paradigmxyz/reth#bedc68e8f4bd26927c1285e64e1cc652a0d839ff"
 dependencies = [
  "alloy-chains",
  "alloy-primitives 0.8.12",
@@ -6666,21 +6691,21 @@ dependencies = [
  "once_cell",
  "rustc-hash 2.0.0",
  "serde",
- "thiserror-no-std",
+ "thiserror 2.0.3",
 ]
 
 [[package]]
 name = "reth-primitives"
-version = "1.1.1"
-source = "git+https://github.com/paradigmxyz/reth#c326708ffc14f1dae63419521884b0a90b3e037d"
+version = "1.1.2"
+source = "git+https://github.com/paradigmxyz/reth#bedc68e8f4bd26927c1285e64e1cc652a0d839ff"
 dependencies = [
- "alloy-consensus 0.6.4",
- "alloy-eips 0.6.4",
- "alloy-network 0.6.4",
+ "alloy-consensus 0.7.2",
+ "alloy-eips 0.7.2",
+ "alloy-network 0.7.2",
  "alloy-primitives 0.8.12",
  "alloy-rlp",
- "alloy-rpc-types 0.6.4",
- "alloy-serde 0.6.4",
+ "alloy-rpc-types 0.7.2",
+ "alloy-serde 0.7.2",
  "alloy-trie",
  "bytes",
  "c-kzg",
@@ -6697,33 +6722,36 @@ dependencies = [
  "revm-primitives",
  "secp256k1",
  "serde",
+ "serde_with",
  "zstd 0.13.2",
 ]
 
 [[package]]
 name = "reth-primitives-traits"
-version = "1.1.1"
-source = "git+https://github.com/paradigmxyz/reth#c326708ffc14f1dae63419521884b0a90b3e037d"
+version = "1.1.2"
+source = "git+https://github.com/paradigmxyz/reth#bedc68e8f4bd26927c1285e64e1cc652a0d839ff"
 dependencies = [
- "alloy-consensus 0.6.4",
- "alloy-eips 0.6.4",
- "alloy-genesis 0.6.4",
+ "alloy-consensus 0.7.2",
+ "alloy-eips 0.7.2",
+ "alloy-genesis 0.7.2",
  "alloy-primitives 0.8.12",
  "alloy-rlp",
+ "auto_impl",
  "byteorder",
  "bytes",
  "derive_more 1.0.0",
  "modular-bitfield",
+ "op-alloy-consensus",
  "reth-codecs",
  "revm-primitives",
- "roaring",
  "serde",
+ "serde_with",
 ]
 
 [[package]]
 name = "reth-static-file-types"
-version = "1.1.1"
-source = "git+https://github.com/paradigmxyz/reth#c326708ffc14f1dae63419521884b0a90b3e037d"
+version = "1.1.2"
+source = "git+https://github.com/paradigmxyz/reth#bedc68e8f4bd26927c1285e64e1cc652a0d839ff"
 dependencies = [
  "alloy-primitives 0.8.12",
  "derive_more 1.0.0",
@@ -6828,16 +6856,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
-]
-
-[[package]]
-name = "roaring"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8f4b84ba6e838ceb47b41de5194a60244fac43d9fe03b71dbe8c5a201081d6d1"
-dependencies = [
- "bytemuck",
- "byteorder",
 ]
 
 [[package]]
@@ -7338,7 +7356,7 @@ checksum = "c7715380eec75f029a4ef7de39a9200e0a63823176b759d055b613f5a87df6a6"
 dependencies = [
  "percent-encoding",
  "serde",
- "thiserror",
+ "thiserror 1.0.69",
 ]
 
 [[package]]
@@ -7547,7 +7565,7 @@ checksum = "adc4e5204eb1910f40f9cfa375f6f05b68c3abac4b6fd879c8ff5e7ae8a0a085"
 dependencies = [
  "num-bigint",
  "num-traits",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
 ]
 
@@ -7708,9 +7726,6 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
 
 [[package]]
 name = "spki"
@@ -8073,7 +8088,16 @@ version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
- "thiserror-impl",
+ "thiserror-impl 1.0.69",
+]
+
+[[package]]
+name = "thiserror"
+version = "2.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c006c85c7651b3cf2ada4584faa36773bd07bac24acfb39f3c431b36d7e667aa"
+dependencies = [
+ "thiserror-impl 2.0.3",
 ]
 
 [[package]]
@@ -8088,23 +8112,14 @@ dependencies = [
 ]
 
 [[package]]
-name = "thiserror-impl-no-std"
-version = "2.0.2"
+name = "thiserror-impl"
+version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "58e6318948b519ba6dc2b442a6d0b904ebfb8d411a3ad3e07843615a72249758"
+checksum = "f077553d607adc1caf65430528a576c757a71ed73944b66ebb58ef2bbd243568"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "thiserror-no-std"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ad459d94dd517257cc96add8a43190ee620011bb6e6cdc82dafd97dfafafea"
-dependencies = [
- "thiserror-impl-no-std",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -8170,7 +8185,7 @@ dependencies = [
  "rand 0.8.5",
  "rustc-hash 1.1.0",
  "sha2 0.10.8",
- "thiserror",
+ "thiserror 1.0.69",
  "unicode-normalization",
  "wasm-bindgen",
  "zeroize",
@@ -8455,7 +8470,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
 dependencies = [
  "crossbeam-channel",
- "thiserror",
+ "thiserror 1.0.69",
  "time",
  "tracing-subscriber",
 ]
@@ -8628,7 +8643,7 @@ dependencies = [
  "rustls 0.23.16",
  "rustls-pki-types",
  "sha1",
- "thiserror",
+ "thiserror 1.0.69",
  "utf-8",
 ]
 
@@ -9357,7 +9372,7 @@ dependencies = [
  "pharos",
  "rustc_version 0.4.1",
  "send_wrapper",
- "thiserror",
+ "thiserror 1.0.69",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",

--- a/bolt-sidecar/Cargo.toml
+++ b/bolt-sidecar/Cargo.toml
@@ -27,18 +27,18 @@ ssz_rs = { git = "https://github.com/ralexstokes/ssz-rs", rev = "ec3073e" }
 ethereum_ssz = "0.5"
 
 # alloy
-alloy = { version = "0.6.4", features = [
+alloy = { version = "0.7.2", features = [
   "full",
   "provider-trace-api",
   "rpc-types-beacon",
   "rpc-types-engine",
 ] }
-alloy-rpc-types-engine = { version = "0.6.4", default-features = false, features = [
+alloy-rpc-types-engine = { version = "0.7.2", default-features = false, features = [
   "jwt",
 ] }
 
 # reth
-reth-primitives = { git = "https://github.com/paradigmxyz/reth", version = "1.1.1" }
+reth-primitives = { git = "https://github.com/paradigmxyz/reth", version = "1.1.2" }
 
 reqwest = "0.12"
 ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus", rev = "cf3c404" }
@@ -79,7 +79,7 @@ commit-boost = { git = "https://github.com/Commit-Boost/commit-boost-client", re
 cb-common = { git = "https://github.com/Commit-Boost/commit-boost-client", rev = "45ce8f1" }
 
 [dev-dependencies]
-alloy-node-bindings = "0.6.4"                                # must match alloy version
+alloy-node-bindings = "0.7.2"                                # must match alloy version
 criterion = { version = "0.5", features = ["html_reports"] }
 
 [package.metadata.cargo-machete]
@@ -95,6 +95,7 @@ harness = false
 [[bin]]
 name = "bolt-sidecar"
 path = "bin/sidecar.rs"
+
 
 [lints.clippy]
 explicit_iter_loop = "warn"

--- a/bolt-sidecar/src/builder/compat.rs
+++ b/bolt-sidecar/src/builder/compat.rs
@@ -1,4 +1,5 @@
 use alloy::{
+    consensus::BlockHeader,
     eips::{eip2718::Encodable2718, eip4895::Withdrawal},
     primitives::{Address, Bloom, B256, U256},
     rpc::types::{
@@ -99,7 +100,7 @@ pub(crate) fn to_alloy_execution_payload(
         .unwrap_or_default();
 
     AlloyExecutionPayload::V3(ExecutionPayloadV3 {
-        blob_gas_used: block.blob_gas_used(),
+        blob_gas_used: block.blob_gas_used().unwrap_or_default(),
         excess_blob_gas: block.excess_blob_gas.unwrap_or_default(),
         payload_inner: ExecutionPayloadV2 {
             payload_inner: ExecutionPayloadV1 {
@@ -107,7 +108,7 @@ pub(crate) fn to_alloy_execution_payload(
                 block_hash,
                 block_number: block.number,
                 extra_data: block.extra_data.clone(),
-                transactions: block.raw_transactions(),
+                transactions: block.encoded_2718_transactions(),
                 fee_recipient: block.header.beneficiary,
                 gas_limit: block.gas_limit,
                 gas_used: block.gas_used,
@@ -161,7 +162,7 @@ pub(crate) fn to_consensus_execution_payload(value: &SealedBlock) -> ConsensusEx
         block_hash: to_bytes32(hash),
         transactions: TryFrom::try_from(transactions).unwrap(),
         withdrawals: TryFrom::try_from(withdrawals).unwrap(),
-        blob_gas_used: value.blob_gas_used(),
+        blob_gas_used: value.blob_gas_used().unwrap_or_default(),
         excess_blob_gas: value.excess_blob_gas.unwrap_or_default(),
     };
     ConsensusExecutionPayload::Deneb(payload)

--- a/bolt-sidecar/src/builder/template.rs
+++ b/bolt-sidecar/src/builder/template.rs
@@ -1,6 +1,9 @@
 use std::collections::HashMap;
 
-use alloy::primitives::{Address, TxHash, U256};
+use alloy::{
+    consensus::Transaction,
+    primitives::{Address, TxHash, U256},
+};
 use ethereum_consensus::{
     crypto::{KzgCommitment, KzgProof},
     deneb::mainnet::{Blob, BlobsBundle},

--- a/bolt-sidecar/src/common/transactions.rs
+++ b/bolt-sidecar/src/common/transactions.rs
@@ -1,10 +1,7 @@
-use alloy::primitives::U256;
+use alloy::{consensus::Transaction, primitives::U256};
 use reth_primitives::PooledTransactionsElement;
 
-use crate::{
-    primitives::{AccountState, TransactionExt},
-    state::ValidationError,
-};
+use crate::{primitives::AccountState, state::ValidationError};
 
 /// Calculates the max_basefee `slot_diff` blocks in the future given a current basefee (in wei).
 /// Returns None if an overflow would occur.

--- a/bolt-sidecar/src/driver.rs
+++ b/bolt-sidecar/src/driver.rs
@@ -1,6 +1,10 @@
 use std::{fmt, sync::Arc, time::Instant};
 
-use alloy::{rpc::types::beacon::events::HeadEvent, signers::local::PrivateKeySigner};
+use alloy::{
+    consensus::{Transaction, TxType},
+    rpc::types::beacon::events::HeadEvent,
+    signers::local::PrivateKeySigner,
+};
 use beacon_api_client::mainnet::Client as BeaconClient;
 use ethereum_consensus::{
     clock::{self, SlotStream, SystemTimeProvider},
@@ -28,7 +32,7 @@ use crate::{
     crypto::{SignableBLS, SignerECDSA},
     primitives::{
         commitment::SignedCommitment, read_signed_delegations_from_file, CommitmentRequest,
-        ConstraintsMessage, FetchPayloadRequest, SignedConstraints, TransactionExt,
+        ConstraintsMessage, FetchPayloadRequest, SignedConstraints,
     },
     signer::{keystore::KeystoreSigner, local::LocalSigner, CommitBoostSigner, SignerBLS},
     state::{fetcher::StateFetcher, ConsensusState, ExecutionState, HeadTracker, StateClient},
@@ -340,7 +344,7 @@ impl<C: StateFetcher, ECDSA: SignerECDSA> SidecarDriver<C, ECDSA> {
         // For more information, check out the constraints API docs:
         // https://docs.boltprotocol.xyz/technical-docs/api/builder#constraints
         for tx in &inclusion_request.txs {
-            let tx_type = tx.tx_type();
+            let tx_type = TxType::try_from(tx.ty()).expect("valid tx type");
             let message =
                 ConstraintsMessage::from_tx(signing_pubkey.clone(), target_slot, tx.clone());
             let digest = message.digest();

--- a/bolt-sidecar/src/primitives/commitment.rs
+++ b/bolt-sidecar/src/primitives/commitment.rs
@@ -1,6 +1,7 @@
 use std::str::FromStr;
 
 use alloy::{
+    consensus::Transaction,
     hex,
     primitives::{keccak256, Address, Signature, B256},
 };
@@ -102,6 +103,7 @@ impl InclusionRequest {
     ) -> eyre::Result<InclusionCommitment> {
         let digest = self.digest();
         let signature = signer.sign_hash(&digest).await?;
+        let signature = Signature::try_from(signature.as_bytes().as_ref())?;
         Ok(InclusionCommitment { request: self, signature })
     }
 
@@ -147,7 +149,7 @@ impl InclusionRequest {
     /// Validates the init code limit.
     pub fn validate_init_code_limit(&self, limit: usize) -> bool {
         for tx in &self.txs {
-            if tx.tx_kind().is_create() && tx.input().len() > limit {
+            if tx.kind().is_create() && tx.input().len() > limit {
                 return false;
             }
         }

--- a/bolt-sidecar/src/signer/commit_boost.rs
+++ b/bolt-sidecar/src/signer/commit_boost.rs
@@ -13,10 +13,7 @@ use ssz::Decode;
 use thiserror::Error;
 use tracing::{debug, error, info};
 
-use crate::{
-    crypto::{bls::BLS_DST_PREFIX, ecdsa::SignerECDSA},
-    primitives::commitment::ECDSASignatureExt,
-};
+use crate::crypto::{bls::BLS_DST_PREFIX, ecdsa::SignerECDSA};
 
 use super::SignerResult;
 
@@ -105,7 +102,8 @@ impl CommitBoostSigner {
 
     /// Verify the ECDSA signature of the object with the given public key.
     pub fn verify_ecdsa(&self, data: &[u8; 32], sig: &Signature, pubkey: &EcdsaPublicKey) -> bool {
-        let sig = secp256k1::ecdsa::Signature::from_str(&sig.to_hex()).expect("signature is valid");
+        let sig_hex = hex::encode(sig.as_bytes());
+        let sig = secp256k1::ecdsa::Signature::from_str(&sig_hex).expect("signature is valid");
         let pubkey =
             secp256k1::PublicKey::from_slice(pubkey.as_ref()).expect("public key is valid");
         secp256k1::Secp256k1::new()

--- a/bolt-sidecar/src/telemetry/metrics.rs
+++ b/bolt-sidecar/src/telemetry/metrics.rs
@@ -1,7 +1,7 @@
 use std::time::Duration;
 
+use alloy::consensus::TxType;
 use metrics::{counter, describe_counter, describe_gauge, describe_histogram, gauge, histogram};
-use reth_primitives::TxType;
 
 use crate::primitives::transaction::tx_type_str;
 


### PR DESCRIPTION
Now that `PooledTransactionsElement` implements `alloy::consensus::Transaction` trait, we can remove some of the functions in our ad-hoc `TransactionExt` trait. However, we still need some of them, so we need to keep our trait as well.