### PR TITLE
feat: build valid fallback payload with Nethermind

### DIFF
--- a/bolt-sidecar/src/builder/fallback/engine_hints/geth.rs
+++ b/bolt-sidecar/src/builder/fallback/engine_hints/geth.rs
@@ -1,8 +1,14 @@
 use alloy::primitives::{Bloom, B256};
 use hex::FromHex;
+use lazy_static::lazy_static;
 use regex::Regex;
 
 use crate::builder::{fallback::engine_hinter::EngineApiHint, BuilderError};
+
+lazy_static! {
+    /// Capture either the "local" or "got" value from the error message
+    static ref REGEX: Regex = Regex::new(r"(?:local:|got) ([0-9a-zA-Z]+)").expect("valid regex");
+}
 
 /// Parse a hinted value from the engine response.
 /// An example error message from the engine API looks like this:
@@ -22,10 +28,7 @@ use crate::builder::{fallback::engine_hinter::EngineApiHint, BuilderError};
 /// - [ValidateState](<https://github.com/ethereum/go-ethereum/blob/9298d2db884c4e3f9474880e3dcfd080ef9eacfa/core/block_validator.go#L122-L151>)
 /// - [Blockhash Mismatch](<https://github.com/ethereum/go-ethereum/blob/9298d2db884c4e3f9474880e3dcfd080ef9eacfa/beacon/engine/types.go#L253-L256>)
 pub fn parse_geth_engine_error_hint(error: &str) -> Result<Option<EngineApiHint>, BuilderError> {
-    // Capture either the "local" or "got" value from the error message
-    let re = Regex::new(r"(?:local:|got) ([0-9a-zA-Z]+)").expect("valid regex");
-
-    let raw_hint_value = match re.captures(error).and_then(|cap| cap.get(1)) {
+    let raw_hint_value = match REGEX.captures(error).and_then(|cap| cap.get(1)) {
         Some(matched) => matched.as_str().to_string(),
         None => return Ok(None),
     };

--- a/bolt-sidecar/src/builder/fallback/engine_hints/mod.rs
+++ b/bolt-sidecar/src/builder/fallback/engine_hints/mod.rs
@@ -21,8 +21,8 @@ pub fn parse_hint_from_engine_response(
 ) -> Result<Option<EngineApiHint>, BuilderError> {
     match client {
         ClientCode::GE => geth::parse_geth_engine_error_hint(error),
-        // TODO: Add Nethermind engine hints parsing
-        // ClientCode::NM => nethermind::parse_nethermind_engine_error_hint(error),
+        ClientCode::NM => nethermind::parse_nethermind_engine_error_hint(error),
+
         _ => {
             error!("Unsupported fallback execution client: {}", client.client_name());
             Err(BuilderError::UnsupportedEngineClient(client))

--- a/bolt-sidecar/src/builder/fallback/engine_hints/nethermind.rs
+++ b/bolt-sidecar/src/builder/fallback/engine_hints/nethermind.rs
@@ -1,6 +1,14 @@
-use tracing::warn;
+use alloy::primitives::{Bloom, B256};
+use hex::FromHex;
+use lazy_static::lazy_static;
+use regex::Regex;
 
 use crate::builder::{fallback::engine_hinter::EngineApiHint, BuilderError};
+
+lazy_static! {
+    /// Capture the "got" value from the error message
+    static ref REGEX: Regex = Regex::new(r"got ([0-9a-zA-Z]+)").expect("valid regex");
+}
 
 /// Parse a hinted value from the engine response.
 /// An example error message from the engine API looks like this:
@@ -11,17 +19,30 @@ use crate::builder::{fallback::engine_hinter::EngineApiHint, BuilderError};
 ///     "id": 1,
 ///     "error": {
 ///         "code":-32000,
-///          "message": "local: blockhash mismatch: got 0x... expected 0x..."
+///          "message": "HeaderGasUsedMismatch: Gas used in header does not match calculated. Expected 0, got 21000"
 ///     }
 /// }
 /// ```
-// TODO: implement hints parsing
-// TODO: remove dead_code attribute
-#[allow(dead_code)]
 pub fn parse_nethermind_engine_error_hint(
     error: &str,
 ) -> Result<Option<EngineApiHint>, BuilderError> {
-    warn!(%error, "Nethermind engine error hint parsing is not implemented");
+    let raw_hint_value = match REGEX.captures(error).and_then(|cap| cap.get(1)) {
+        Some(matched) => matched.as_str().to_string(),
+        None => return Ok(None),
+    };
+
+    // Match the hint value to the corresponding hint type based on other parts of the error message
+    if error.contains("InvalidHeaderHash") {
+        return Ok(Some(EngineApiHint::BlockHash(B256::from_hex(raw_hint_value)?)));
+    } else if error.contains("HeaderGasUsedMismatch") {
+        return Ok(Some(EngineApiHint::GasUsed(raw_hint_value.parse()?)));
+    } else if error.contains("InvalidStateRoot") {
+        return Ok(Some(EngineApiHint::StateRoot(B256::from_hex(raw_hint_value)?)));
+    } else if error.contains("InvalidReceiptsRoot") {
+        return Ok(Some(EngineApiHint::ReceiptsRoot(B256::from_hex(raw_hint_value)?)));
+    } else if error.contains("InvalidLogsBloom") {
+        return Ok(Some(EngineApiHint::LogsBloom(Bloom::from_hex(&raw_hint_value)?)));
+    };
 
     Ok(None)
 }

--- a/bolt-sidecar/src/builder/fallback/payload_builder.rs
+++ b/bolt-sidecar/src/builder/fallback/payload_builder.rs
@@ -144,9 +144,8 @@ impl FallbackPayloadBuilder {
 mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
-    use alloy::consensus::constants;
     use alloy::{
-        consensus::proofs,
+        consensus::{constants, proofs},
         eips::eip2718::{Decodable2718, Encodable2718},
         network::{EthereumWallet, TransactionBuilder},
         primitives::{hex, Address},
@@ -195,9 +194,9 @@ mod tests {
         let raw_encoded = tx_signed.encoded_2718();
         let tx_signed_reth = TransactionSigned::decode_2718(&mut raw_encoded.as_slice())?;
 
-        let slot = genesis_time
-            + (SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs() / cfg.chain.slot_time())
-            + 1;
+        let slot = genesis_time +
+            (SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs() / cfg.chain.slot_time()) +
+            1;
 
         let block = builder.build_fallback_payload(slot, &[tx_signed_reth]).await?;
 

--- a/bolt-sidecar/src/builder/mod.rs
+++ b/bolt-sidecar/src/builder/mod.rs
@@ -66,8 +66,8 @@ pub enum BuilderError {
     InvalidTransactions(String),
     #[error("Got an unexpected response from engine_newPayload query: {0}")]
     UnexpectedPayloadStatus(PayloadStatusEnum),
-    #[error("Failed to parse any hints from engine API validation error")]
-    FailedToParseHintsFromEngine,
+    #[error("Failed to parse any hints from engine API validation error (client: {0})")]
+    FailedToParseHintsFromEngine(String),
     #[error("Unsupported engine hint: {0}")]
     UnsupportedEngineHint(String),
     #[error("Unsupported engine client: {0}")]


### PR DESCRIPTION
This PR adds the ability to build valid fallback payloads with the Nethermind EL client.
It has been tested with the following setup:

1. Nethermind client running a patched version that includes hints in validation error messages
2. `test_build_fallback_payload` with `cfg.engine_api_url` set to the above client

These are the logs of the test:

```text
❯ RUST_LOG=bolt_sidecar=trace cargo test --package bolt-sidecar --lib -- builder::fallback::payload_builder::tests::test_build_fallback_payload --exact --show-output --nocapture
     Running unittests src/lib.rs (target/debug/deps/bolt_sidecar-2d55fce0317b88be)

2024-12-19T12:04:04.256598Z DEBUG bolt_sidecar::builder::fallback::payload_builder: Fetched execution client info client=Nethermind
2024-12-19T12:04:04.381762Z DEBUG bolt_sidecar::builder::fallback::engine_hinter: Fetching hint from engine API iteration=0
2024-12-19T12:04:04.434898Z DEBUG bolt_sidecar::builder::fallback::engine_hinter: Received hint from engine API hint=GasUsed(21000)
2024-12-19T12:04:04.434962Z DEBUG bolt_sidecar::builder::fallback::engine_hinter: Fetching hint from engine API iteration=1
2024-12-19T12:04:04.485953Z DEBUG bolt_sidecar::builder::fallback::engine_hinter: Received hint from engine API hint=ReceiptsRoot(0xf78dfb743fbd92ade140711c8bbc542b5e307f0ab7984eff35d751969fe57efa)
2024-12-19T12:04:04.486032Z DEBUG bolt_sidecar::builder::fallback::engine_hinter: Fetching hint from engine API iteration=2
2024-12-19T12:04:04.540129Z DEBUG bolt_sidecar::builder::fallback::engine_hinter: Received hint from engine API hint=StateRoot(0x55c184230284c82489d53907141b055179e44ac734ced8754d43a70e7cdf94c3)
2024-12-19T12:04:04.540187Z DEBUG bolt_sidecar::builder::fallback::engine_hinter: Fetching hint from engine API iteration=3
2024-12-19T12:04:04.587525Z DEBUG bolt_sidecar::builder::fallback::engine_hinter: Received hint from engine API hint=ValidPayload
```

Note that merging this PR won't be enough because we are using a local patch of the client. This will only work after upstreaming our changes into Nethermind and waiting for an official release. Then users will have to use a version >= that of the release.

Here you can find the patch PR: https://github.com/NethermindEth/nethermind/pull/7939

* part of #385 