### PR TITLE
fix(cli): return non-ABI error responses

### DIFF
--- a/bolt-cli/src/commands/validators.rs
+++ b/bolt-cli/src/commands/validators.rs
@@ -1,7 +1,5 @@
 use alloy::{
-    network::EthereumWallet,
-    providers::{Provider, ProviderBuilder},
-    signers::local::PrivateKeySigner,
+    network::EthereumWallet, providers::ProviderBuilder, signers::local::PrivateKeySigner,
     sol_types::SolInterface,
 };
 use ethereum_consensus::crypto::PublicKey as BlsPublicKey;
@@ -33,11 +31,9 @@ impl ValidatorsCommand {
                 let provider = ProviderBuilder::new()
                     .with_recommended_fillers()
                     .wallet(EthereumWallet::from(signer))
-                    .on_http(rpc_url.clone());
+                    .on_http(rpc_url);
 
-                let chain_id = provider.get_chain_id().await?;
-                let chain = Chain::from_id(chain_id)
-                    .unwrap_or_else(|| panic!("chain id {} not supported", chain_id));
+                let chain = Chain::try_from_provider(&provider).await?;
 
                 let bolt_validators_address = deployments_for_chain(chain).bolt.validators;
 
@@ -105,9 +101,9 @@ impl ValidatorsCommand {
 
             ValidatorsSubcommand::Status { rpc_url, pubkeys_path, pubkeys } => {
                 let provider = ProviderBuilder::new().on_http(rpc_url);
-                let chain_id = provider.get_chain_id().await?;
-                let chain = Chain::from_id(chain_id)
-                    .unwrap_or_else(|| panic!("chain id {} not supported", chain_id));
+
+                let chain = Chain::try_from_provider(&provider).await?;
+
                 let registry = deployments_for_chain(chain).bolt.validators;
 
                 let mut bls_pubkeys = Vec::new();

--- a/bolt-cli/src/common/mod.rs
+++ b/bolt-cli/src/common/mod.rs
@@ -7,7 +7,7 @@ use alloy::{
 use ethereum_consensus::crypto::PublicKey as BlsPublicKey;
 use eyre::{Context, Result};
 use serde::Serialize;
-use tracing::info;
+use tracing::{error, info};
 
 /// BoltManager contract bindings.
 pub mod bolt_manager;
@@ -69,12 +69,19 @@ pub fn write_to_file<T: Serialize>(out: &str, data: &T) -> Result<()> {
 pub fn try_parse_contract_error<T: SolInterface>(error: ContractError) -> Result<T, ContractError> {
     match error {
         ContractError::TransportError(TransportError::ErrorResp(resp)) => {
-            let data = resp.data.unwrap_or_default();
+            let data = resp.data.clone().unwrap_or_default();
             let data = data.get().trim_matches('"');
             let data = Bytes::from_str(data).unwrap_or_default();
 
+            if data.is_empty() {
+                error!("Could not decode error data from transport response.");
+                return Err(ContractError::TransportError(TransportError::ErrorResp(resp)));
+            }
+
             T::abi_decode(&data, true).map_err(Into::into)
         }
+
+        // For any other error, return the original error
         _ => Err(error),
     }
 }


### PR DESCRIPTION
Fixes the weird error response:

```text
Error: type check failed for "BoltValidatorsErrors" with data: 

Caused by:
    type check failed for "BoltValidatorsErrors" with data: 

Location:
    src/commands/validators.rs:83:39
```

when receiving a response from the RPC that's not necessarily an ABI-decodable error (for instance, "insufficient funds")