### PR TITLE
feat(bolt-sidecar): add version to metadata endpoint

### DIFF
--- a/bolt-sidecar/src/api/commitments/server/mod.rs
+++ b/bolt-sidecar/src/api/commitments/server/mod.rs
@@ -177,10 +177,7 @@ fn make_router(state: Arc<CommitmentsApiInner>) -> Router {
 
 #[cfg(test)]
 mod test {
-    use crate::{
-        api::commitments::{jsonrpc::JsonResponse, spec::SIGNATURE_HEADER},
-        common::BOLT_SIDECAR_VERSION,
-    };
+    use crate::{api::commitments::spec::SIGNATURE_HEADER, common::BOLT_SIDECAR_VERSION};
     use alloy::signers::{k256::SecretKey, local::PrivateKeySigner};
     use handlers::MetadataResponse;
     use serde_json::json;

--- a/bolt-sidecar/src/api/commitments/server/mod.rs
+++ b/bolt-sidecar/src/api/commitments/server/mod.rs
@@ -177,8 +177,12 @@ fn make_router(state: Arc<CommitmentsApiInner>) -> Router {
 
 #[cfg(test)]
 mod test {
-    use crate::api::commitments::spec::SIGNATURE_HEADER;
+    use crate::{
+        api::commitments::{jsonrpc::JsonResponse, spec::SIGNATURE_HEADER},
+        common::BOLT_SIDECAR_VERSION,
+    };
     use alloy::signers::{k256::SecretKey, local::PrivateKeySigner};
+    use handlers::MetadataResponse;
     use serde_json::json;
 
     use crate::{
@@ -293,12 +297,11 @@ mod test {
     #[tokio::test]
     async fn test_request_metadata() {
         let _ = tracing_subscriber::fmt::try_init();
-
         let mut server = CommitmentsApiServer::new("0.0.0.0:0");
-
         let (events_tx, _) = mpsc::channel(1);
 
-        server.run(events_tx, LimitsOpts::default()).await;
+        let expected_limits = LimitsOpts::default();
+        server.run(events_tx, expected_limits).await;
         let addr = server.local_addr();
 
         let payload = json!({
@@ -309,9 +312,7 @@ mod test {
         });
 
         let url = format!("http://{addr}");
-
         let client = reqwest::Client::new();
-
         let response = client
             .post(url)
             .json(&payload)
@@ -322,8 +323,12 @@ mod test {
             .await
             .unwrap();
 
-        let limits: LimitsOpts = serde_json::from_value(response.result).unwrap();
+        let metadata: MetadataResponse = serde_json::from_value(response.result).unwrap();
 
-        assert_eq!(limits, LimitsOpts::default());
+        assert_eq!(metadata.max_commitments_per_slot, expected_limits.max_commitments_per_slot);
+        assert_eq!(metadata.max_committed_gas_per_slot, expected_limits.max_committed_gas_per_slot);
+        assert_eq!(metadata.min_priority_fee, expected_limits.min_priority_fee);
+        assert_eq!(metadata.max_account_states_size, expected_limits.max_account_states_size);
+        assert_eq!(metadata.version, BOLT_SIDECAR_VERSION.to_string());
     }
 }

--- a/bolt-sidecar/src/api/commitments/server/mod.rs
+++ b/bolt-sidecar/src/api/commitments/server/mod.rs
@@ -325,10 +325,19 @@ mod test {
 
         let metadata: MetadataResponse = serde_json::from_value(response.result).unwrap();
 
-        assert_eq!(metadata.max_commitments_per_slot, expected_limits.max_commitments_per_slot);
-        assert_eq!(metadata.max_committed_gas_per_slot, expected_limits.max_committed_gas_per_slot);
-        assert_eq!(metadata.min_priority_fee, expected_limits.min_priority_fee);
-        assert_eq!(metadata.max_account_states_size, expected_limits.max_account_states_size);
+        assert_eq!(
+            metadata.limits.max_commitments_per_slot,
+            expected_limits.max_commitments_per_slot
+        );
+        assert_eq!(
+            metadata.limits.max_committed_gas_per_slot,
+            expected_limits.max_committed_gas_per_slot
+        );
+        assert_eq!(metadata.limits.min_inclusion_profit, expected_limits.min_inclusion_profit);
+        assert_eq!(
+            metadata.limits.max_account_states_size,
+            expected_limits.max_account_states_size
+        );
         assert_eq!(metadata.version, BOLT_SIDECAR_VERSION.to_string());
     }
 }


### PR DESCRIPTION
For each lookahead window the Firewall will query proposers to get their version and profit expectation.
Currently `bolt_getVersion` is queried, but we wanna consolidate so only one API call is needed to get all the metadata info.

Explicitly check each field in test to catch regression. Current assert will not catch changes to `LimitsOpts` since we compare with default.

Discovered that https://github.com/chainbound/bolt/pull/599 broke `bolt_metadata` but I'm not goint to revert and bump the API since it's not in use yet.

Next PR will add profit to the `bolt_metadata` endpoint.