### PR TITLE
feat(bolt-sidecar): use pricing model to validate priority fee

### DIFF
--- a/bolt-sidecar/.env.example
+++ b/bolt-sidecar/.env.example
@@ -33,8 +33,8 @@ BOLT_SIDECAR_BUILDER_PRIVATE_KEY=
 BOLT_SIDECAR_MAX_COMMITMENTS_PER_SLOT=128
 # Max committed gas per slot
 BOLT_SIDECAR_MAX_COMMITTED_GAS_PER_SLOT=10_000_000
-# Min priority fee to accept for a commitment
-BOLT_SIDECAR_MIN_PRIORITY_FEE=2000000000 # 2 Gwei = 2 * 10^9 wei
+# Min profit per gas to accept a commitment
+BOLT_SIDECAR_MIN_PROFIT=2000000000 # 2 Gwei = 2 * 10^9 wei
 
 # Chain configuration
 # Chain on which the sidecar is running

--- a/bolt-sidecar/README.md
+++ b/bolt-sidecar/README.md
@@ -115,11 +115,11 @@ Options:
           [env: BOLT_SIDECAR_MAX_COMMITTED_GAS=]
           [default: 10000000]
 
-      --min-priority-fee <MIN_PRIORITY_FEE>
-          Min priority fee to accept for a commitment
+      --min-inclusion-profit <MIN_INCLUSION_PROFIT>
+          Min profit per gas to accept a commitment
 
-          [env: BOLT_SIDECAR_MIN_PRIORITY_FEE=]
-          [default: 1000000000]
+          [env: BOLT_SIDECAR_MIN_PROFIT=]
+          [default: 2000000000]
 
       --chain <CHAIN>
           Chain on which the sidecar is running

--- a/bolt-sidecar/src/config/limits.rs
+++ b/bolt-sidecar/src/config/limits.rs
@@ -8,8 +8,8 @@ pub const DEFAULT_MAX_COMMITMENTS: usize = 128;
 /// Default max committed gas per block.
 pub const DEFAULT_MAX_COMMITTED_GAS: u64 = 10_000_000;
 
-/// Default min priority fee to accept for a commitment.
-pub const DEFAULT_MIN_PRIORITY_FEE: u128 = 1_000_000_000; // 1 Gwei
+/// Default min profit to accept for a commitment.
+pub const DEFAULT_MIN_PROFIT: u64 = 2_000_000_000; // 2 Gwei
 
 /// Default max account states size.
 pub const DEFAULT_MAX_ACCOUNT_STATES_SIZE: u64 = 1_024;
@@ -32,13 +32,13 @@ pub struct LimitsOpts {
         default_value_t = LimitsOpts::default().max_committed_gas_per_slot
     )]
     pub max_committed_gas_per_slot: NonZero<u64>,
-    /// Min priority fee to accept for a commitment
+    /// Min profit per gas to accept a commitment
     #[clap(
         long,
-        env = "BOLT_SIDECAR_MIN_PRIORITY_FEE",
-        default_value_t = LimitsOpts::default().min_priority_fee
+        env = "BOLT_SIDECAR_MIN_PROFIT",
+        default_value_t = LimitsOpts::default().min_inclusion_profit
     )]
-    pub min_priority_fee: u128,
+    pub min_inclusion_profit: u64,
     /// The maximum size in MiB of the [crate::state::ExecutionState] ScoreCache that holds account
     /// states. Each [crate::primitives::AccountState] is 48 bytes, its score is [usize] bytes, and
     /// its key is 20 bytes, so the default value of 1024 KiB = 1 MiB can hold around 15k account
@@ -58,7 +58,7 @@ impl Default for LimitsOpts {
                 .expect("Valid non-zero"),
             max_committed_gas_per_slot: NonZero::new(DEFAULT_MAX_COMMITTED_GAS)
                 .expect("Valid non-zero"),
-            min_priority_fee: DEFAULT_MIN_PRIORITY_FEE,
+            min_inclusion_profit: DEFAULT_MIN_PROFIT,
             max_account_states_size: NonZero::new(1_024).expect("Valid non-zero"),
         }
     }

