### PR TITLE
fix(sidecar): discard inclusion requests for past slots

### DIFF
--- a/bolt-sidecar/src/state/consensus.rs
+++ b/bolt-sidecar/src/state/consensus.rs
@@ -114,7 +114,10 @@ impl ConsensusState {
     /// If the request is valid, return the validator public key for the target slot.
     pub fn validate_request(&self, req: &InclusionRequest) -> Result<BlsPublicKey, ConsensusError> {
         // Check if the slot is in the current epoch or next epoch (if unsafe lookahead is enabled)
-        if req.slot < self.epoch.start_slot || req.slot >= self.furthest_slot() {
+        if req.slot < self.epoch.start_slot ||
+            req.slot >= self.furthest_slot() ||
+            req.slot <= self.latest_slot
+        {
             return Err(ConsensusError::InvalidSlot(req.slot));
         }
 


### PR DESCRIPTION
We were not discarding requests for past slots correctly in the consensus state. Error logs:

```
2024-12-20T14:58:20.001706Z  INFO bolt_sidecar::driver: Commitment deadline reached, building local block slot=3233692
2024-12-20T14:58:20.004268Z DEBUG bolt_sidecar::builder::fallback::payload_builder: Fetched execution client info client=Geth
2024-12-20T14:58:20.005687Z DEBUG bolt_sidecar::builder::fallback::engine_hinter: Fetching hint from engine API iteration=0
2024-12-20T14:58:20.009734Z DEBUG bolt_sidecar::builder::fallback::engine_hinter: Received hint from engine API hint=GasUsed(86024)
2024-12-20T14:58:20.009749Z DEBUG bolt_sidecar::builder::fallback::engine_hinter: Fetching hint from engine API iteration=1
2024-12-20T14:58:20.013330Z DEBUG bolt_sidecar::builder::fallback::engine_hinter: Received hint from engine API hint=ReceiptsRoot(0x29ea2f9eccb1f78c0a567e26b02037f21213cdc5a44f98b8a84bea2f7edfc1fd)
2024-12-20T14:58:20.013343Z DEBUG bolt_sidecar::builder::fallback::engine_hinter: Fetching hint from engine API iteration=2
2024-12-20T14:58:20.017059Z DEBUG bolt_sidecar::builder::fallback::engine_hinter: Received hint from engine API hint=StateRoot(0x4afde063cecbddb282411f6710f1c3d7325e4edae22f08dbb74e5bfe7a654fbd)
2024-12-20T14:58:20.017076Z DEBUG bolt_sidecar::builder::fallback::engine_hinter: Fetching hint from engine API iteration=3
2024-12-20T14:58:20.021007Z DEBUG bolt_sidecar::builder::fallback::engine_hinter: Received hint from engine API hint=ValidPayload
2024-12-20T14:58:24.000424Z DEBUG bolt_sidecar::state::consensus: Updating slot to 3233692
2024-12-20T14:58:24.186754Z DEBUG bolt_sidecar::api::builder: Received get_header request
2024-12-20T14:58:24.464791Z DEBUG POST /rpc{method=bolt_requestInclusion}: bolt_sidecar::api::commitments::handlers: Received new request
2024-12-20T14:58:24.464840Z DEBUG POST /rpc{method=bolt_requestInclusion}: bolt_sidecar::api::commitments::handlers: New inclusion request inclusion_request=InclusionRequest { slot: 3233692, txs: [FullTransaction {
 sender: None }], signature: None, signer: None }
2024-12-20T14:58:24.465067Z  INFO POST /rpc{method=bolt_requestInclusion}: bolt_sidecar::api::commitments::handlers: New valid inclusion request received signer=0x0673c1ca2a2bdb4b305c2e150993931992260bcd digest=0xb
45ee70d394a044ee57acd0aec58a6a2d8564d507bea87ebf0bad1be2ae4c8e7
2024-12-20T14:58:24.465114Z  INFO bolt_sidecar::driver: Received new commitment request: Inclusion(InclusionRequest { slot: 3233692, txs: [FullTransaction { sender: None }], signature: Some(PrimitiveSignature { y_p
arity: false, r: 60821522720648703870328698480501512992452861535077733325231170707857045004315, s: 56843433439786798955804534837901819074961974591751504223100471856116304365212 }), signer: Some(0x0673c1ca2a2bdb4b30
5c2e150993931992260bcd) })
2024-12-20T14:58:24.466797Z DEBUG bolt_sidecar::state::execution: Validating basefee slot_diff=1 basefee=7 max_basefee=8
2024-12-20T14:58:24.466815Z TRACE bolt_sidecar::state::execution: found diffs nonce_diff=4 balance_diff=346752000400000 slot=3233692 sender=0x0673c1ca2a2bdb4b305c2e150993931992260bcd
2024-12-20T14:58:24.466822Z DEBUG bolt_sidecar::state::execution: Validating transaction account_state=AccountState { transaction_count: 8513, balance: 9633762104000000000, has_code: false } nonce_diff=4 balance_di
ff=346752000400000
2024-12-20T14:58:24.466831Z  INFO bolt_sidecar::driver: Validation against execution state passed target_slot=3233692 elapsed=1.676328ms
2024-12-20T14:58:24.467582Z DEBUG bolt_sidecar::driver: Commitment signed and sent target_slot=3233692 elapsed=2.426281ms
2024-12-20T14:58:24.506087Z DEBUG bolt_sidecar::api::builder: Returning signed builder bid elapsed=319.331523ms
2024-12-20T14:58:24.998808Z DEBUG bolt_sidecar::api::builder: Received get_payload request
```

The logs display acceptance of a request after said slot has been updated.

Potentially a fix for #602 