### PR TITLE
fix(bolt-sidecar): return error when no bids

### DIFF
--- a/bolt-sidecar/src/api/spec.rs
+++ b/bolt-sidecar/src/api/spec.rs
@@ -63,6 +63,8 @@ pub enum BuilderApiError {
     FailedDelegating(ErrorResponse),
     #[error("Failed to revoke constraint submission rights: {0:?}")]
     FailedRevoking(ErrorResponse),
+    #[error("No bids found for slot {0}")]
+    NoBids(u64),
     #[error("Failed to fetch local payload for slot {0}")]
     FailedToFetchLocalPayload(u64),
     #[error("Axum error: {0:?}")]
@@ -84,14 +86,15 @@ pub enum BuilderApiError {
 impl IntoResponse for BuilderApiError {
     fn into_response(self) -> Response {
         match self {
-            Self::FailedRegisteringValidators(error) |
-            Self::FailedGettingHeader(error) |
-            Self::FailedGettingPayload(error) |
-            Self::FailedSubmittingConstraints(error) |
-            Self::FailedDelegating(error) |
-            Self::FailedRevoking(error) => {
+            Self::FailedRegisteringValidators(error)
+            | Self::FailedGettingHeader(error)
+            | Self::FailedGettingPayload(error)
+            | Self::FailedSubmittingConstraints(error)
+            | Self::FailedDelegating(error)
+            | Self::FailedRevoking(error) => {
                 (StatusCode::from_u16(error.code).unwrap(), Json(error)).into_response()
             }
+            Self::NoBids(_) => (StatusCode::NO_CONTENT, self.to_string()).into_response(),
             Self::AxumError(err) => (StatusCode::BAD_REQUEST, err.to_string()).into_response(),
             Self::JsonError(err) => (StatusCode::BAD_REQUEST, err.to_string()).into_response(),
             Self::FailedToFetchLocalPayload(_) => {

--- a/bolt-sidecar/src/client/constraints.rs
+++ b/bolt-sidecar/src/client/constraints.rs
@@ -238,6 +238,10 @@ impl ConstraintsApi for ConstraintsClient {
             .send()
             .await?;
 
+        if response.status() != StatusCode::NO_CONTENT {
+            return Err(BuilderApiError::NoBids(params.slot));
+        }
+
         if response.status() != StatusCode::OK {
             let error = response.json::<ErrorResponse>().await?;
             return Err(BuilderApiError::FailedGettingHeader(error));


### PR DESCRIPTION
Fixes https://github.com/chainbound/bolt/issues/515

Before it tried to get an error from 204, which didn't exist.

```
{"duration":"0.119152","level":"info","method":"GET","msg":"http: GET /eth/v1/builder/header_with_proofs/3203582/0x8c34059ed5607d63f7f300f16654117dfb04c5e173ef74106e782f54481430c3/0x88b876f6f2d910442b04b4ec00ffd70cc84024ed7c86ba3dcff761b2b18a230b62034ab48a08916c4118aecdbda65671 204","path":"/eth/v1/builder/header_with_proofs/3203582/0x8c34059ed5607d63f7f300f16654117dfb04c5e173ef74106e782f54481430c3/0x88b876f6f2d910442b04b4ec00ffd70cc84024ed7c86ba3dcff761b2b18a230b62034ab48a08916c4118aecdbda65671","status":204,"time":"2024-12-16T10:36:38.677Z","version":""}
```