### PR TITLE
feat(sidecar): add git commit hash to version tag

### DIFF
--- a/bolt-sidecar/Cargo.lock
+++ b/bolt-sidecar/Cargo.lock
@@ -1573,6 +1573,7 @@ dependencies = [
  "beacon-api-client",
  "bls 0.2.0 (git+https://github.com/sigp/lighthouse)",
  "blst",
+ "built",
  "bytes",
  "cb-common",
  "clap",
@@ -1586,6 +1587,7 @@ dependencies = [
  "futures",
  "hex",
  "http-body-util",
+ "lazy_static",
  "metrics 0.23.0",
  "metrics-exporter-prometheus",
  "parking_lot",
@@ -1621,6 +1623,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bf88ba1141d185c399bee5288d850d63b8369520c1eafc32a0430b5b6c287bf4"
 dependencies = [
  "tinyvec",
+]
+
+[[package]]
+name = "built"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c360505aed52b7ec96a3636c3f039d99103c37d1d9b4f7a8c743d3ea9ffcd03b"
+dependencies = [
+ "git2",
 ]
 
 [[package]]
@@ -3747,6 +3758,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4271d37baee1b8c7e4b708028c57d816cf9d2434acb33a549475f78c181f6253"
 
 [[package]]
+name = "git2"
+version = "0.19.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b903b73e45dc0c6c596f2d37eccece7c1c8bb6e4407b001096387c63d0d93724"
+dependencies = [
+ "bitflags 2.6.0",
+ "libc",
+ "libgit2-sys",
+ "log",
+ "url",
+]
+
+[[package]]
 name = "glob"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4715,6 +4739,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "libgit2-sys"
+version = "0.17.0+1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "10472326a8a6477c3c20a64547b0059e4b0d086869eee31e6d7da728a8eb7224"
+dependencies = [
+ "cc",
+ "libc",
+ "libz-sys",
+ "pkg-config",
+]
+
+[[package]]
 name = "libloading"
 version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4814,6 +4850,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "29f835d03d717946d28b1d1ed632eb6f0e24a299388ee623d0c23118d3e8a7fa"
 dependencies = [
  "cc",
+ "pkg-config",
+ "vcpkg",
+]
+
+[[package]]
+name = "libz-sys"
+version = "1.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d2d16453e800a8cf6dd2fc3eb4bc99b786a9b90c663b8559a5b1a041bf89e472"
+dependencies = [
+ "cc",
+ "libc",
  "pkg-config",
  "vcpkg",
 ]

--- a/bolt-sidecar/Cargo.toml
+++ b/bolt-sidecar/Cargo.toml
@@ -65,6 +65,7 @@ thiserror = "2.0"
 rand = "0.8.5"
 dotenvy = "0.15.7"
 regex = "1.10.5"
+lazy_static = "1.5.0"
 
 # tracing
 tracing = "0.1.40"
@@ -72,9 +73,7 @@ tracing-subscriber = { version = "0.3.18", features = ["env-filter", "fmt"] }
 
 # telemetry
 metrics = "0.23"
-metrics-exporter-prometheus = { version = "0.15.3", features = [
-  "http-listener",
-] }
+metrics-exporter-prometheus = { version = "0.15.3", features = ["http-listener"] }
 
 # commit-boost
 commit-boost = { git = "https://github.com/Commit-Boost/commit-boost-client", rev = "0f8f69b"  }
@@ -83,6 +82,9 @@ cb-common = { git = "https://github.com/Commit-Boost/commit-boost-client", rev =
 [dev-dependencies]
 alloy-node-bindings = "0.8.0"                                # must match alloy version
 criterion = { version = "0.5", features = ["html_reports"] }
+
+[build-dependencies]
+built = { version = "0.7.5", features = ["git2"] }
 
 [package.metadata.cargo-machete]
 ignored = ["ethereum_ssz"]

--- a/bolt-sidecar/bin/sidecar.rs
+++ b/bolt-sidecar/bin/sidecar.rs
@@ -1,7 +1,9 @@
 use eyre::bail;
 use tracing::info;
 
-use bolt_sidecar::{config::Opts, telemetry::init_telemetry_stack, SidecarDriver};
+use bolt_sidecar::{
+    common::BOLT_SIDECAR_VERSION, config::Opts, telemetry::init_telemetry_stack, SidecarDriver,
+};
 
 const BOLT: &str = r#"
 ██████╗  ██████╗ ██╗  ████████╗
@@ -14,6 +16,7 @@ const BOLT: &str = r#"
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
     println!("{}", BOLT);
+    println!("Running version: {}", BOLT_SIDECAR_VERSION.clone());
 
     let opts = Opts::try_parse()?;
 

--- a/bolt-sidecar/build.rs
+++ b/bolt-sidecar/build.rs
@@ -1,0 +1,3 @@
+fn main() {
+    built::write_built_file().expect("Failed to acquire build-time information");
+}

--- a/bolt-sidecar/src/api/commitments/handlers.rs
+++ b/bolt-sidecar/src/api/commitments/handlers.rs
@@ -13,7 +13,7 @@ use tracing::{debug, error, info, instrument};
 
 use crate::{
     api::commitments::headers::auth_from_headers,
-    common::CARGO_PKG_VERSION,
+    common::BOLT_SIDECAR_VERSION,
     primitives::{commitment::SignatureError, InclusionRequest},
 };
 
@@ -36,14 +36,11 @@ pub async fn rpc_entrypoint(
     debug!("Received new request");
 
     match payload.method.as_str() {
-        GET_VERSION_METHOD => {
-            let version_string = format!("bolt-sidecar-v{CARGO_PKG_VERSION}");
-            Ok(Json(JsonResponse {
-                id: payload.id,
-                result: Value::String(version_string),
-                ..Default::default()
-            }))
-        }
+        GET_VERSION_METHOD => Ok(Json(JsonResponse {
+            id: payload.id,
+            result: Value::String(BOLT_SIDECAR_VERSION.clone()),
+            ..Default::default()
+        })),
 
         GET_METADATA_METHOD => {
             let response = JsonResponse {

--- a/bolt-sidecar/src/client/engine.rs
+++ b/bolt-sidecar/src/client/engine.rs
@@ -17,8 +17,11 @@ use alloy_transport_http::{
     AuthLayer, AuthService, HyperClient,
 };
 use http_body_util::Full;
+use lazy_static::lazy_static;
 use reqwest::Url;
 use tower::ServiceBuilder;
+
+use crate::common::BOLT_SIDECAR_VERSION;
 
 /// A Hyper HTTP client with a JWT authentication layer.
 type HyperAuthClient<B = Full<Bytes>> = HyperClient<B, AuthService<Client<HttpConnector, B>>>;
@@ -56,14 +59,16 @@ impl EngineClient {
 
     /// Send a request to identify the engine client version.
     pub async fn engine_client_version(&self) -> TransportResult<Vec<ClientVersionV1>> {
-        // Send a mocked client info to the EL, since this is a required request argument
-        let mocked_cl_info = ClientVersionV1 {
-            code: ClientCode::RH, // pretend we are Reth
-            version: format!("v{}", env!("CARGO_PKG_VERSION")),
-            name: "BoltSidecar".to_string(),
-            commit: "unstable".to_string(),
-        };
-
-        self.inner.get_client_version_v1(mocked_cl_info).await
+        self.inner.get_client_version_v1(MOCKED_ENGINE_VERSION.clone()).await
     }
+}
+
+lazy_static! {
+    /// The mocked engine version for the Bolt sidecar.
+    pub static ref MOCKED_ENGINE_VERSION: ClientVersionV1 = ClientVersionV1 {
+        code: ClientCode::RH, // pretend we are Reth
+        version: BOLT_SIDECAR_VERSION.clone(),
+        name: "BoltSidecar".to_string(),
+        commit: "unstable".to_string(),
+    };
 }

--- a/bolt-sidecar/src/common/mod.rs
+++ b/bolt-sidecar/src/common/mod.rs
@@ -1,11 +1,19 @@
+use lazy_static::lazy_static;
+
 /// Utilities for retrying a future with backoff.
 pub mod backoff;
+
 /// A hash map-like bounded data structure with an additional scoring mechanism.
 pub mod score_cache;
+
 /// Secret key types wrappers for BLS, ECDSA and JWT.
 pub mod secrets;
+
 /// Utility functions for working with transactions.
 pub mod transactions;
 
-/// The version of the Bolt sidecar binary.
-pub const CARGO_PKG_VERSION: &str = env!("CARGO_PKG_VERSION");
+lazy_static! {
+    /// The version of the Bolt sidecar binary.
+    pub static ref BOLT_SIDECAR_VERSION: String =
+        format!("v{}-{}", env!("CARGO_PKG_VERSION"), crate::built_info::GIT_COMMIT_HASH_SHORT.unwrap_or("unknown"));
+}

--- a/bolt-sidecar/src/lib.rs
+++ b/bolt-sidecar/src/lib.rs
@@ -48,3 +48,9 @@ pub mod chain_io;
 /// Utilities for testing
 #[cfg(test)]
 mod test_util;
+
+/// Built-time information about the sidecar binary.
+pub mod built_info {
+    // Docs: https://docs.rs/built/latest/built/
+    include!(concat!(env!("OUT_DIR"), "/built.rs"));
+}


### PR DESCRIPTION
Closes #557 

The sidecar version is also printed at startup:

```text
❯ cargo r
    Blocking waiting for file lock on build directory
   Compiling bolt-sidecar v0.3.0-alpha
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 6.96s
     Running `target/debug/bolt-sidecar`

██████╗  ██████╗ ██╗  ████████╗
██╔══██╗██╔═══██╗██║  ╚══██╔══╝
██████╔╝██║   ██║██║     ██║
██╔══██╗██║   ██║██║     ██║
██████╔╝╚██████╔╝███████╗██║
╚═════╝  ╚═════╝ ╚══════╝╚═╝
Running version: v0.3.0-alpha-f511fc4
No .env file found, using environment variables
```