### PR TITLE
chore(sidecar, holesky): update example environment variables files

### DIFF
--- a/bolt-sidecar/.env.example
+++ b/bolt-sidecar/.env.example
@@ -2,7 +2,15 @@
 
 # Port to listen on for incoming JSON-RPC requests of the Commitments API. This
 # port should be open on your firewall in order to receive external requests!
-BOLT_SIDECAR_PORT=8017
+BOLT_SIDECAR_PORT=
+# Comma-separated list of allowed RPC addresses to subscribe via websocket to receive
+# incoming commitments requests.
+# This is incompatible with the `BOLT_SIDECAR_RPC_URL` option.
+BOLT_SIDECAR_FIREWALL_RPCS="wss://rpc-holesky.bolt.chainbound.io/api/v1/firewall_stream"
+# Secret ECDSA key to sign commitment messages with. The public key associated
+# to it must be then used when registering the operator in bolt
+# contracts
+BOLT_SIDECAR_OPERATOR_PRIVATE_KEY=
 # Execution client API URL
 BOLT_SIDECAR_EXECUTION_API_URL="http://localhost:8545"
 # URL for the beacon client
@@ -21,10 +29,6 @@ BOLT_SIDECAR_CONSTRAINTS_API_URL="http://localhost:18551"
 BOLT_SIDECAR_ENGINE_JWT_HEX=
 # The fee recipient address for fallback blocks
 BOLT_SIDECAR_FEE_RECIPIENT=
-# Secret ECDSA key to sign commitment messages with. The public key associated
-# to it must be then used when registering the operator in the `BoltManager`
-# contract
-BOLT_SIDECAR_COMMITMENT_PRIVATE_KEY=
 # Secret BLS key to sign fallback payloads with
 BOLT_SIDECAR_BUILDER_PRIVATE_KEY=
 

--- a/bolt-sidecar/src/config/commitments.rs
+++ b/bolt-sidecar/src/config/commitments.rs
@@ -16,7 +16,7 @@ pub struct CommitmentOpts {
     /// This port should be open on your firewall in order to receive external requests!
     #[clap(long, env = "BOLT_SIDECAR_PORT")]
     pub port: Option<u16>,
-    /// Comma-separated list of allowed RPC addresses to subscribe via websocket to receive
+    /// Comma-separated list of allowed RPC URLs to subscribe via websocket to receive
     /// incoming commitments requests.
     #[clap(
         long,

--- a/testnets/holesky/bolt-sidecar.env.example
+++ b/testnets/holesky/bolt-sidecar.env.example
@@ -1,8 +1,12 @@
 # Ethereum Node Connections + PBS URLs
 
-# Port to listen on for incoming JSON-RPC requests of the Commitments API. This
-# port should be open on your firewall in order to receive external requests!
-BOLT_SIDECAR_PORT=8017
+# Comma-separated list of allowed RPC addresses to subscribe via websocket to receive
+# incoming commitments requests.
+# This is incompatible with the `BOLT_SIDECAR_RPC_URL` option.
+BOLT_SIDECAR_FIREWALL_RPCS="wss://rpc-holesky.bolt.chainbound.io/api/v1/firewall_stream"
+# Secret ECDSA key to sign commitment messages with. The public key associated
+# to it must be then used when registering the operator in bolt contracts
+BOLT_SIDECAR_OPERATOR_PRIVATE_KEY=
 # Execution client API URL
 BOLT_SIDECAR_EXECUTION_API_URL="http://host.docker.internal:8545"
 # URL for the beacon client
@@ -21,10 +25,6 @@ BOLT_SIDECAR_CONSTRAINTS_API_URL="http://bolt-mev-boost-holesky:18551"
 BOLT_SIDECAR_ENGINE_JWT_HEX=
 # The fee recipient address for fallback blocks
 BOLT_SIDECAR_FEE_RECIPIENT=
-# Secret ECDSA key to sign commitment messages with. The public key associated
-# to it must be then used when registering the operator in the `BoltManager`
-# contract
-BOLT_SIDECAR_COMMITMENT_PRIVATE_KEY=
 # Secret BLS key to sign fallback payloads with
 BOLT_SIDECAR_BUILDER_PRIVATE_KEY=
 


### PR DESCRIPTION
Updates such files with the firewall delegation options and removes the stale `BOLT_SIDECAR_COMMITMENT_PRIVATE_KEY`