### PR TITLE
fix(sidecar): ping messages were not sent

### DIFF
--- a/bolt-sidecar/src/api/commitments/firewall/receiver.rs
+++ b/bolt-sidecar/src/api/commitments/firewall/receiver.rs
@@ -25,10 +25,6 @@ use super::{
     processor::{CommitmentRequestProcessor, InterruptReason, ProcessorState},
 };
 
-/// The maximum number of retries to attempt when reconnecting to a websocket server.
-/// Try indefinitely.
-const MAX_RETRIES: usize = usize::MAX;
-
 /// The maximum messages size to receive via websocket connection, in bits, set to 32MiB.
 ///
 /// It is enough to account for a commitment request with 6 blobs and the largest
@@ -124,7 +120,7 @@ impl CommitmentsReceiver {
 
             tokio::spawn(async move {
                 retry_with_backoff_if(
-                    MAX_RETRIES,
+                    None,
                     Some(retry_config),
                     // NOTE: this needs to be a closure because it must be re-called upon failure.
                     // As such we also need to clone the inputs again.

--- a/bolt-sidecar/src/driver.rs
+++ b/bolt-sidecar/src/driver.rs
@@ -430,7 +430,7 @@ impl<C: StateFetcher, ECDSA: SignerECDSA> SidecarDriver<C, ECDSA> {
         let constraints_client = Arc::new(self.constraints_client.clone());
 
         // Submit constraints to the constraints service with an exponential retry mechanism.
-        tokio::spawn(retry_with_backoff(10, None, move || {
+        tokio::spawn(retry_with_backoff(Some(10), None, move || {
             let constraints_client = Arc::clone(&constraints_client);
             let constraints = Arc::clone(&constraints);
             async move {


### PR DESCRIPTION
This PR fixes the ping of the `CommitmentRequestProcessor`. In essence, pings were sent only if other events woke up the task because the receiver is not using the asynchronous context.
Moreover, a broadcast receiver doesn't track individual tasks or their wakers. As such, I've opted to completely remove the `PingTicker` and use an interval instead spawned per task, that once ticked sends ping messages.