### PR TITLE
feat(cli): add command to output a compressed pubkey hash

### DIFF
--- a/bolt-cli/src/cli.rs
+++ b/bolt-cli/src/cli.rs
@@ -44,6 +44,10 @@ pub enum Cmd {
 
     /// Useful data generation commands.
     Generate(GenerateCommand),
+
+    /// Output the pubkey hash of a BLS public key.
+    #[clap(hide = true)]
+    PubkeyHash(PubkeyHashCommand),
 }
 
 impl Cmd {
@@ -56,6 +60,7 @@ impl Cmd {
             Self::Validators(cmd) => cmd.run().await,
             Self::Operators(cmd) => cmd.run().await,
             Self::Generate(cmd) => cmd.run(),
+            Self::PubkeyHash(cmd) => cmd.run(),
         }
     }
 }
@@ -321,6 +326,13 @@ pub struct GenerateCommand {
 pub enum GenerateSubcommand {
     /// Generate a BLS keypair.
     Bls,
+}
+
+#[derive(Debug, Clone, Parser)]
+pub struct PubkeyHashCommand {
+    /// The BLS public key to hash.
+    #[clap(value_parser, env = "KEY")]
+    pub key: String,
 }
 
 /// The action to perform.

--- a/bolt-cli/src/commands/mod.rs
+++ b/bolt-cli/src/commands/mod.rs
@@ -18,3 +18,7 @@ pub mod operators;
 
 /// Module for generating various types of data like BLS keys.
 pub mod generate;
+
+/// Module for the `pubkey_hash` command to generate
+/// a pubkey hash from a public key.
+pub mod pubkey_hash;

--- a/bolt-cli/src/commands/pubkey_hash.rs
+++ b/bolt-cli/src/commands/pubkey_hash.rs
@@ -1,0 +1,15 @@
+use crate::{
+    cli::PubkeyHashCommand,
+    common::{hash::compress_bls_pubkey, parse_bls_public_key},
+};
+
+impl PubkeyHashCommand {
+    pub fn run(&self) -> eyre::Result<()> {
+        let parsed = parse_bls_public_key(&self.key)?;
+        let hash = compress_bls_pubkey(&parsed);
+
+        println!("{}", alloy::hex::encode_prefixed(hash));
+
+        Ok(())
+    }
+}


### PR DESCRIPTION
This PR adds a "pubkey-hash" command to the bolt CLI, which can be useful for debugging purposes. 
It simply requires a pubkey as argument. Here is an example:

```sh
bolt pubkey-hash 0x90b7beb2568094bec116f264b63d259c9205e5a969e11316ec57b57ef827c206504730ddbfccf7731a802cb99401446a

0x43068754c6062ac20e198e99f87d492973592ccd
```

this command is hidden from clap so it's not shown to users in the help menu. 