### PR TITLE
chore(sidecar/holesky): add preset for delegation, env docs

### DIFF
--- a/bolt-sidecar/src/config/mod.rs
+++ b/bolt-sidecar/src/config/mod.rs
@@ -76,9 +76,9 @@ pub struct Opts {
     /// one set for your validators.
     #[clap(long, env = "BOLT_SIDECAR_FEE_RECIPIENT")]
     pub fee_recipient: Address,
-    /// Secret BLS key to sign fallback payloads with. This can be any key. You can generate one
-    /// with the `bolt` CLI tool, using `bolt generate bls`.
-    #[clap(long, env = "BOLT_SIDECAR_BUILDER_PRIVATE_KEY")]
+    /// Secret BLS key to sign fallback payloads with. This can be any key, and by default a random
+    /// one is created. You can generate one with the `bolt` CLI tool, using `bolt generate bls`.
+    #[clap(long, env = "BOLT_SIDECAR_BUILDER_PRIVATE_KEY", default_value_t = BlsSecretKeyWrapper::random())]
     pub builder_private_key: BlsSecretKeyWrapper,
     /// Secret ECDSA key used to sign commitment messages on behalf of your validators.
     /// This MUST be set to the private key of your operator address registered in a restaking protocol.

--- a/bolt-sidecar/src/config/mod.rs
+++ b/bolt-sidecar/src/config/mod.rs
@@ -75,11 +75,13 @@ pub struct Opts {
     /// The fee recipient address for fallback blocks
     #[clap(long, env = "BOLT_SIDECAR_FEE_RECIPIENT")]
     pub fee_recipient: Address,
-    /// Secret BLS key to sign fallback payloads with
+    /// Secret BLS key to sign fallback payloads with. This can be any key. You can generate one
+    /// with the `bolt` CLI tool, using `bolt generate bls`.
     #[clap(long, env = "BOLT_SIDECAR_BUILDER_PRIVATE_KEY")]
     pub builder_private_key: BlsSecretKeyWrapper,
-    /// Secret ECDSA key to sign commitment messages with. The public key associated to it must be
-    /// then used when registering the operator in the `BoltManager` contract.
+    /// Secret ECDSA key used to sign commitment messages on behalf of your validators. The public
+    /// key associated is an operator registered in the `BoltManager` contract and in a restaking
+    /// protocol.
     #[clap(long, env = "BOLT_SIDECAR_COMMITMENT_PRIVATE_KEY")]
     pub commitment_private_key: EcdsaSecretKeyWrapper,
     /// Unsafely disables consensus checks when validating commitments.

--- a/bolt-sidecar/src/config/mod.rs
+++ b/bolt-sidecar/src/config/mod.rs
@@ -72,16 +72,16 @@ pub struct Opts {
     /// containing the hex-encoded secret.
     #[clap(long, env = "BOLT_SIDECAR_ENGINE_JWT_HEX")]
     pub engine_jwt_hex: JwtSecretConfig,
-    /// The fee recipient address for fallback blocks
+    /// The fee recipient address for locally-built fallback blocks. It should be the same as the
+    /// one set for your validators.
     #[clap(long, env = "BOLT_SIDECAR_FEE_RECIPIENT")]
     pub fee_recipient: Address,
     /// Secret BLS key to sign fallback payloads with. This can be any key. You can generate one
     /// with the `bolt` CLI tool, using `bolt generate bls`.
     #[clap(long, env = "BOLT_SIDECAR_BUILDER_PRIVATE_KEY")]
     pub builder_private_key: BlsSecretKeyWrapper,
-    /// Secret ECDSA key used to sign commitment messages on behalf of your validators. The public
-    /// key associated is an operator registered in the `BoltManager` contract and in a restaking
-    /// protocol.
+    /// Secret ECDSA key used to sign commitment messages on behalf of your validators.
+    /// This MUST be set to the private key of your operator address registered in a restaking protocol.
     #[clap(long, env = "BOLT_SIDECAR_COMMITMENT_PRIVATE_KEY")]
     pub commitment_private_key: EcdsaSecretKeyWrapper,
     /// Unsafely disables consensus checks when validating commitments.

--- a/testnets/holesky/QUICK_START.md
+++ b/testnets/holesky/QUICK_START.md
@@ -343,33 +343,32 @@ separate guide [here](./commit-boost/README.md) in detail.
 
 ### Docker mode
 
-First, change directory to the `testnets/holesky` folder in the bolt repository you cloned in step 1:
+First, change directory to the `testnets/holesky` folder in the bolt repository
+you cloned in step 1:
 
 ```bash
 cd testnets/holesky
 ```
 
-In this directory you will find a `docker-compose.yml` file that you can use to start the Bolt-sidecar.
-But before doing that, you will need to change the configuration file to match your setup.
+In this directory you will find a `docker-compose.yml` file that you can use to
+start the bolt sidecar. But before doing that, you will need to change the
+configuration file to match your setup.
 
-To get started with the configuration, copy the example file:
+To get started with the configuration, copy the following preset file:
 
 ```bash
-cp bolt-sidecar.env.example bolt-sidecar.env
+cp ./presets/sidecar-delegations-preset.env.example bolt-sidecar.env
 ```
 
-<details>
-<summary>Here is a brief explanation of some of the less-obvious fields in the `bolt-sidecar.env` file:</summary>
+This preset file will run the bolt-sidecar in "delegation" mode, which is the
+recommended way to set it up.
 
-- `BOLT_SIDECAR_COMMITMENT_PRIVATE_KEY`: this is the private key of the operator address that you registered in the
-  restaking protocol in the previous steps. This is the key that will be used to sign commitments for your validators.
-- `BOLT_SIDECAR_BUILDER_PRIVATE_KEY`: this can be any valid BLS private key. You can generate one using the `bolt generate bls` command.
+Fill the configuration excluding the "Signing options"
+section, which will be covered below. Remember to set the
+`BOLT_SIDECAR_COMMITMENT_PRIVATE_KEY` to the operator private key registered in
+the previous step.
 
-The section "signing options" is by far the most complex part of the configuration file.
-It is used to configure how Bolt protocol understands and authenticates your validators.
-
-Although this is a quick guide, delegation must be understood correctly in order to be setup properly.
-Here is a quick rundown of how it works:
+**Why delegation?**
 
 The bolt-sidecar needs to know which validators it is controlling (aka, which validators it can sign commitments
 on behalf of). Otherwise it may sign commitments for random validators which would get you slashed.
@@ -383,7 +382,7 @@ to sign a message that essentially says "I authorize this other key to sign comm
 
 This way, operators don't need to use their validator secret keys in their online sidecar setup anymore.
 
-This is by far the most recommended way to set up the bolt-sidecar.
+**Creating delegations**
 
 In order to create and use these delegations, you can follow these steps:
 
@@ -409,7 +408,7 @@ In order to create and use these delegations, you can follow these steps:
 
 That's it! You can proceed to the next step.
 
-</details>
+**Configuring MEV-Boost**
 
 After you've filled out the sidecar configuration, you can do the same with the `mev-boost` configuration:
 
@@ -421,6 +420,8 @@ And fill out the values in the `mev-boost.env` file as well.
 
 - NOTE: the config file comes with relay URLs already set up for you. Feel free to change them if
   you only want to use some specific relays.
+
+**Start the docker compose**
 
 Once the config files are in place, make sure you have Docker running and then start the docker compose:
 

--- a/testnets/holesky/presets/sidecar-delegations-preset.env.example
+++ b/testnets/holesky/presets/sidecar-delegations-preset.env.example
@@ -25,9 +25,6 @@ BOLT_SIDECAR_FEE_RECIPIENT=
 # Secret ECDSA key used to sign commitment messages on behalf of your validators.
 # This MUST be set to the private key of your operator address registered in a restaking protocol.
 BOLT_SIDECAR_COMMITMENT_PRIVATE_KEY=
-# Secret BLS key to sign fallback payloads with. This can be any key. You can generate one
-# with the `bolt` CLI tool, using `bolt generate bls`.
-BOLT_SIDECAR_BUILDER_PRIVATE_KEY=
 
 # Commitments limits
 # Max number of commitments to accept per block

--- a/testnets/holesky/presets/sidecar-delegations-preset.env.example
+++ b/testnets/holesky/presets/sidecar-delegations-preset.env.example
@@ -19,11 +19,11 @@ BOLT_SIDECAR_CONSTRAINTS_API_URL="http://bolt-mev-boost-holesky:18551"
 # either be a hex-encoded string or a file path to a file containing the
 # hex-encoded secret.
 BOLT_SIDECAR_ENGINE_JWT_HEX=
-# The fee recipient address for fallback blocks
+# The fee recipient address for locally-built fallback blocks. It should be the same as the
+# one set for your validators.
 BOLT_SIDECAR_FEE_RECIPIENT=
-# Secret ECDSA key used to sign commitment messages on behalf of your validators. The public
-# key associated is an operator registered in the `BoltManager` contract and in a restaking
-# protocol.
+# Secret ECDSA key used to sign commitment messages on behalf of your validators.
+# This MUST be set to the private key of your operator address registered in a restaking protocol.
 BOLT_SIDECAR_COMMITMENT_PRIVATE_KEY=
 # Secret BLS key to sign fallback payloads with. This can be any key. You can generate one
 # with the `bolt` CLI tool, using `bolt generate bls`.
@@ -40,9 +40,6 @@ BOLT_SIDECAR_MIN_PRIORITY_FEE=4_000_000_000 # 4 Gwei = 4 * 10^9 wei
 # Chain configuration
 # Chain on which the sidecar is running
 BOLT_SIDECAR_CHAIN="holesky"
-# The slot time duration in seconds. If provided, it overrides the default for
-# the selected [chain]
-BOLT_SIDECAR_SLOT_TIME=12
 # The deadline in the slot at which the sidecar will stop accepting new
 # commitments for the next block (parsed as milliseconds)
 BOLT_SIDECAR_COMMITMENT_DEADLINE=8000

--- a/testnets/holesky/presets/sidecar-delegations-preset.env.example
+++ b/testnets/holesky/presets/sidecar-delegations-preset.env.example
@@ -1,0 +1,60 @@
+# Ethereum Node Connections + PBS URLs
+
+# Port to listen on for incoming JSON-RPC requests of the Commitments API. This
+# port should be open on your firewall in order to receive external requests!
+BOLT_SIDECAR_PORT=8017
+# Execution client API URL
+BOLT_SIDECAR_EXECUTION_API_URL="http://172.56.0.1:8545"
+# URL for the beacon client
+BOLT_SIDECAR_BEACON_API_URL="http://172.56.0.1:5052"
+# Execution client Engine API URL. This is needed for fallback block building
+# and must be a synced Geth node
+BOLT_SIDECAR_ENGINE_API_URL="http://172.56.0.1:8551"
+# The port from which the Bolt sidecar will receive Builder-API requests from the Beacon client
+BOLT_SIDECAR_CONSTRAINTS_PROXY_PORT=18550
+# URL to forward the constraints produced by the Bolt sidecar to a server
+# supporting the Constraints API, such as an MEV-Boost fork
+BOLT_SIDECAR_CONSTRAINTS_API_URL="http://bolt-mev-boost-holesky:18551"
+# The JWT secret token to authenticate calls to the engine API. It can be
+# either be a hex-encoded string or a file path to a file containing the
+# hex-encoded secret.
+BOLT_SIDECAR_ENGINE_JWT_HEX=
+# The fee recipient address for fallback blocks
+BOLT_SIDECAR_FEE_RECIPIENT=
+# Secret ECDSA key used to sign commitment messages on behalf of your validators. The public
+# key associated is an operator registered in the `BoltManager` contract and in a restaking
+# protocol.
+BOLT_SIDECAR_COMMITMENT_PRIVATE_KEY=
+# Secret BLS key to sign fallback payloads with. This can be any key. You can generate one
+# with the `bolt` CLI tool, using `bolt generate bls`.
+BOLT_SIDECAR_BUILDER_PRIVATE_KEY=
+
+# Commitments limits
+# Max number of commitments to accept per block
+BOLT_SIDECAR_MAX_COMMITMENTS_PER_SLOT=128
+# Max committed gas per slot
+BOLT_SIDECAR_MAX_COMMITTED_GAS_PER_SLOT=10_000_000
+# Min priority fee to accept for a commitment
+BOLT_SIDECAR_MIN_PRIORITY_FEE=4_000_000_000 # 4 Gwei = 4 * 10^9 wei
+
+# Chain configuration
+# Chain on which the sidecar is running
+BOLT_SIDECAR_CHAIN="holesky"
+# The slot time duration in seconds. If provided, it overrides the default for
+# the selected [chain]
+BOLT_SIDECAR_SLOT_TIME=12
+# The deadline in the slot at which the sidecar will stop accepting new
+# commitments for the next block (parsed as milliseconds)
+BOLT_SIDECAR_COMMITMENT_DEADLINE=8000
+# Enable a two-epoch lookahead by enabling unsafe lookahead option
+BOLT_SIDECAR_ENABLE_UNSAFE_LOOKAHEAD=true
+
+# Signing options.
+# The path to the delegations file
+BOLT_SIDECAR_DELEGATIONS_PATH=
+# The private key of the account for which delegations have been made.
+BOLT_SIDECAR_CONSTRAINT_PRIVATE_KEY=
+
+# Telemetry and Metrics
+BOLT_SIDECAR_METRICS_PORT=9091 # Changing this requires also changing the `target.json` file
+BOLT_SIDECAR_DISABLE_METRICS=false


### PR DESCRIPTION
This PR introduces a `sidecar-delegations-preset.env.example` file that, as the name suggests, offers an example environment variable file with only the delegations signing options enabled.
The quick guide README has been changed accordingly, along with the documentation of some of the environment variables available.

This is how the "Docker mode" section of the quick guide looks like now:

![image](https://github.com/user-attachments/assets/b6221b1c-542b-4061-a6d6-622f82d73f54)
