### PR TITLE
fix: bolt pubkeys local-keystore command flags

### DIFF
--- a/bolt-cli/README.md
+++ b/bolt-cli/README.md
@@ -196,8 +196,7 @@ bolt pubkeys secret-keys --secret-keys 642e0d33fde8968a48b5f560c1b20143eb82036c1
 
 ```text
 bolt pubkeys local-keystore \
-  --path test_data/lighthouse/validators \
-  --password-path test_data/lighthouse/secrets
+  --path test_data/lighthouse/validators
 ```
 
 3. Listing BLS public keys from a remote DIRK keystore

--- a/testnets/holesky/QUICK_START.md
+++ b/testnets/holesky/QUICK_START.md
@@ -74,7 +74,7 @@ depending on where your keys are stored:
   (with `validators` and `secrets` subdirectories containing the keystores and passwords respectively).
 
 ```bash
-bolt pubkeys local-keystore --path <validators_path> --password-path <secrets_path>
+bolt pubkeys local-keystore --path <validators_path>
 ```
 
 Example file structure when using `local-keystore` source:
@@ -94,7 +94,7 @@ Example file structure when using `local-keystore` source:
 In this case you would run the command (called from the `validator_keys` directory):
 
 ```bash
-bolt pubkeys local-keystore --path validators --password-path secrets
+bolt pubkeys local-keystore --path validators
 ```
 
 </details>


### PR DESCRIPTION
We don't need to read secrets for reading pubkeys, since `KeysSource` and `SecretsSource` are different enums now.