### PR TITLE
chore: add audit action

### DIFF
--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,14 @@
+name: Security audit
+on:
+  push:
+    paths: 
+      - '**/Cargo.toml'
+      - '**/Cargo.lock'
+jobs:
+  security_audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: rustsec/audit-check@v1.4.1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Solve https://github.com/chainbound/bolt/issues/415

Alternative to https://github.com/chainbound/bolt/pull/484/files where https://github.com/actions-rs/audit-check is deprecated.

This Action doesn't have too many users, but used by rust-lang, cloudflare and tokio-rs, so consider it ok.
https://grep.app/search?q=rustsec/audit-check

Run on PRs where deps change, will add follow-up where it's also run periodically.