### PR TITLE
chore(ci): run on self-hosted

### DIFF
--- a/.github/workflows/bolt_boost_ci.yml
+++ b/.github/workflows/bolt_boost_ci.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   cargo-tests:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 10
     env:
       RUST_BACKTRACE: 1

--- a/.github/workflows/bolt_cli_ci.yml
+++ b/.github/workflows/bolt_cli_ci.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   cargo-tests:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 10
     env:
       RUST_BACKTRACE: 1

--- a/.github/workflows/bolt_sidecar_ci.yml
+++ b/.github/workflows/bolt_sidecar_ci.yml
@@ -20,7 +20,7 @@ concurrency:
 
 jobs:
   cargo-tests:
-    runs-on: ubuntu-latest
+    runs-on: self-hosted
     timeout-minutes: 20
     env:
       RUST_BACKTRACE: 1


### PR DESCRIPTION
Should improve CI times. We could also consider breaking up CI and have separate jobs for clippy/lint and test.