### PR TITLE
feat(bolt-sidecar): implement pricing models for preconfs

### DIFF
--- a/bolt-sidecar/src/chain_io/manager.rs
+++ b/bolt-sidecar/src/chain_io/manager.rs
@@ -96,13 +96,12 @@ impl BoltManager {
                             ))
                             .await;
                             continue;
-                        } else {
-                            warn!(
-                                "Non-retryable transport error when connecting to EL node: {}",
-                                transport_err
-                            );
-                            return Err(transport_err.into());
                         }
+                        warn!(
+                            "Non-retryable transport error when connecting to EL node: {}",
+                            transport_err
+                        );
+                        return Err(transport_err.into());
                     }
                     Err(err) => {
                         // For other errors, parse and return immediately

--- a/bolt-sidecar/src/state/mod.rs
+++ b/bolt-sidecar/src/state/mod.rs
@@ -11,6 +11,10 @@ use tokio::time::Sleep;
 mod execution;
 pub use execution::{ExecutionState, ValidationError};
 
+/// Module to calculate pricing.
+pub mod pricing;
+pub use pricing::PreconfPricing;
+
 /// Module to fetch state from the Execution layer.
 pub mod fetcher;
 pub use fetcher::StateClient;

--- a/bolt-sidecar/src/state/pricing.rs
+++ b/bolt-sidecar/src/state/pricing.rs
@@ -143,6 +143,9 @@ mod tests {
             pricing.calculate_min_priority_fee(incoming_gas, preconfirmed_gas).unwrap();
 
         // Expected fee: ~19 Gwei
+        // This will likely never happen, since you want to reserve some gas
+        // on top of the block for MEV, but enforcing this is not the responsibility
+        // of the pricing model.
         assert!(
             (min_fee_wei as f64 - 19_175_357_339.0).abs() < 1_000.0,
             "Expected ~19,175,357,339 Wei, got {} Wei",

--- a/bolt-sidecar/src/state/pricing.rs
+++ b/bolt-sidecar/src/state/pricing.rs
@@ -29,6 +29,12 @@ pub enum PricingError {
     },
 }
 
+impl Default for PreconfPricing {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl PreconfPricing {
     /// Initializes a new PreconfPricing with default parameters.
     pub fn new() -> Self {

--- a/bolt-sidecar/src/state/pricing.rs
+++ b/bolt-sidecar/src/state/pricing.rs
@@ -1,0 +1,188 @@
+/// Handles pricing calculations for preconfirmations
+#[derive(Debug)]
+pub struct PreconfPricing {
+    block_gas_limit: u64,
+    base_multiplier: f64,
+    gas_scalar: f64,
+}
+
+/// Errors that can occur during pricing calculations
+#[derive(Debug, thiserror::Error)]
+pub enum PricingError {
+    /// Preconfirmed gas exceeds the block limit
+    #[error("Preconfirmed gas {0} exceeds block limit {1}")]
+    ExceedsBlockLimit(u64, u64),
+    /// Insufficient remaining gas for the incoming transaction
+    #[error("Insufficient remaining gas: requested {requested}, available {available}")]
+    /// Insufficient remaining gas for the incoming transaction
+    InsufficientGas {
+        /// Gas requested by the incoming transaction
+        requested: u64,
+        /// Gas available in the block
+        available: u64,
+    },
+    /// Incoming gas is zero
+    #[error("Invalid gas limit: Incoming gas ({incoming_gas}) is zero")]
+    InvalidGasLimit {
+        /// Gas required by the incoming transaction
+        incoming_gas: u64,
+    },
+}
+
+impl PreconfPricing {
+    /// Initializes a new PreconfPricing with default parameters.
+    pub fn new() -> Self {
+        Self { block_gas_limit: 30_000_000, base_multiplier: 0.019, gas_scalar: 1.02e-6 }
+    }
+
+    /// Calculate the minimum priority fee for a preconfirmation based on
+    /// https://research.lido.fi/t/a-pricing-model-for-inclusion-preconfirmations/9136
+    ///
+    /// # Arguments
+    /// * `incoming_gas` - Gas required by the incoming transaction
+    /// * `preconfirmed_gas` - Total gas already preconfirmed
+    ///
+    /// # Returns
+    /// * `Ok(f64)` - The minimum priority fee in Wei
+    /// * `Err(PricingError)` - If the calculation cannot be performed
+    pub fn calculate_min_priority_fee(
+        &self,
+        incoming_gas: u64,
+        preconfirmed_gas: u64,
+    ) -> Result<u64, PricingError> {
+        // Check if preconfirmed gas exceeds block limit
+        if preconfirmed_gas >= self.block_gas_limit {
+            return Err(PricingError::ExceedsBlockLimit(preconfirmed_gas, self.block_gas_limit));
+        }
+
+        // Validate incoming gas
+        if incoming_gas == 0 {
+            return Err(PricingError::InvalidGasLimit { incoming_gas });
+        }
+
+        // Check if there is enough gas remaining in the block
+        let remaining_gas = self.block_gas_limit - preconfirmed_gas;
+        if incoming_gas > remaining_gas {
+            return Err(PricingError::InsufficientGas {
+                requested: incoming_gas,
+                available: remaining_gas,
+            });
+        }
+
+        // T(IG,UG) = 0.019 * ln(1.02⋅10^-6(30M-UG)+1 / 1.02⋅10^-6(30M-UG-IG)+1) / IG
+        // where
+        // IG = Gas used by the incoming transaction
+        // UG = Gas already preconfirmed
+        // T = Inclusion tip per gas
+        // 30M = Current gas limit (36M soon?)
+        let after_gas = remaining_gas - incoming_gas;
+
+        // Calculate numerator and denominator for the logarithm
+        let numerator = self.gas_scalar * (remaining_gas as f64) + 1.0;
+        let denominator = self.gas_scalar * (after_gas as f64) + 1.0;
+
+        // Calculate gas used
+        let expected_val = self.base_multiplier * (numerator / denominator).ln();
+
+        // Calculate the inclusion tip
+        let inclusion_tip_ether = expected_val / (incoming_gas as f64);
+        let inclusion_tip_wei = (inclusion_tip_ether * 1e18) as u64;
+
+        Ok(inclusion_tip_wei)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_min_priority_fee_zero_preconfirmed() {
+        let pricing = PreconfPricing::new();
+
+        // Test minimum fee (21k gas ETH transfer, 0 preconfirmed)
+        let incoming_gas = 21_000;
+        let preconfirmed_gas = 0;
+        let min_fee_wei =
+            pricing.calculate_min_priority_fee(incoming_gas, preconfirmed_gas).unwrap();
+
+        // Expected fee: ~0.61 Gwei
+        assert!(
+            (min_fee_wei as f64 - 613_499_092.0).abs() < 1_000.0,
+            "Expected ~610,000,000 Wei, got {} Wei",
+            min_fee_wei
+        );
+    }
+
+    #[test]
+    fn test_min_priority_fee_medium_load() {
+        let pricing = PreconfPricing::new();
+
+        // Test medium load (21k gas, 15M preconfirmed)
+        let incoming_gas = 21_000;
+        let preconfirmed_gas = 15_000_000;
+        let min_fee_wei =
+            pricing.calculate_min_priority_fee(incoming_gas, preconfirmed_gas).unwrap();
+
+        // Expected fee: ~1.17 Gwei
+        assert!(
+            (min_fee_wei as f64 - 1_189_738_950.0).abs() < 1_000.0,
+            "Expected ~1,189,738,950 Wei, got {} Wei",
+            min_fee_wei
+        );
+    }
+
+    #[test]
+    fn test_min_priority_fee_max_load() {
+        let pricing = PreconfPricing::new();
+
+        // Test last preconfirmed transaction (21k gas, almost 30M preconfirmed)
+        let incoming_gas = 21_000;
+        let preconfirmed_gas = 30_000_000 - 21_000;
+        let min_fee_wei =
+            pricing.calculate_min_priority_fee(incoming_gas, preconfirmed_gas).unwrap();
+
+        // Expected fee: ~19 Gwei
+        assert!(
+            (min_fee_wei as f64 - 19_175_357_339.0).abs() < 1_000.0,
+            "Expected ~19,175,357,339 Wei, got {} Wei",
+            min_fee_wei
+        );
+    }
+
+    #[test]
+    fn test_error_exceeds_block_limit() {
+        let pricing = PreconfPricing::new();
+
+        let incoming_gas = 21_000;
+        let preconfirmed_gas = 30_000_001;
+
+        let result = pricing.calculate_min_priority_fee(incoming_gas, preconfirmed_gas);
+        assert!(matches!(result, Err(PricingError::ExceedsBlockLimit(30_000_001, 30_000_000))));
+    }
+
+    #[test]
+    fn test_error_insufficient_gas() {
+        let pricing = PreconfPricing::new();
+
+        let incoming_gas = 15_000_001;
+        let preconfirmed_gas = 15_000_000;
+
+        let result = pricing.calculate_min_priority_fee(incoming_gas, preconfirmed_gas);
+        assert!(matches!(
+            result,
+            Err(PricingError::InsufficientGas { requested: 15_000_001, available: 15_000_000 })
+        ));
+    }
+
+    #[test]
+    fn test_error_zero_incoming_gas() {
+        let pricing = PreconfPricing::new();
+
+        let incoming_gas = 0;
+        let preconfirmed_gas = 0;
+
+        let result = pricing.calculate_min_priority_fee(incoming_gas, preconfirmed_gas);
+        assert!(matches!(result, Err(PricingError::InvalidGasLimit { incoming_gas: 0 })));
+    }
+}

--- a/bolt-sidecar/src/state/pricing.rs
+++ b/bolt-sidecar/src/state/pricing.rs
@@ -121,6 +121,25 @@ mod tests {
     }
 
     #[test]
+    fn test_min_priority_fee_zero_big_preconfirmed() {
+        let pricing = PreconfPricing::default();
+
+        // Test minimum fee (210k gas ETH transfer, 0 preconfirmed)
+        let incoming_gas = 210_000;
+        let preconfirmed_gas = 0;
+        let min_fee_wei =
+            pricing.calculate_min_priority_fee(incoming_gas, preconfirmed_gas).unwrap();
+
+        // This preconf uses 10x more gas than the 21k preconf,
+        // but the fee is only slightly higher.
+        assert!(
+            (min_fee_wei as f64 - 615_379_171.0).abs() < 1_000.0,
+            "Expected ~615,379,171 Wei, got {} Wei",
+            min_fee_wei
+        );
+    }
+
+    #[test]
     fn test_min_priority_fee_medium_load() {
         let pricing = PreconfPricing::default();
 

--- a/bolt-sidecar/src/state/pricing.rs
+++ b/bolt-sidecar/src/state/pricing.rs
@@ -112,10 +112,10 @@ mod tests {
         let min_fee_wei =
             pricing.calculate_min_priority_fee(incoming_gas, preconfirmed_gas).unwrap();
 
-        // Expected fee: ~0.61 Gwei
+        // Pricing model article expects fee of 0.61 Gwei
         assert!(
             (min_fee_wei as f64 - 613_499_092.0).abs() < 1_000.0,
-            "Expected ~610,000,000 Wei, got {} Wei",
+            "Expected ~613,499,092 Wei, got {} Wei",
             min_fee_wei
         );
     }
@@ -130,7 +130,7 @@ mod tests {
         let min_fee_wei =
             pricing.calculate_min_priority_fee(incoming_gas, preconfirmed_gas).unwrap();
 
-        // Expected fee: ~1.17 Gwei
+        // Pricing model article expects fee of ~1.17 Gwei
         assert!(
             (min_fee_wei as f64 - 1_189_738_950.0).abs() < 1_000.0,
             "Expected ~1,189,738,950 Wei, got {} Wei",


### PR DESCRIPTION
Implement pricing model from https://research.lido.fi/t/a-pricing-model-for-inclusion-preconfirmations/9136

Some limitations that we need to consider before using this model, is that the price of a preconf is both dependent on how much gas has already been preconfirmed for a slot and how much gas a preconf tx will consume:

**Price race**
If preconfirmations P1 and P2 race the, latter will use an outdated price because the price depends on how much gas has been preconfirmed. We don't want P2 to be rejected, as this would result in poor UX. It will also limit how many tx we can preconfirm based on latency. 

We can do either or both slippage on the preconf tip or add some slack in the validation, so P2..Px would still get accepted with P1 price.

To avoid that the price that users gets is too outdated the entity that provides the price to users (or the users) needs to be aware of how much gas has been preconfirmed.


**Preconfirmations that use a lot of gas could underpay**
A preconf that consumes 170k gas should pay more than one that consumes a 17k gas. Currently, I'm not sure how this aligns with the existing wallet flow, put for a preconf req we need to know the gas that will be consumed.

Since price is calulated in steps, not as an integral, the 210k gas preconf would also pay less than 10x21k gas preconfs. While this discrepancy might not be significant, we need to be mindful of the oportunity cost for proposers.

Alternatively, users can just pay the worst preconf price and alway be included.

After this I plan to:
- Avoid hardcoded gas limit as it might change soon
- Start using pricing model in validation