### PR TITLE
fix(bolt-sidecar): correctly get preconf gas limit from env

### DIFF
--- a/bolt-sidecar/src/config/chain.rs
+++ b/bolt-sidecar/src/config/chain.rs
@@ -20,9 +20,6 @@ pub const DEFAULT_COMMITMENT_DEADLINE_IN_MILLIS: u64 = 8_000;
 /// Default slot time duration in seconds.
 pub const DEFAULT_SLOT_TIME_IN_SECONDS: u64 = 12;
 
-/// Default gas limit for the sidecar.
-pub const DEFAULT_GAS_LIMIT: u64 = 30_000_000;
-
 /// The domain mask for signing application-builder messages.
 pub const APPLICATION_BUILDER_DOMAIN_MASK: [u8; 4] = [0, 0, 0, 1];
 
@@ -34,7 +31,6 @@ pub const DEFAULT_CHAIN_CONFIG: ChainConfig = ChainConfig {
     chain: Chain::Mainnet,
     commitment_deadline: DEFAULT_COMMITMENT_DEADLINE_IN_MILLIS,
     slot_time: DEFAULT_SLOT_TIME_IN_SECONDS,
-    gas_limit: DEFAULT_GAS_LIMIT,
     enable_unsafe_lookahead: false,
 };
 
@@ -65,15 +61,6 @@ pub struct ChainConfig {
         default_value_t = DEFAULT_CHAIN_CONFIG.slot_time,
     )]
     pub(crate) slot_time: u64,
-    /// The gas limit for the sidecar.
-    /// This is the maximum amount of gas that can be used for a single transaction.
-    /// If provided, it overrides the default for the selected [Chain].
-    #[clap(
-        long,
-        env = "BOLT_SIDECAR_GAS_LIMIT",
-        default_value_t = DEFAULT_CHAIN_CONFIG.gas_limit
-    )]
-    pub(crate) gas_limit: u64,
     /// Toggle to enable unsafe lookahead for the sidecar. If `true`, commitments requests will be
     /// validated against a two-epoch lookahead window.
     #[clap(
@@ -159,11 +146,6 @@ impl ChainConfig {
     /// Get the slot time for the given chain in seconds.
     pub fn slot_time(&self) -> u64 {
         self.slot_time
-    }
-
-    /// Get the gas limit for the given chain.
-    pub fn gas_limit(&self) -> u64 {
-        self.gas_limit
     }
 
     /// Get the domain for signing application-builder messages on the given chain.

--- a/bolt-sidecar/src/driver.rs
+++ b/bolt-sidecar/src/driver.rs
@@ -200,7 +200,7 @@ impl<C: StateFetcher, ECDSA: SignerECDSA> SidecarDriver<C, ECDSA> {
         }
 
         let beacon_client = BeaconClient::new(opts.beacon_api_url.clone());
-        let execution = ExecutionState::new(fetcher, opts.limits, opts.chain.gas_limit).await?;
+        let execution = ExecutionState::new(fetcher, opts.limits).await?;
 
         let genesis_time = beacon_client.get_genesis_details().await?.genesis_time;
         let slot_stream =

--- a/bolt-sidecar/src/state/execution.rs
+++ b/bolt-sidecar/src/state/execution.rs
@@ -179,6 +179,7 @@ pub struct ExecutionState<C> {
 /// Other values used for validation.
 #[derive(Debug)]
 pub struct ValidationParams {
+    // The maximum amount of gas reserved to preconfirmations for blocks.
     pub preconf_gas_limit: u64,
     pub max_tx_input_bytes: usize,
     pub max_init_code_byte_size: usize,

--- a/bolt-sidecar/src/state/execution.rs
+++ b/bolt-sidecar/src/state/execution.rs
@@ -230,7 +230,7 @@ impl<C: StateFetcher> ExecutionState<C> {
             kzg_settings: EnvKzgSettings::default(),
             // TODO: add a way to configure these values from CLI
             validation_params: ValidationParams::new(gas_limit),
-            pricing: InclusionPricer::new(gas_limit),
+            pricing: InclusionPricer::new(limits.max_committed_gas_per_slot.get()),
         })
     }
 

--- a/bolt-sidecar/src/state/execution.rs
+++ b/bolt-sidecar/src/state/execution.rs
@@ -179,7 +179,7 @@ pub struct ExecutionState<C> {
 /// Other values used for validation.
 #[derive(Debug)]
 pub struct ValidationParams {
-    pub block_gas_limit: u64,
+    pub preconf_gas_limit: u64,
     pub max_tx_input_bytes: usize,
     pub max_init_code_byte_size: usize,
 }
@@ -187,7 +187,7 @@ pub struct ValidationParams {
 impl ValidationParams {
     pub fn new(gas_limit: u64) -> Self {
         Self {
-            block_gas_limit: gas_limit,
+            preconf_gas_limit: gas_limit,
             max_tx_input_bytes: 4 * 32 * 1024,
             max_init_code_byte_size: 2 * 24576,
         }
@@ -282,8 +282,8 @@ impl<C: StateFetcher> ExecutionState<C> {
             return Err(ValidationError::TransactionSizeTooHigh);
         }
 
-        // Check if the gas limit is higher than the preconf block gas limit
-        if req.gas_limit() > self.validation_params.block_gas_limit {
+        // Check if the gas limit is higher than the preconf gas limit
+        if req.gas_limit() > self.validation_params.preconf_gas_limit {
             return Err(ValidationError::GasLimitTooHigh);
         }
 


### PR DESCRIPTION
Currently we get `BOLT_SIDECAR_GAS_LIMIT` which is the gas limit for a single tx. It defaults to `DEFAULT_GAS_LIMIT` which is 30M. That means pricing input validation will not fail when trying to use more gas than what's left for preconfs in a block. Other valdiation might reject this earlier, but I'd like it to be rejected here as well.

I think it's confusing to have to ENV vars that do the same, so removed `BOLT_SIDECAR_GAS_LIMIT` and replace it with `BOLT_SIDECAR_MAX_COMMITTED_GAS`