### PR TITLE
fix(holesky): entrypoint logic to not replace envs when empty

### DIFF
--- a/bolt-sidecar/src/config/mod.rs
+++ b/bolt-sidecar/src/config/mod.rs
@@ -21,7 +21,6 @@ use telemetry::TelemetryOpts;
 /// Operating limits for commitments and constraints.
 pub mod limits;
 use limits::LimitsOpts;
-use tracing::debug;
 
 use crate::common::secrets::{BlsSecretKeyWrapper, EcdsaSecretKeyWrapper, JwtSecretConfig};
 
@@ -144,7 +143,7 @@ fn remove_empty_envs() -> eyre::Result<()> {
     for item in env::vars() {
         let (key, val) = item;
         if val.trim().is_empty() {
-            debug!("removing empty env var: {}", key);
+            println!("Removing empty environment variable with key: {}", key);
             std::env::remove_var(key)
         }
     }

--- a/bolt-sidecar/src/config/mod.rs
+++ b/bolt-sidecar/src/config/mod.rs
@@ -143,7 +143,6 @@ fn remove_empty_envs() -> eyre::Result<()> {
     for item in env::vars() {
         let (key, val) = item;
         if val.trim().is_empty() {
-            println!("Removing empty environment variable with key: {}", key);
             std::env::remove_var(key)
         }
     }

--- a/testnets/holesky/entrypoint.sh
+++ b/testnets/holesky/entrypoint.sh
@@ -12,15 +12,15 @@ source .env
 # Override some of the environment variables provided by the user, even if
 # provided via .env file, so that the volume mounts work as expected.
 #
-# The "+" syntax replaces the environment variable with the alternate valuee
-# only if set.
+# The ":+" syntax replaces the environment variable with the alternate value
+# only if set _and_ not empty.
 # Reference: https://docs.docker.com/compose/how-tos/environment-variables/variable-interpolation/#interpolation-syntax
 #
 # Ensure these environment variables are either empty or set with the
 # alternative values, overriding what's provided with the `--env-file` flag in
 # the Docker Compose file and matching the volume mounts.
-export BOLT_SIDECAR_DELEGATIONS_PATH="${BOLT_SIDECAR_DELEGATIONS_PATH+/etc/delegations.json}"
-export BOLT_SIDECAR_KEYSTORE_PATH="${BOLT_SIDECAR_KEYSTORE_PATH+/etc/keystore}"
-export BOLT_SIDECAR_KEYSTORE_SECRETS_PATH="${BOLT_SIDECAR_KEYSTORE_SECRETS_PATH+/etc/secrets}"
+export BOLT_SIDECAR_DELEGATIONS_PATH="${BOLT_SIDECAR_DELEGATIONS_PATH:+/etc/delegations.json}"
+export BOLT_SIDECAR_KEYSTORE_PATH="${BOLT_SIDECAR_KEYSTORE_PATH:+/etc/keystore}"
+export BOLT_SIDECAR_KEYSTORE_SECRETS_PATH="${BOLT_SIDECAR_KEYSTORE_SECRETS_PATH:+/etc/secrets}"
 
 ./bolt-sidecar


### PR DESCRIPTION
There was an error in the entrypoint logic that was replacing some environment variable names with the volume mount paths even when they were empty. That should only happen when they're set.
As such, the sidecar was throwing an error because it seeing incompatible flags provided.