--- a/bolt-sidecar/src/primitives/commitment.rs
+++ b/bolt-sidecar/src/primitives/commitment.rs
@@ -191,7 +191,7 @@ impl InclusionRequest {
             let min_priority_fee =
                 pricing.calculate_min_priority_fee(tx.gas_limit(), preconfirmed_gas)?;
 
-            let tip = tx.effective_tip_per_gas(max_base_fee).unwrap_or(0);
+            let tip = tx.effective_tip_per_gas(max_base_fee).unwrap_or_default();
             if tip < min_priority_fee as u128 {
                 return Ok(false);
             }

--- a/bolt-sidecar/src/primitives/commitment.rs
+++ b/bolt-sidecar/src/primitives/commitment.rs
@@ -7,7 +7,10 @@ use alloy::{
 };
 use serde::{de, Deserialize, Deserializer, Serialize};
 
-use crate::crypto::SignerECDSA;
+use crate::{
+    crypto::SignerECDSA,
+    state::{pricing::PricingError, PreconfPricing},
+};
 
 use super::{deserialize_txs, serialize_txs, FullTransaction, TransactionExt};
 
@@ -173,10 +176,29 @@ impl InclusionRequest {
     /// Validates the priority fee against a minimum priority fee.
     /// Returns `true` if the "effective priority fee" is greater than or equal to the set minimum
     /// priority fee, `false` otherwise.
-    pub fn validate_min_priority_fee(&self, max_base_fee: u128, min_priority_fee: u128) -> bool {
-        self.txs.iter().all(|tx| {
-            tx.effective_tip_per_gas(max_base_fee).map_or(false, |tip| tip >= min_priority_fee)
-        })
+    /// Returns an error if min priority fee cannot be calculated.
+    pub fn validate_min_priority_fee(
+        &self,
+        pricing: &PreconfPricing,
+        preconfirmed_gas: u64,
+        max_base_fee: u128,
+    ) -> Result<bool, PricingError> {
+        // Each included tx will move the price up
+        // So we need to calculate the minimum priority fee for each tx
+        let mut local_preconfirmed_gas = preconfirmed_gas;
+        for tx in &self.txs {
+            // Calculate minimum required priority fee for this transaction
+            let min_priority_fee =
+                pricing.calculate_min_priority_fee(tx.gas_limit(), preconfirmed_gas)?;
+
+            let tip = tx.effective_tip_per_gas(max_base_fee).unwrap_or(0);
+            if tip < min_priority_fee as u128 {
+                return Ok(false);
+            }
+            // Increment the preconfirmed gas for the next transaction in the bundle
+            local_preconfirmed_gas = local_preconfirmed_gas.saturating_add(tx.gas_limit());
+        }
+        Ok(true)
     }
 
     /// Returns the total gas limit of all transactions in this request.

--- a/bolt-sidecar/src/primitives/commitment.rs
+++ b/bolt-sidecar/src/primitives/commitment.rs
@@ -181,6 +181,7 @@ impl InclusionRequest {
         &self,
         pricing: &PreconfPricing,
         preconfirmed_gas: u64,
+        min_inclusion_profit: u64,
         max_base_fee: u128,
     ) -> Result<bool, PricingError> {
         // Each included tx will move the price up
@@ -188,8 +189,9 @@ impl InclusionRequest {
         let mut local_preconfirmed_gas = preconfirmed_gas;
         for tx in &self.txs {
             // Calculate minimum required priority fee for this transaction
-            let min_priority_fee =
-                pricing.calculate_min_priority_fee(tx.gas_limit(), preconfirmed_gas)?;
+            let min_priority_fee = pricing
+                .calculate_min_priority_fee(tx.gas_limit(), preconfirmed_gas)?
+                + min_inclusion_profit;
 
             let tip = tx.effective_tip_per_gas(max_base_fee).unwrap_or_default();
             if tip < min_priority_fee as u128 {

--- a/bolt-sidecar/src/primitives/commitment.rs
+++ b/bolt-sidecar/src/primitives/commitment.rs
@@ -9,7 +9,7 @@ use serde::{de, Deserialize, Deserializer, Serialize};
 
 use crate::{
     crypto::SignerECDSA,
-    state::{pricing::PricingError, PreconfPricing},
+    state::{pricing::PricingError, InclusionPricer},
 };
 
 use super::{deserialize_txs, serialize_txs, FullTransaction, TransactionExt};
@@ -179,7 +179,7 @@ impl InclusionRequest {
     /// Returns an error if min priority fee cannot be calculated.
     pub fn validate_min_priority_fee(
         &self,
-        pricing: &PreconfPricing,
+        pricing: &InclusionPricer,
         preconfirmed_gas: u64,
         min_inclusion_profit: u64,
         max_base_fee: u128,

--- a/bolt-sidecar/src/state/execution.rs
+++ b/bolt-sidecar/src/state/execution.rs
@@ -963,7 +963,7 @@ mod tests {
 
         // Create a transaction with a max priority fee that is too low
         let tx = default_test_transaction(*sender, None)
-            .with_max_priority_fee_per_gas(GWEI_TO_WEI as u128);
+            .with_max_priority_fee_per_gas(GWEI_TO_WEI as u128 / 2);
 
         let mut request = create_signed_inclusion_request(&[tx], sender_pk, 10).await?;
 
@@ -1006,7 +1006,7 @@ mod tests {
 
         // Create a transaction with a gas price that is too low
         let tx = default_test_transaction(*sender, None)
-            .with_gas_price(max_base_fee + GWEI_TO_WEI as u128);
+            .with_gas_price(max_base_fee + GWEI_TO_WEI as u128 / 2);
 
         let mut request = create_signed_inclusion_request(&[tx], sender_pk, 10).await?;
 

--- a/bolt-sidecar/src/state/execution.rs
+++ b/bolt-sidecar/src/state/execution.rs
@@ -22,7 +22,7 @@ use crate::{
     telemetry::ApiMetrics,
 };
 
-use super::PreconfPricing;
+use super::InclusionPricer;
 use super::{account_state::AccountStateCache, fetcher::StateFetcher};
 
 /// Possible commitment validation errors.
@@ -173,7 +173,7 @@ pub struct ExecutionState<C> {
     /// Other values used for validation
     validation_params: ValidationParams,
     /// Pricing calculator for preconfirmations.
-    pricing: PreconfPricing,
+    pricing: InclusionPricer,
 }
 
 /// Other values used for validation.
@@ -230,7 +230,7 @@ impl<C: StateFetcher> ExecutionState<C> {
             kzg_settings: EnvKzgSettings::default(),
             // TODO: add a way to configure these values from CLI
             validation_params: ValidationParams::new(gas_limit),
-            pricing: PreconfPricing::new(gas_limit),
+            pricing: InclusionPricer::new(gas_limit),
         })
     }
 

--- a/bolt-sidecar/src/state/execution.rs
+++ b/bolt-sidecar/src/state/execution.rs
@@ -321,7 +321,12 @@ impl<C: StateFetcher> ExecutionState<C> {
         }
 
         // Ensure max_priority_fee_per_gas is greater than or equal to the calculated min_priority_fee
-        if !req.validate_min_priority_fee(&self.pricing, template_committed_gas, max_basefee)? {
+        if !req.validate_min_priority_fee(
+            &self.pricing,
+            template_committed_gas,
+            self.limits.min_inclusion_profit,
+            max_basefee,
+        )? {
             return Err(ValidationError::MaxPriorityFeePerGasTooLow);
         }
 
@@ -838,7 +843,7 @@ mod tests {
         state.update_head(None, slot).await?;
 
         // Set the sender balance to just enough to pay for 1 transaction
-        let balance = U256::from_str("500000000000000").unwrap(); // leave just 0.0005 ETH
+        let balance = U256::from_str("600000000000000").unwrap(); // leave just 0.0005 ETH
         let sender_account = client.get_account_state(sender, None).await.unwrap();
         let balance_to_burn = sender_account.balance - balance;
 
@@ -857,7 +862,8 @@ mod tests {
         let tx = default_test_transaction(*sender, Some(1));
         let mut request = create_signed_inclusion_request(&[tx], sender_pk, 10).await?;
 
-        assert!(state.validate_request(&mut request).await.is_ok());
+        let validation = state.validate_request(&mut request).await;
+        assert!(validation.is_ok(), "Validation failed: {validation:?}");
 
         let message = ConstraintsMessage::build(Default::default(), request.clone());
         let signature = signer.sign_commit_boost_root(message.digest())?;
@@ -870,10 +876,13 @@ mod tests {
 
         // this should fail because the balance is insufficient as we spent
         // all of it on the previous preconfirmation
-        assert!(matches!(
-            state.validate_request(&mut request).await,
-            Err(ValidationError::InsufficientBalance)
-        ));
+        let validation_result = state.validate_request(&mut request).await;
+
+        assert!(
+            matches!(validation_result, Err(ValidationError::InsufficientBalance)),
+            "Expected InsufficientBalance error, got {:?}",
+            validation_result
+        );
 
         Ok(())
     }
@@ -949,7 +958,7 @@ mod tests {
         let anvil = launch_anvil();
         let client = StateClient::new(anvil.endpoint_url());
 
-        let limits = LimitsOpts { min_priority_fee: 2 * GWEI_TO_WEI as u128, ..Default::default() };
+        let limits = LimitsOpts { ..Default::default() };
 
         let mut state = ExecutionState::new(client.clone(), limits, DEFAULT_GAS_LIMIT).await?;
 
@@ -987,7 +996,7 @@ mod tests {
         let anvil = launch_anvil();
         let client = StateClient::new(anvil.endpoint_url());
 
-        let limits = LimitsOpts { min_priority_fee: 2 * GWEI_TO_WEI as u128, ..Default::default() };
+        let limits = LimitsOpts { ..Default::default() };
 
         let mut state = ExecutionState::new(client.clone(), limits, DEFAULT_GAS_LIMIT).await?;
 
@@ -1030,7 +1039,7 @@ mod tests {
         let anvil = launch_anvil();
         let client = StateClient::new(anvil.endpoint_url());
 
-        let limits = LimitsOpts { min_priority_fee: 2 * GWEI_TO_WEI as u128, ..Default::default() };
+        let limits = LimitsOpts { ..Default::default() };
 
         let mut state = ExecutionState::new(client.clone(), limits, DEFAULT_GAS_LIMIT).await?;
 
@@ -1165,7 +1174,7 @@ mod tests {
         let anvil = launch_anvil();
         let client = StateClient::new(anvil.endpoint_url());
 
-        let limits = LimitsOpts { min_priority_fee: 1000000000, ..Default::default() };
+        let limits = LimitsOpts { min_inclusion_profit: 1_000_000_000, ..Default::default() };
         let mut state = ExecutionState::new(client.clone(), limits, DEFAULT_GAS_LIMIT).await?;
 
         let sender = anvil.addresses().first().unwrap();
@@ -1288,11 +1297,13 @@ mod tests {
             .with_value(uint!(11_000_U256 * Uint::from(ETH_TO_WEI)));
 
         let mut request = create_signed_inclusion_request(&[tx1, tx2, tx3], sender_pk, 10).await?;
+        let validation_result = state.validate_request(&mut request).await;
 
-        assert!(matches!(
-            state.validate_request(&mut request).await,
-            Err(ValidationError::InsufficientBalance)
-        ));
+        assert!(
+            matches!(validation_result, Err(ValidationError::InsufficientBalance)),
+            "Expected InsufficientBalance error, got {:?}",
+            validation_result
+        );
 
         Ok(())
     }

--- a/bolt-sidecar/src/state/execution.rs
+++ b/bolt-sidecar/src/state/execution.rs
@@ -66,6 +66,9 @@ pub enum ValidationError {
     /// The sender does not have enough balance to pay for the transaction.
     #[error("Not enough balance to pay for value + maximum fee")]
     InsufficientBalance,
+    /// Pricing calculation error.
+    #[error("Pricing calculation error: {0}")]
+    Pricing(#[from] pricing::PricingError),
     /// There are too many EIP-4844 transactions in the target block.
     #[error("Too many EIP-4844 transactions in target block")]
     Eip4844Limit,
@@ -113,6 +116,7 @@ impl ValidationError {
             Self::MaxPriorityFeePerGasTooHigh => "max_priority_fee_per_gas_too_high",
             Self::MaxPriorityFeePerGasTooLow => "max_priority_fee_per_gas_too_low",
             Self::InsufficientBalance => "insufficient_balance",
+            Self::Pricing(_) => "pricing",
             Self::Eip4844Limit => "eip4844_limit",
             Self::SlotTooLow(_) => "slot_too_low",
             Self::MaxCommitmentsReachedForSlot(_, _) => "max_commitments_reached_for_slot",
@@ -122,12 +126,6 @@ impl ValidationError {
             Self::ChainIdMismatch => "chain_id_mismatch",
             Self::Internal(_) => "internal",
         }
-    }
-}
-
-impl From<pricing::PricingError> for ValidationError {
-    fn from(err: pricing::PricingError) -> Self {
-        Self::Internal(format!("Pricing error: {}", err))
     }
 }
 

--- a/bolt-sidecar/src/state/execution.rs
+++ b/bolt-sidecar/src/state/execution.rs
@@ -126,7 +126,7 @@ impl ValidationError {
 
 impl From<pricing::PricingError> for ValidationError {
     fn from(err: pricing::PricingError) -> Self {
-        ValidationError::Internal(format!("Pricing error: {}", err))
+        Self::Internal(format!("Pricing error: {}", err))
     }
 }
 

--- a/bolt-sidecar/src/state/mod.rs
+++ b/bolt-sidecar/src/state/mod.rs
@@ -13,7 +13,7 @@ pub use execution::{ExecutionState, ValidationError};
 
 /// Module to calculate pricing.
 pub mod pricing;
-pub use pricing::PreconfPricing;
+pub use pricing::InclusionPricer;
 
 /// Module to fetch state from the Execution layer.
 pub mod fetcher;

--- a/bolt-sidecar/src/state/pricing.rs
+++ b/bolt-sidecar/src/state/pricing.rs
@@ -142,17 +142,27 @@ mod tests {
         let pricing = PreconfPricing::default();
 
         // Test minimum fee (210k gas ETH transfer, 0 preconfirmed)
-        let incoming_gas = 210_000;
+        let big_gas = 210_000;
         let preconfirmed_gas = 0;
-        let min_fee_wei =
-            pricing.calculate_min_priority_fee(incoming_gas, preconfirmed_gas).unwrap();
+        let big_fee = pricing.calculate_min_priority_fee(big_gas, preconfirmed_gas).unwrap();
 
+        // Test minimum fee (10x21k gas ETH transfer, 0 preconfirmed)
+        let small_gas = 21_000;
+        let mut small_fee_sum = 0;
+        for _ in 0..10 {
+            let small_fee =
+                pricing.calculate_min_priority_fee(small_gas, preconfirmed_gas).unwrap();
+            small_fee_sum += small_fee;
+        }
+
+        // A preconf that uses
         // This preconf uses 10x more gas than the 21k preconf,
         // but the fee is only slightly higher.
         assert!(
-            (min_fee_wei as f64 - 615_379_171.0).abs() < 1_000.0,
-            "Expected ~615,379,171 Wei, got {} Wei",
-            min_fee_wei
+            (big_fee as f64 - small_fee_sum as f64).abs() < 1_000.0,
+            "Expected big preconf to cost the same as many small ones, big {} Wei, small {} Wei",
+            big_fee,
+            small_fee_sum
         );
     }
 

--- a/bolt-sidecar/src/state/pricing.rs
+++ b/bolt-sidecar/src/state/pricing.rs
@@ -147,38 +147,6 @@ mod tests {
     }
 
     #[test]
-    fn test_min_priority_fee_zero_big_preconfirmed() {
-        let pricing = PreconfPricing::default();
-
-        // Test minimum fee (210k gas ETH transfer, 0 preconfirmed)
-        let big_gas = 210_000;
-        let preconfirmed_gas_big = 0;
-        let big_fee = pricing.calculate_min_priority_fee(big_gas, preconfirmed_gas_big).unwrap();
-
-        // Test minimum fee (10x21k gas ETH transfer, 0 preconfirmed)
-        let small_gas = 21_000;
-        let mut preconfirmed_gas_small = 0;
-        let mut small_fee_sum = 0;
-        for _ in 0..10 {
-            let small_fee =
-                pricing.calculate_min_priority_fee(small_gas, preconfirmed_gas_small).unwrap();
-            small_fee_sum += small_fee;
-            preconfirmed_gas_small += small_gas;
-        }
-
-        // Moving on the pricing curve in 10 steps should cost
-        // the same as moving in one big step per gas.
-        let small_sum_fee_avg = small_fee_sum / 10;
-
-        assert!(
-            (big_fee as f64 - small_sum_fee_avg as f64).abs() < 1_000.0,
-            "Expected big preconf to cost the same as many small ones, big {} Wei, small {} Wei",
-            big_fee,
-            small_fee_sum
-        );
-    }
-
-    #[test]
     fn test_min_priority_fee_medium_load() {
         let pricing = PreconfPricing::default();
 
@@ -214,6 +182,38 @@ mod tests {
             (min_fee_wei as f64 - 19_175_357_339.0).abs() < 1_000.0,
             "Expected ~19,175,357,339 Wei, got {} Wei",
             min_fee_wei
+        );
+    }
+
+    #[test]
+    fn test_min_priority_fee_zero_big_preconfirmed() {
+        let pricing = PreconfPricing::default();
+
+        // Test minimum fee (210k gas ETH transfer, 0 preconfirmed)
+        let big_gas = 210_000;
+        let preconfirmed_gas_big = 0;
+        let big_fee = pricing.calculate_min_priority_fee(big_gas, preconfirmed_gas_big).unwrap();
+
+        // Test minimum fee (10x21k gas ETH transfer, 0 preconfirmed)
+        let small_gas = 21_000;
+        let mut preconfirmed_gas_small = 0;
+        let mut small_fee_sum = 0;
+        for _ in 0..10 {
+            let small_fee =
+                pricing.calculate_min_priority_fee(small_gas, preconfirmed_gas_small).unwrap();
+            small_fee_sum += small_fee;
+            preconfirmed_gas_small += small_gas;
+        }
+
+        // Moving on the pricing curve in 10 steps should cost
+        // the same as moving in one big step per gas.
+        let small_sum_fee_avg = small_fee_sum / 10;
+
+        assert!(
+            (big_fee as f64 - small_sum_fee_avg as f64).abs() < 1_000.0,
+            "Expected big preconf to cost the same as many small ones, big {} Wei, small {} Wei",
+            big_fee,
+            small_fee_sum
         );
     }
 

--- a/bolt-sidecar/src/state/pricing.rs
+++ b/bolt-sidecar/src/state/pricing.rs
@@ -8,7 +8,7 @@ const GAS_SCALAR: f64 = 1.02e-6;
 
 /// Handles pricing calculations for preconfirmations
 #[derive(Debug)]
-pub struct PreconfPricing {
+pub struct InclusionPricer {
     block_gas_limit: u64,
     base_multiplier: f64,
     gas_scalar: f64,
@@ -37,14 +37,14 @@ pub enum PricingError {
     },
 }
 
-impl Default for PreconfPricing {
+impl Default for InclusionPricer {
     fn default() -> Self {
         Self::new(DEFAULT_BLOCK_GAS_LIMIT)
     }
 }
 
-impl PreconfPricing {
-    /// Initializes a new PreconfPricing with default parameters.
+impl InclusionPricer {
+    /// Initializes a new InclusionPricer with default parameters.
     pub fn new(block_gas_limit: u64) -> Self {
         Self { block_gas_limit, base_multiplier: BASE_MULTIPLIER, gas_scalar: GAS_SCALAR }
     }
@@ -130,7 +130,7 @@ mod tests {
 
     #[test]
     fn test_min_priority_fee_zero_preconfirmed() {
-        let pricing = PreconfPricing::default();
+        let pricing = InclusionPricer::default();
 
         // Test minimum fee (21k gas ETH transfer, 0 preconfirmed)
         let incoming_gas = 21_000;
@@ -148,7 +148,7 @@ mod tests {
 
     #[test]
     fn test_min_priority_fee_medium_load() {
-        let pricing = PreconfPricing::default();
+        let pricing = InclusionPricer::default();
 
         // Test medium load (21k gas, 15M preconfirmed)
         let incoming_gas = 21_000;
@@ -166,7 +166,7 @@ mod tests {
 
     #[test]
     fn test_min_priority_fee_max_load() {
-        let pricing = PreconfPricing::default();
+        let pricing = InclusionPricer::default();
 
         // Test last preconfirmed transaction (21k gas, almost 30M preconfirmed)
         let incoming_gas = 21_000;
@@ -187,7 +187,7 @@ mod tests {
 
     #[test]
     fn test_min_priority_fee_80p() {
-        let pricing = PreconfPricing::default();
+        let pricing = InclusionPricer::default();
 
         // Test preconfirmed transaction when 80% of the block is already used
         let incoming_gas = 21_000;
@@ -205,7 +205,7 @@ mod tests {
 
     #[test]
     fn test_min_priority_fee_zero_big_preconfirmed() {
-        let pricing = PreconfPricing::default();
+        let pricing = InclusionPricer::default();
 
         // Test minimum fee (210k gas ETH transfer, 0 preconfirmed)
         let big_gas = 210_000;
@@ -237,7 +237,7 @@ mod tests {
 
     #[test]
     fn test_priority_fee_all_gas() {
-        let pricing = PreconfPricing::default();
+        let pricing = InclusionPricer::default();
 
         // Test one preconf for all the available gas
         let incoming_gas = 30_000_000;
@@ -254,7 +254,7 @@ mod tests {
 
     #[test]
     fn test_min_priority_fee_zero_preconfirmed_36m() {
-        let pricing = PreconfPricing::new(36_000_000);
+        let pricing = InclusionPricer::new(36_000_000);
 
         // Test minimum fee (21k gas ETH transfer, 0 preconfirmed)
         let incoming_gas = 21_000;
@@ -271,7 +271,7 @@ mod tests {
 
     #[test]
     fn test_min_priority_fee_medium_load_36m() {
-        let pricing = PreconfPricing::new(36_000_000);
+        let pricing = InclusionPricer::new(36_000_000);
 
         // Test medium load (21k gas, 18M preconfirmed)
         let incoming_gas = 21_000;
@@ -288,7 +288,7 @@ mod tests {
 
     #[test]
     fn test_min_priority_fee_max_load_36m() {
-        let pricing = PreconfPricing::new(36_000_000);
+        let pricing = InclusionPricer::new(36_000_000);
 
         // Test last preconfirmed transaction (21k gas, almost 30M preconfirmed)
         let incoming_gas = 21_000;
@@ -309,7 +309,7 @@ mod tests {
 
     #[test]
     fn test_error_exceeds_block_limit() {
-        let pricing = PreconfPricing::default();
+        let pricing = InclusionPricer::default();
 
         let incoming_gas = 21_000;
         let preconfirmed_gas = 30_000_001;
@@ -320,7 +320,7 @@ mod tests {
 
     #[test]
     fn test_error_insufficient_gas() {
-        let pricing = PreconfPricing::default();
+        let pricing = InclusionPricer::default();
 
         let incoming_gas = 15_000_001;
         let preconfirmed_gas = 15_000_000;
@@ -334,7 +334,7 @@ mod tests {
 
     #[test]
     fn test_error_zero_incoming_gas() {
-        let pricing = PreconfPricing::default();
+        let pricing = InclusionPricer::default();
 
         let incoming_gas = 0;
         let preconfirmed_gas = 0;

--- a/bolt-sidecar/src/state/pricing.rs
+++ b/bolt-sidecar/src/state/pricing.rs
@@ -196,6 +196,27 @@ mod tests {
     }
 
     #[test]
+    fn test_priority_fee_all_gas() {
+        let pricing = PreconfPricing::default();
+
+        // Test one preconf for all the available gas
+        let incoming_gas = 30_000_000;
+        let preconfirmed_gas = 0;
+        let min_fee_wei =
+            pricing.calculate_min_priority_fee(incoming_gas, preconfirmed_gas).unwrap();
+
+        // Expected fee: ~19 Gwei
+        // This will likely never happen, since you want to reserve some gas
+        // on top of the block for MEV, but enforcing this is not the responsibility
+        // of the pricing model.
+        assert!(
+            (min_fee_wei as f64 - 2_186_999_509.0).abs() < 1_000.0,
+            "Expected ~2,186,999,509 Wei, got {} Wei",
+            min_fee_wei
+        );
+    }
+
+    #[test]
     fn test_min_priority_fee_zero_preconfirmed_36m() {
         let pricing = PreconfPricing::new(36_000_000);
 

--- a/bolt-sidecar/src/state/pricing.rs
+++ b/bolt-sidecar/src/state/pricing.rs
@@ -143,16 +143,18 @@ mod tests {
 
         // Test minimum fee (210k gas ETH transfer, 0 preconfirmed)
         let big_gas = 210_000;
-        let preconfirmed_gas = 0;
-        let big_fee = pricing.calculate_min_priority_fee(big_gas, preconfirmed_gas).unwrap();
+        let preconfirmed_gas_big = 0;
+        let big_fee = pricing.calculate_min_priority_fee(big_gas, preconfirmed_gas_big).unwrap();
 
         // Test minimum fee (10x21k gas ETH transfer, 0 preconfirmed)
         let small_gas = 21_000;
+        let mut preconfirmed_gas_small = 0;
         let mut small_fee_sum = 0;
         for _ in 0..10 {
             let small_fee =
-                pricing.calculate_min_priority_fee(small_gas, preconfirmed_gas).unwrap();
+                pricing.calculate_min_priority_fee(small_gas, preconfirmed_gas_small).unwrap();
             small_fee_sum += small_fee;
+            preconfirmed_gas_small += small_gas;
         }
 
         // A preconf that uses

--- a/bolt-sidecar/src/state/pricing.rs
+++ b/bolt-sidecar/src/state/pricing.rs
@@ -186,6 +186,24 @@ mod tests {
     }
 
     #[test]
+    fn test_min_priority_fee_80p() {
+        let pricing = PreconfPricing::default();
+
+        // Test preconfirmed transaction when 80% of the block is already used
+        let incoming_gas = 21_000;
+        let preconfirmed_gas = (30_000_000 as f64 * 0.8) as u64;
+        let min_fee_wei =
+            pricing.calculate_min_priority_fee(incoming_gas, preconfirmed_gas).unwrap();
+
+        // Expected fee: ~
+        assert!(
+            (min_fee_wei as f64 - 2_726_012_676.0).abs() < 1_000.0,
+            "Expected ~2,726,012,676 Wei, got {} Wei",
+            min_fee_wei
+        );
+    }
+
+    #[test]
     fn test_min_priority_fee_zero_big_preconfirmed() {
         let pricing = PreconfPricing::default();
 

--- a/bolt-sidecar/src/state/pricing.rs
+++ b/bolt-sidecar/src/state/pricing.rs
@@ -191,7 +191,7 @@ mod tests {
 
         // Test preconfirmed transaction when 80% of the block is already used
         let incoming_gas = 21_000;
-        let preconfirmed_gas = (30_000_000 as f64 * 0.8) as u64;
+        let preconfirmed_gas = (30_000_000_f64 * 0.8) as u64;
         let min_fee_wei =
             pricing.calculate_min_priority_fee(incoming_gas, preconfirmed_gas).unwrap();
 

--- a/bolt-sidecar/src/state/pricing.rs
+++ b/bolt-sidecar/src/state/pricing.rs
@@ -215,10 +215,6 @@ mod tests {
         let min_fee_wei =
             pricing.calculate_min_priority_fee(incoming_gas, preconfirmed_gas).unwrap();
 
-        // Expected fee: ~19 Gwei
-        // This will likely never happen, since you want to reserve some gas
-        // on top of the block for MEV, but enforcing this is not the responsibility
-        // of the pricing model.
         assert!(
             (min_fee_wei as f64 - 2_186_999_509.0).abs() < 1_000.0,
             "Expected ~2,186,999,509 Wei, got {} Wei",

--- a/bolt-sidecar/src/state/pricing.rs
+++ b/bolt-sidecar/src/state/pricing.rs
@@ -57,7 +57,7 @@ impl PreconfPricing {
     /// * `preconfirmed_gas` - Total gas already preconfirmed
     ///
     /// # Returns
-    /// * `Ok(f64)` - The minimum inclusion fee in Wei per gas
+    /// * `Ok(u64)` - The minimum inclusion fee in Wei per gas
     /// * `Err(PricingError)` - If the calculation cannot be performed
     ///
     /// Be careful relying on the result of this when preconfirmed gas is close to 30M

--- a/bolt-sidecar/src/test_util.rs
+++ b/bolt-sidecar/src/test_util.rs
@@ -129,7 +129,7 @@ pub(crate) fn default_test_transaction(sender: Address, nonce: Option<u64>) -> T
         .with_nonce(nonce.unwrap_or(0))
         .with_value(U256::from(100))
         .with_gas_limit(21_000)
-        .with_max_priority_fee_per_gas(1_000_000_000) // 1 gwei
+        .with_max_priority_fee_per_gas(3_000_000_000) // 3 gwei
         .with_max_fee_per_gas(20_000_000_000)
 }
 

--- a/testnets/holesky/README.md
+++ b/testnets/holesky/README.md
@@ -777,7 +777,7 @@ Options:
           [env: BOLT_SIDECAR_MAX_COMMITTED_GAS=]
           [default: 10000000]
 
-      --min-inclusion_profit <MIN_INCLUSION_PROFIT>
+      --min-inclusion-profit <MIN_INCLUSION_PROFIT>
           Min profit per gas to accept a commitment
 
           [env: BOLT_SIDECAR_MIN_PROFIT=]

--- a/testnets/holesky/README.md
+++ b/testnets/holesky/README.md
@@ -777,11 +777,11 @@ Options:
           [env: BOLT_SIDECAR_MAX_COMMITTED_GAS=]
           [default: 10000000]
 
-      --min-priority-fee <MIN_PRIORITY_FEE>
-          Min priority fee to accept for a commitment
+      --min-inclusion_profit <MIN_INCLUSION_PROFIT>
+          Min profit per gas to accept a commitment
 
-          [env: BOLT_SIDECAR_MIN_PRIORITY_FEE=]
-          [default: 1000000000]
+          [env: BOLT_SIDECAR_MIN_PROFIT=]
+          [default: 2000000000]
 
       --chain <CHAIN>
           Chain on which the sidecar is running

--- a/testnets/holesky/bolt-sidecar.env.example
+++ b/testnets/holesky/bolt-sidecar.env.example
@@ -33,8 +33,8 @@ BOLT_SIDECAR_BUILDER_PRIVATE_KEY=
 BOLT_SIDECAR_MAX_COMMITMENTS_PER_SLOT=128
 # Max committed gas per slot
 BOLT_SIDECAR_MAX_COMMITTED_GAS_PER_SLOT=10_000_000
-# Min priority fee to accept for a commitment
-BOLT_SIDECAR_MIN_PRIORITY_FEE=2000000000 # 2 Gwei = 2 * 10^9 wei
+#  Min profit per gas to accept a commitment
++BOLT_SIDECAR_MIN_PROFIT=2000000000 # 2 Gwei = 2 * 10^9 wei
 
 # Chain configuration
 # Chain on which the sidecar is running

--- a/testnets/holesky/commit-boost/bolt-sidecar.env.example
+++ b/testnets/holesky/commit-boost/bolt-sidecar.env.example
@@ -58,9 +58,9 @@ BOLT_SIDECAR_MAX_COMMITMENTS_PER_SLOT=128
 # YOU CAN CHANGE THIS TO YOUR LIKING 👇
 BOLT_SIDECAR_MAX_COMMITTED_GAS_PER_SLOT=10000000
 
-# Min priority fee to accept for a commitment
+# Min profit per gas to accept a commitment
 # YOU CAN CHANGE THIS TO YOUR LIKING 👇
-BOLT_SIDECAR_MIN_PRIORITY_FEE=4000000000 # 4 Gwei = 4 * 10^9 wei
+BOLT_SIDECAR_MIN_PROFIT=2000000000 # 2 Gwei = 2 * 10^9 wei
 
 # Chain configuration
 # Chain on which the sidecar is running

--- a/testnets/holesky/presets/sidecar-delegations-preset.env.example
+++ b/testnets/holesky/presets/sidecar-delegations-preset.env.example
@@ -31,8 +31,8 @@ BOLT_SIDECAR_COMMITMENT_PRIVATE_KEY=
 BOLT_SIDECAR_MAX_COMMITMENTS_PER_SLOT=128
 # Max committed gas per slot
 BOLT_SIDECAR_MAX_COMMITTED_GAS_PER_SLOT=10_000_000
-# Min priority fee to accept for a commitment
-BOLT_SIDECAR_MIN_PRIORITY_FEE=2000000000 # 2 Gwei = 2 * 10^9 wei
+# Min profit per gas to accept a commitment
+BOLT_SIDECAR_MIN_PROFIT=2000000000 # 2 Gwei = 2 * 10^9 wei
 
 # Chain configuration
 # Chain on which the sidecar is running


### PR DESCRIPTION
Implement [pricing model](https://research.lido.fi/t/a-pricing-model-for-inclusion-preconfirmations/9136#p-19482-a-model-for-cumulative-proposer-rewards-13) pioneered by Nethermind Research.

The pricing model defines a pricing curve to ensure proposers don't give up any profits when preconfirming a transaciton. Proposers would want profit for the extra work they do and for the "risk free" rate they could get on the 1 ETH collateral they put down with liquid staking. We're currently researching what this profit should be, but for now we default it to 2 GWEI but make it configurable.

In many cases the proposer will outsource the pricing to the Firewall, but this will PR will make sure proposers don't accept a preconf where they lose money.