### PR TITLE
chore(cli): unify KeysSource and SecretsSource

### DIFF
--- a/bolt-cli/src/cli.rs
+++ b/bolt-cli/src/cli.rs
@@ -75,7 +75,7 @@ pub struct DelegateCommand {
 
     /// The source of the private key.
     #[clap(subcommand)]
-    pub source: SecretsSource,
+    pub source: KeysSource,
 }
 
 /// Command for outputting a list of pubkeys in JSON format.
@@ -327,45 +327,6 @@ pub enum Action {
 
 #[derive(Debug, Clone, Parser)]
 pub enum KeysSource {
-    /// Use directly local public keys as source.
-    PublicKeys {
-        /// The public keys in hex format. Multiple public keys must be seperated by commas.
-        #[clap(long, env = "PUBLIC_KEYS", value_delimiter = ',', hide_env_values = true)]
-        public_keys: Vec<String>,
-    },
-
-    /// Use local secret keys to generate the associated public keys.
-    SecretKeys {
-        /// The private key in hex format. Multiple secret keys must be seperated by commas.
-        #[clap(long, env = "SECRET_KEYS", value_delimiter = ',', hide_env_values = true)]
-        secret_keys: Vec<String>,
-    },
-
-    /// Use an EIP-2335 filesystem keystore directory as source for public keys.
-    LocalKeystore {
-        /// The path to the keystore file.
-        #[clap(long, env = "KEYSTORE_PATH")]
-        path: String,
-    },
-
-    /// Use a remote DIRK keystore as source for public keys.
-    Dirk {
-        /// The options for connecting to the DIRK keystore.
-        #[clap(flatten)]
-        opts: DirkOpts,
-    },
-
-    /// Use a remote web3signer keystore as source for the public keys.
-    #[clap(name = "web3signer")]
-    Web3Signer {
-        /// The options for connecting to the web3signer keystore.
-        #[clap(flatten)]
-        opts: Web3SignerOpts,
-    },
-}
-
-#[derive(Debug, Clone, Parser)]
-pub enum SecretsSource {
     /// Use local secret keys to generate the signed messages.
     SecretKeys {
         /// The private key in hex format.

--- a/bolt-cli/src/commands/delegate/mod.rs
+++ b/bolt-cli/src/commands/delegate/mod.rs
@@ -2,7 +2,7 @@ use eyre::Result;
 use tracing::debug;
 
 use crate::{
-    cli::{DelegateCommand, SecretsSource},
+    cli::{DelegateCommand, KeysSource},
     common::{keystore::KeystoreSecret, parse_bls_public_key, write_to_file},
 };
 
@@ -25,7 +25,7 @@ impl DelegateCommand {
     /// Run the `delegate` command.
     pub async fn run(self) -> Result<()> {
         let signed_messages = match self.source {
-            SecretsSource::SecretKeys { secret_keys } => {
+            KeysSource::SecretKeys { secret_keys } => {
                 let delegatee_pubkey = parse_bls_public_key(&self.delegatee_pubkey)?;
                 local::generate_from_local_keys(
                     &secret_keys,
@@ -34,7 +34,7 @@ impl DelegateCommand {
                     self.action,
                 )?
             }
-            SecretsSource::LocalKeystore { opts } => {
+            KeysSource::LocalKeystore { opts } => {
                 let keystore_secret = KeystoreSecret::from_keystore_options(&opts)?;
                 let delegatee_pubkey = parse_bls_public_key(&self.delegatee_pubkey)?;
                 keystore::generate_from_keystore(
@@ -45,11 +45,11 @@ impl DelegateCommand {
                     self.action,
                 )?
             }
-            SecretsSource::Dirk { opts } => {
+            KeysSource::Dirk { opts } => {
                 let delegatee_pubkey = parse_bls_public_key(&self.delegatee_pubkey)?;
                 dirk::generate_from_dirk(opts, delegatee_pubkey, self.chain, self.action).await?
             }
-            SecretsSource::Web3Signer { opts } => {
+            KeysSource::Web3Signer { opts } => {
                 let delegatee_pubkey = parse_bls_public_key(&self.delegatee_pubkey)?;
                 web3signer::generate_from_web3signer(opts, delegatee_pubkey, self.action).await?
             }

--- a/bolt-cli/src/commands/pubkeys.rs
+++ b/bolt-cli/src/commands/pubkeys.rs
@@ -16,18 +16,14 @@ use crate::{
 impl PubkeysCommand {
     pub async fn run(self) -> Result<()> {
         match self.source {
-            KeysSource::PublicKeys { public_keys } => {
-                write_to_file(&self.out, &public_keys)?;
-                println!("Pubkeys saved to {}", self.out);
-            }
             KeysSource::SecretKeys { secret_keys } => {
                 let pubkeys = list_from_local_keys(&secret_keys)?;
 
                 write_to_file(&self.out, &pubkeys)?;
                 println!("Pubkeys generated and saved to {}", self.out);
             }
-            KeysSource::LocalKeystore { path } => {
-                let pubkeys = list_from_keystore(&path)?;
+            KeysSource::LocalKeystore { opts } => {
+                let pubkeys = list_from_keystore(&opts.path)?;
 
                 write_to_file(&self.out, &pubkeys)?;
                 println!("Pubkeys generated from local keystore and saved to {}", self.out);


### PR DESCRIPTION
Following node operators feedback, the `bolt pubkeys public-keys --public-keys` command was removed.
KeysSource and SecretsSource has been squashed back into a single type. 