### PR TITLE
Tests run on public testnet for quicker CI/CD

### DIFF
--- a/bolt-sidecar/src/chain_io/manager.rs
+++ b/bolt-sidecar/src/chain_io/manager.rs
@@ -223,6 +223,7 @@ mod tests {
     use ethereum_consensus::primitives::BlsPublicKey;
     use reqwest::Url;
     use std::time::Duration;
+    use tracing::{info, warn};
 
     use crate::{
         chain_io::{manager::generate_operator_keys_mismatch_error, utils::pubkey_hash},
@@ -236,12 +237,12 @@ mod tests {
     async fn test_verify_validator_pubkeys() -> eyre::Result<()> {
         let _ = tracing_subscriber::fmt::try_init();
         let Some(url) = try_get_execution_api_url().await else {
-            tracing::warn!("skipping test: execution API URL is not reachable");
+            warn!("skipping test: execution API URL is not reachable");
             return Ok(());
         };
 
-        let manager =
-            BoltManager::from_chain(Url::parse(url).unwrap(), Chain::Holesky).expect("manager deployed on Holesky");
+        let manager = BoltManager::from_chain(Url::parse(url).unwrap(), Chain::Holesky)
+            .expect("manager deployed on Holesky");
 
         let operator =
             Address::from_hex("725028b0b7c3db8b8242d35cd3a5779838b217b1").expect("valid address");
@@ -279,12 +280,13 @@ mod tests {
     #[tokio::test]
     async fn test_verify_validator_pubkeys_retry() -> eyre::Result<()> {
         let Some(url) = try_get_execution_api_url().await else {
-            tracing::warn!("skipping test: execution API URL is not reachable");
+            warn!("skipping test: execution API URL is not reachable");
             return Ok(());
         };
 
         // Point to an EL node that is not yet online
-        let unresponsive_url = Url::parse("http://localhost:10000").expect("valid execution API URL");
+        let unresponsive_url =
+            Url::parse("http://localhost:10000").expect("valid execution API URL");
 
         let manager = BoltManager::from_chain(unresponsive_url, Chain::Holesky)
             .expect("manager deployed on Holesky");
@@ -299,7 +301,7 @@ mod tests {
             // Sleep for a bit so verify_validator_pubkeys is called before the anvil is up
             tokio::time::sleep(Duration::from_millis(100)).await;
             let anvil = Anvil::new().fork(Url::parse(url).unwrap()).port(10000u16).spawn();
-            tracing::info!("anvil node: {}", anvil.endpoint());
+            info!("anvil node: {}", anvil.endpoint());
             tokio::time::sleep(Duration::from_secs(10)).await;
         });
 

--- a/bolt-sidecar/src/chain_io/manager.rs
+++ b/bolt-sidecar/src/chain_io/manager.rs
@@ -227,7 +227,7 @@ mod tests {
     use crate::{
         chain_io::{manager::generate_operator_keys_mismatch_error, utils::pubkey_hash},
         config::chain::Chain,
-        test_util::{get_test_config, try_get_execution_api_url},
+        test_util::try_get_execution_api_url,
     };
 
     use super::BoltManager;

--- a/bolt-sidecar/src/client/beacon.rs
+++ b/bolt-sidecar/src/client/beacon.rs
@@ -124,12 +124,13 @@ impl Debug for BeaconClient {
 mod tests {
     use super::*;
     use crate::test_util::try_get_beacon_api_url;
+    use tracing::warn;
 
     #[tokio::test]
     async fn test_get_prev_randao() -> eyre::Result<()> {
         let _ = tracing_subscriber::fmt::try_init();
         let Some(url) = try_get_beacon_api_url().await else {
-            tracing::warn!("skipping test: beacon API URL is not reachable");
+            warn!("skipping test: beacon API URL is not reachable");
             return Ok(());
         };
 
@@ -143,7 +144,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_expected_withdrawals_at_head() -> eyre::Result<()> {
         let Some(url) = try_get_beacon_api_url().await else {
-            tracing::warn!("skipping test: beacon API URL is not reachable");
+            warn!("skipping test: beacon API URL is not reachable");
             return Ok(());
         };
 
@@ -157,7 +158,7 @@ mod tests {
     #[tokio::test]
     async fn test_get_parent_beacon_block_root() -> eyre::Result<()> {
         let Some(url) = try_get_beacon_api_url().await else {
-            tracing::warn!("skipping test: beacon API URL is not reachable");
+            warn!("skipping test: beacon API URL is not reachable");
             return Ok(());
         };
 

--- a/bolt-sidecar/src/client/beacon.rs
+++ b/bolt-sidecar/src/client/beacon.rs
@@ -123,47 +123,48 @@ impl Debug for BeaconClient {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use std::str::FromStr;
+    use crate::test_util::try_get_beacon_api_url;
 
     #[tokio::test]
-    async fn test_get_prev_randao() {
-        let url = Url::from_str("http://remotebeast:44400").unwrap();
+    async fn test_get_prev_randao() -> eyre::Result<()> {
+        let _ = tracing_subscriber::fmt::try_init();
+        let Some(url) = try_get_beacon_api_url().await else {
+            tracing::warn!("skipping test: beacon API URL is not reachable");
+            return Ok(());
+        };
 
-        if reqwest::get(url.clone()).await.is_err_and(|err| err.is_timeout() || err.is_connect()) {
-            eprintln!("Skipping test because remotebeast is not reachable");
-            return;
-        }
-
-        let beacon_api = BeaconClient::new(url);
+        let beacon_api = BeaconClient::new(Url::parse(url).unwrap());
 
         assert!(beacon_api.get_prev_randao().await.is_ok());
+
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_get_expected_withdrawals_at_head() {
-        let url = Url::from_str("http://remotebeast:44400").unwrap();
+    async fn test_get_expected_withdrawals_at_head() -> eyre::Result<()> {
+        let Some(url) = try_get_beacon_api_url().await else {
+            tracing::warn!("skipping test: beacon API URL is not reachable");
+            return Ok(());
+        };
 
-        if reqwest::get(url.clone()).await.is_err_and(|err| err.is_timeout() || err.is_connect()) {
-            eprintln!("Skipping test because remotebeast is not reachable");
-            return;
-        }
-
-        let beacon_api = BeaconClient::new(url);
+        let beacon_api = BeaconClient::new(Url::parse(url).unwrap());
 
         assert!(beacon_api.get_expected_withdrawals_at_head().await.is_ok());
+
+        Ok(())
     }
 
     #[tokio::test]
-    async fn test_get_parent_beacon_block_root() {
-        let url = Url::from_str("http://remotebeast:44400").unwrap();
+    async fn test_get_parent_beacon_block_root() -> eyre::Result<()> {
+        let Some(url) = try_get_beacon_api_url().await else {
+            tracing::warn!("skipping test: beacon API URL is not reachable");
+            return Ok(());
+        };
 
-        if reqwest::get(url.clone()).await.is_err_and(|err| err.is_timeout() || err.is_connect()) {
-            eprintln!("Skipping test because remotebeast is not reachable");
-            return;
-        }
-
-        let beacon_api = BeaconClient::new(url);
+        let beacon_api = BeaconClient::new(Url::parse(url).unwrap());
 
         assert!(beacon_api.get_parent_beacon_block_root().await.is_ok());
+
+        Ok(())
     }
 }

--- a/bolt-sidecar/src/primitives/commitment.rs
+++ b/bolt-sidecar/src/primitives/commitment.rs
@@ -192,8 +192,8 @@ impl InclusionRequest {
         for tx in &self.txs {
             // Calculate minimum required priority fee for this transaction
             let min_priority_fee = pricing
-                .calculate_min_priority_fee(tx.gas_limit(), preconfirmed_gas)?
-                + min_inclusion_profit;
+                .calculate_min_priority_fee(tx.gas_limit(), preconfirmed_gas)? +
+                min_inclusion_profit;
 
             let tip = tx.effective_tip_per_gas(max_base_fee).unwrap_or_default();
             if tip < min_priority_fee as u128 {

--- a/bolt-sidecar/src/state/execution.rs
+++ b/bolt-sidecar/src/state/execution.rs
@@ -8,7 +8,6 @@ use std::collections::HashMap;
 use thiserror::Error;
 use tracing::{debug, error, trace, warn};
 
-use crate::state::pricing;
 use crate::{
     builder::BlockTemplate,
     common::{
@@ -19,11 +18,11 @@ use crate::{
     primitives::{
         signature::SignatureError, AccountState, InclusionRequest, SignedConstraints, Slot,
     },
+    state::pricing,
     telemetry::ApiMetrics,
 };
 
-use super::InclusionPricer;
-use super::{account_state::AccountStateCache, fetcher::StateFetcher};
+use super::{account_state::AccountStateCache, fetcher::StateFetcher, InclusionPricer};
 
 /// Possible commitment validation errors.
 ///
@@ -310,7 +309,8 @@ impl<C: StateFetcher> ExecutionState<C> {
             return Err(ValidationError::BaseFeeTooLow(max_basefee));
         }
 
-        // Ensure max_priority_fee_per_gas is greater than or equal to the calculated min_priority_fee
+        // Ensure max_priority_fee_per_gas is greater than or equal to the calculated
+        // min_priority_fee
         if !req.validate_min_priority_fee(
             &self.pricing,
             template_committed_gas,

--- a/bolt-sidecar/src/state/pricing.rs
+++ b/bolt-sidecar/src/state/pricing.rs
@@ -67,7 +67,6 @@ impl InclusionPricer {
     /// important reason is that we omit large outlier transactions to improve average
     /// fit, which disproportionately affects the most valuable transactions.
     /// """
-    ///
     pub fn calculate_min_priority_fee(
         &self,
         incoming_gas: u64,
@@ -84,8 +83,8 @@ impl InclusionPricer {
         let after_gas = remaining_gas - incoming_gas;
 
         // Calculate numerator and denominator for the logarithm
-        let fraction = (self.gas_scalar * (remaining_gas as f64) + 1.0)
-            / (self.gas_scalar * (after_gas as f64) + 1.0);
+        let fraction = (self.gas_scalar * (remaining_gas as f64) + 1.0) /
+            (self.gas_scalar * (after_gas as f64) + 1.0);
 
         // Calculate block space value in Ether
         let block_space_value = self.base_multiplier * fraction.ln();

--- a/bolt-sidecar/src/test_util.rs
+++ b/bolt-sidecar/src/test_util.rs
@@ -31,14 +31,10 @@ use crate::{
 };
 
 /// The URL of the test execution client HTTP API.
-///
-/// NOTE: this DNS is only available through the Chainbound Tailnet
-const EXECUTION_API_URL: &str = "http://remotebeast:48545";
+const EXECUTION_API_URL: &str = "https://ethereum-holesky-rpc.publicnode.com";
 
 /// The URL of the test beacon client HTTP API.
-///
-/// NOTE: this DNS is only available through the Chainbound Tailnet
-const BEACON_API_URL: &str = "http://remotebeast:44400";
+const BEACON_API_URL: &str = "https://ethereum-holesky-beacon-api.publicnode.com";
 
 /// The URL of the test engine client HTTP API.
 ///

--- a/bolt-sidecar/src/test_util.rs
+++ b/bolt-sidecar/src/test_util.rs
@@ -31,10 +31,10 @@ use crate::{
 };
 
 /// The URL of the test execution client HTTP API.
-const EXECUTION_API_URL: &str = "https://ethereum-holesky-rpc.publicnode.com";
+const EXECUTION_API_URL: &str = "https://geth-holesky.bolt.chainbound.io";
 
 /// The URL of the test beacon client HTTP API.
-const BEACON_API_URL: &str = "https://ethereum-holesky-beacon-api.publicnode.com";
+const BEACON_API_URL: &str = "https://lighthouse-holesky.bolt.chainbound.io";
 
 /// The URL of the test engine client HTTP API.
 ///
@@ -94,13 +94,13 @@ pub(crate) async fn get_test_config() -> Option<Opts> {
     };
 
     if let Some(url) = try_get_execution_api_url().await {
-        opts.execution_api_url = url.parse().expect("valid URL");
+        opts.execution_api_url = url.parse().expect("valid execution API URL");
     }
     if let Some(url) = try_get_beacon_api_url().await {
-        opts.beacon_api_url = url.parse().expect("valid URL");
+        opts.beacon_api_url = url.parse().expect("valid beacon API URL");
     }
     if let Some(url) = try_get_engine_api_url().await {
-        opts.engine_api_url = url.parse().expect("valid URL");
+        opts.engine_api_url = url.parse().expect("valid engine API URL");
     }
     opts.engine_jwt_hex = JwtSecretConfig::from(jwt.as_str());
 


### PR DESCRIPTION
Bolt uses custom DNS (http://remotebeast:48545) which limits external contributors from running tests (`just test`) without having to go through setting up EL, CL, Constraints API, e.t.c.

### Improvements:
- Added Holesky testnets for EL, CL APIs (engine API open for discussion).
- Reused API functions in test_utils like `try_get_execution_api_url()`.
- Changed a few `println` for proper logging.

For more information, please refer to this [issue](https://github.com/chainbound/bolt/issues/581).
Closes #581