### PR TITLE
feat(bolt-sidecar): add config for retry function

### DIFF
--- a/bolt-sidecar/src/chain_io/manager.rs
+++ b/bolt-sidecar/src/chain_io/manager.rs
@@ -259,8 +259,8 @@ mod tests {
                     .as_ref()).expect("valid bls public key")];
         let res = manager.verify_validator_pubkeys(keys.clone(), commitment_signer_pubkey).await;
         assert!(
-            res.unwrap_err().to_string() ==
-                generate_operator_keys_mismatch_error(
+            res.unwrap_err().to_string()
+                == generate_operator_keys_mismatch_error(
                     pubkey_hash(&keys[0]),
                     commitment_signer_pubkey,
                     operator
@@ -308,8 +308,8 @@ mod tests {
         let result = manager.verify_validator_pubkeys(keys.clone(), commitment_signer_pubkey).await;
 
         assert!(
-            result.unwrap_err().to_string() ==
-                generate_operator_keys_mismatch_error(
+            result.unwrap_err().to_string()
+                == generate_operator_keys_mismatch_error(
                     pubkey_hash(&keys[0]),
                     commitment_signer_pubkey,
                     operator

--- a/bolt-sidecar/src/common/backoff.rs
+++ b/bolt-sidecar/src/common/backoff.rs
@@ -5,9 +5,14 @@ use tokio_retry::{
     Retry,
 };
 
+/// Configuration for retry
+#[derive(Debug)]
 pub struct RetryConfig {
+    /// Initial delay in milliseconds before the first retry
     pub initial_delay_ms: u64,
+    /// Maximum delay in seconds between retries
     pub max_delay_secs: u64,
+    /// Multiplication factor for exponential backoff
     pub factor: u64,
 }
 

--- a/bolt-sidecar/src/common/backoff.rs
+++ b/bolt-sidecar/src/common/backoff.rs
@@ -5,14 +5,27 @@ use tokio_retry::{
     Retry,
 };
 
+pub struct RetryConfig {
+    pub initial_delay_ms: u64,
+    pub max_delay_secs: u64,
+    pub factor: u64,
+}
+
 /// Retry a future with exponential backoff and jitter.
-pub async fn retry_with_backoff<F, T, E>(max_retries: usize, fut: impl Fn() -> F) -> Result<T, E>
+pub async fn retry_with_backoff<F, T, E>(
+    max_retries: usize,
+    config: Option<RetryConfig>,
+    fut: impl Fn() -> F,
+) -> Result<T, E>
 where
     F: Future<Output = Result<T, E>>,
 {
-    let backoff = ExponentialBackoff::from_millis(100)
-        .factor(2)
-        .max_delay(Duration::from_secs(1))
+    let config =
+        config.unwrap_or(RetryConfig { initial_delay_ms: 100, max_delay_secs: 1, factor: 2 });
+
+    let backoff = ExponentialBackoff::from_millis(config.initial_delay_ms)
+        .factor(config.factor)
+        .max_delay(Duration::from_secs(config.max_delay_secs))
         .take(max_retries)
         .map(jitter);
 
@@ -21,14 +34,14 @@ where
 
 #[cfg(test)]
 mod tests {
+    use super::*;
+
     use std::sync::Arc;
     use thiserror::Error;
     use tokio::{
         sync::Mutex,
         time::{Duration, Instant},
     };
-
-    use super::*;
 
     #[derive(Debug, Error)]
     #[error("mock error")]
@@ -59,7 +72,7 @@ mod tests {
     async fn test_retry_success_without_retry() {
         let counter = Arc::new(Mutex::new(Counter::new(0)));
 
-        let result = retry_with_backoff(5, || {
+        let result = retry_with_backoff(5, None, || {
             let counter = Arc::clone(&counter);
             async move {
                 let mut counter = counter.lock().await;
@@ -76,7 +89,7 @@ mod tests {
     async fn test_retry_until_success() {
         let counter = Arc::new(Mutex::new(Counter::new(3))); // Fail 3 times, succeed on 4th
 
-        let result = retry_with_backoff(5, || async {
+        let result = retry_with_backoff(5, None, || async {
             let counter = Arc::clone(&counter);
             let mut counter = counter.lock().await;
             counter.retryable_fn().await
@@ -91,7 +104,7 @@ mod tests {
     async fn test_max_retries_reached() {
         let counter = Arc::new(Mutex::new(Counter::new(5))); // Fail 5 times, max retries = 3
 
-        let result = retry_with_backoff(3, || {
+        let result = retry_with_backoff(3, None, || {
             let counter = Arc::clone(&counter);
             async move {
                 let mut counter = counter.lock().await;
@@ -109,7 +122,7 @@ mod tests {
         let counter = Arc::new(Mutex::new(Counter::new(3))); // Fail 3 times, succeed on 4th
         let start_time = Instant::now();
 
-        let result = retry_with_backoff(5, || {
+        let result = retry_with_backoff(5, None, || {
             let counter = Arc::clone(&counter);
             async move {
                 let mut counter = counter.lock().await;

--- a/bolt-sidecar/src/driver.rs
+++ b/bolt-sidecar/src/driver.rs
@@ -415,7 +415,7 @@ impl<C: StateFetcher, ECDSA: SignerECDSA> SidecarDriver<C, ECDSA> {
         let constraints_client = Arc::new(self.constraints_client.clone());
 
         // Submit constraints to the constraints service with an exponential retry mechanism.
-        tokio::spawn(retry_with_backoff(10, move || {
+        tokio::spawn(retry_with_backoff(10, None, move || {
             let constraints_client = Arc::clone(&constraints_client);
             let constraints = Arc::clone(&constraints);
             async move {


### PR DESCRIPTION
Sometimes I think it could be useful to be able to retry instantly instead of waiting 100ms which is currently hardcoded.