### PR TITLE
chore(cli): bump version

### DIFF
--- a/bolt-cli/Cargo.lock
+++ b/bolt-cli/Cargo.lock
@@ -1257,7 +1257,7 @@ dependencies = [
 
 [[package]]
 name = "bolt"
-version = "0.1.0"
+version = "0.1.1"
 dependencies = [
  "alloy",
  "alloy-node-bindings",

--- a/bolt-cli/Cargo.toml
+++ b/bolt-cli/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "bolt"
-version = "0.1.0"
+version = "0.1.1"
 edition = "2021"
 
 [dependencies]
@@ -26,9 +26,9 @@ bls12_381 = "0.8.0"
 ethereum-consensus = { git = "https://github.com/ralexstokes/ethereum-consensus", rev = "cf3c404" }
 lighthouse_eth2_keystore = { package = "eth2_keystore", git = "https://github.com/sigp/lighthouse", rev = "a87f19d" }
 alloy = { version = "0.7.3", features = [
-    "full",
-    "provider-anvil-api",
-    "provider-anvil-node",
+  "full",
+  "provider-anvil-api",
+  "provider-anvil-node",
 ] }
 
 # utils

--- a/bolt-cli/src/cli.rs
+++ b/bolt-cli/src/cli.rs
@@ -94,6 +94,9 @@ pub struct PubkeysCommand {
 #[derive(Debug, Clone, Parser)]
 pub struct SendCommand {
     /// bolt RPC URL to send requests to and fetch lookahead info from.
+    ///
+    /// Leaving this empty will default to the canonical bolt RPC URL, which
+    /// automatically manages increasing nonces on preconfirmed state.
     #[clap(long, env = "BOLT_RPC_URL", default_value = "https://rpc-holesky.bolt.chainbound.io")]
     pub bolt_rpc_url: Url,
 


### PR DESCRIPTION
Prepares the v0.1.1 release of the `bolt` CLI and informs that using the canonical bolt RPC will offer automatic management of nonces on preconfirmed state.