### PR TITLE
fix(holesky): Align CB config and env files

### DIFF
--- a/bolt-sidecar/.env.example
+++ b/bolt-sidecar/.env.example
@@ -1,57 +1,71 @@
-# Ethereum Node Connections + PBS URLs
+# --- Ethereum Node Connections + PBS URLs ---
 
 # Port to listen on for incoming JSON-RPC requests of the Commitments API. This
 # port should be open on your firewall in order to receive external requests!
+# If you are using the BOLT_SIDECAR_FIREWALL_RPCS option, this variable MUST remain empty.
 BOLT_SIDECAR_PORT=
+
 # Comma-separated list of allowed RPC addresses to subscribe via websocket to receive
 # incoming commitments requests.
-# This is incompatible with the `BOLT_SIDECAR_RPC_URL` option.
+# This is incompatible with the `BOLT_SIDECAR_PORT` option.
 BOLT_SIDECAR_FIREWALL_RPCS="wss://rpc-holesky.bolt.chainbound.io/api/v1/firewall_stream"
+
 # Secret ECDSA key to sign commitment messages with. The public key associated
 # to it must be then used when registering the operator in bolt
 # contracts
 BOLT_SIDECAR_OPERATOR_PRIVATE_KEY=
+
 # Execution client API URL
 BOLT_SIDECAR_EXECUTION_API_URL="http://localhost:8545"
+
 # URL for the beacon client
 BOLT_SIDECAR_BEACON_API_URL="http://localhost:5052"
+
 # Execution client Engine API URL. This is needed for fallback block building
 # and must be a synced Geth node
 BOLT_SIDECAR_ENGINE_API_URL="http://localhost:8551"
+
 # The port from which the Bolt sidecar will receive Builder-API requests from the Beacon client
 BOLT_SIDECAR_CONSTRAINTS_PROXY_PORT=18550
+
 # URL to forward the constraints produced by the Bolt sidecar to a server
 # supporting the Constraints API, such as an MEV-Boost fork
 BOLT_SIDECAR_CONSTRAINTS_API_URL="http://localhost:18551"
+
 # The JWT secret token to authenticate calls to the engine API. It can be
 # either be a hex-encoded string or a file path to a file containing the
 # hex-encoded secret.
 BOLT_SIDECAR_ENGINE_JWT_HEX=
+
 # The fee recipient address for fallback blocks
 BOLT_SIDECAR_FEE_RECIPIENT=
+
 # Secret BLS key to sign fallback payloads with
 BOLT_SIDECAR_BUILDER_PRIVATE_KEY=
 
-# Commitments limits
+# --- Commitments limits ---
+
 # Max committed gas per slot
 BOLT_SIDECAR_MAX_COMMITTED_GAS_PER_SLOT=10_000_000
+
 # Min profit per gas to accept a commitment
 BOLT_SIDECAR_MIN_PROFIT=2000000000 # 2 Gwei = 2 * 10^9 wei
 
-# Chain configuration
+# --- Chain configuration ---
+
 # Chain on which the sidecar is running
 BOLT_SIDECAR_CHAIN="holesky"
-# The slot time duration in seconds. If provided, it overrides the default for
-# the selected [chain]
-BOLT_SIDECAR_SLOT_TIME=12
+
 # The deadline in the slot at which the sidecar will stop accepting new
 # commitments for the next block (parsed as milliseconds)
 BOLT_SIDECAR_COMMITMENT_DEADLINE=8000
+
 # Toggle to enable unsafe lookahead for the sidecar. If `true`, commitments requests will be
 # validated against a two-epoch lookahead window.
 BOLT_SIDECAR_ENABLE_UNSAFE_LOOKAHEAD=false
 
-# Signing options.
+# --- Signing options ---
+
 BOLT_SIDECAR_CONSTRAINT_PRIVATE_KEY=
 BOLT_SIDECAR_CB_SIGNER_URL=
 BOLT_SIDECAR_CB_JWT_HEX=
@@ -60,6 +74,7 @@ BOLT_SIDECAR_KEYSTORE_SECRETS_PATH=
 BOLT_SIDECAR_KEYSTORE_PATH=
 BOLT_SIDECAR_DELEGATIONS_PATH=
 
-# Telemetry and Metrics
+# --- Telemetry and Metrics options ---
+
 BOLT_SIDECAR_METRICS_PORT=9091
 BOLT_SIDECAR_DISABLE_METRICS=false

--- a/testnets/holesky/commit-boost/bolt-sidecar.env.example
+++ b/testnets/holesky/commit-boost/bolt-sidecar.env.example
@@ -1,6 +1,17 @@
 # Port to listen on for incoming JSON-RPC requests of the Commitments API.
 # (This is where users will send preconfirmation requests to)
-BOLT_SIDECAR_PORT=8017
+# If you are using the Firewall RPCs option, this variable MUST remain empty.
+BOLT_SIDECAR_PORT=
+
+# Comma-separated list of allowed RPC addresses to subscribe via websocket to receive
+# incoming commitments requests.
+# This is incompatible with the `BOLT_SIDECAR_RPC_URL` option.
+BOLT_SIDECAR_FIREWALL_RPCS="wss://rpc-holesky.bolt.chainbound.io/api/v1/firewall_stream"
+
+# Secret ECDSA key to sign commitment messages with. The ETH address derived from the public key 
+# associated to it must be then used when registering the operator in the bolt contracts.
+# SET THIS 👇
+BOLT_SIDECAR_OPERATOR_PRIVATE_KEY=
 
 # Execution client API URL
 # CHANGE THIS ACCORDING TO YOUR NODE SETUP 👇
@@ -15,12 +26,6 @@ BOLT_SIDECAR_BEACON_API_URL="http://127.0.0.1:5052"
 # CHANGE THIS ACCORDING TO YOUR NODE SETUP 👇
 BOLT_SIDECAR_ENGINE_API_URL="http://127.0.0.1:8551"
 
-# Execution client Engine Secret.
-# This is the secret token token to authenticate calls to the engine API. It can be
-# either be a hex-encoded string or a file path to a file containing the secret.
-# SET THIS ACCORDING TO YOUR NODE SETUP 👇
-BOLT_SIDECAR_ENGINE_JWT_HEX=
-
 # The port from which the Bolt sidecar will receive Builder-API requests from the Beacon client.
 # E.g. on Lighthouse this is set by the `--builder http://localhost:18550` flag.
 # YOU DON'T HAVE TO CHANGE THIS 
@@ -31,14 +36,15 @@ BOLT_SIDECAR_CONSTRAINTS_PROXY_PORT=18550
 # YOU DON'T HAVE TO CHANGE THIS 
 BOLT_SIDECAR_CONSTRAINTS_API_URL="http://cb_pbs:18551"
 
+# Execution client Engine Secret.
+# This is the secret token token to authenticate calls to the engine API. It can be
+# either be a hex-encoded string or a file path to a file containing the secret.
+# SET THIS ACCORDING TO YOUR NODE SETUP 👇
+BOLT_SIDECAR_ENGINE_JWT_HEX=
+
 # The fee recipient address for fallback blocks (this is the address that will receive the fees).
 # SET THIS ACCORDING TO YOUR VALIDATOR SETUP 👇
 BOLT_SIDECAR_FEE_RECIPIENT=
-
-# Secret ECDSA key to sign commitment messages with. The ETH address derived from the public key 
-# associated to it must be then used when registering the operator in the bolt contracts.
-# SET THIS 👇
-BOLT_SIDECAR_OPERATOR_PRIVATE_KEY=
 
 # Secret BLS key to sign fallback payloads with. This should be a BLS secret of 32 bytes.
 # You can generate one with the `bolt generate bls` command.

--- a/testnets/holesky/commit-boost/bolt-sidecar.env.example
+++ b/testnets/holesky/commit-boost/bolt-sidecar.env.example
@@ -36,9 +36,9 @@ BOLT_SIDECAR_CONSTRAINTS_API_URL="http://cb_pbs:18551"
 BOLT_SIDECAR_FEE_RECIPIENT=
 
 # Secret ECDSA key to sign commitment messages with. The ETH address derived from the public key 
-# associated to it must be then used when registering the operator in the `BoltManager` contract.
+# associated to it must be then used when registering the operator in the bolt contracts.
 # SET THIS 👇
-BOLT_SIDECAR_COMMITMENT_PRIVATE_KEY=
+BOLT_SIDECAR_OPERATOR_PRIVATE_KEY=
 
 # Secret BLS key to sign fallback payloads with. This should be a BLS secret of 32 bytes.
 # You can generate one with the `bolt generate bls` command.

--- a/testnets/holesky/commit-boost/bolt-sidecar.env.example
+++ b/testnets/holesky/commit-boost/bolt-sidecar.env.example
@@ -1,11 +1,11 @@
 # Port to listen on for incoming JSON-RPC requests of the Commitments API.
 # (This is where users will send preconfirmation requests to)
-# If you are using the Firewall RPCs option, this variable MUST remain empty.
+# If you are using the BOLT_SIDECAR_FIREWALL_RPCS option, this variable MUST remain empty.
 BOLT_SIDECAR_PORT=
 
 # Comma-separated list of allowed RPC addresses to subscribe via websocket to receive
 # incoming commitments requests.
-# This is incompatible with the `BOLT_SIDECAR_RPC_URL` option.
+# This is incompatible with the `BOLT_SIDECAR_PORT` option.
 BOLT_SIDECAR_FIREWALL_RPCS="wss://rpc-holesky.bolt.chainbound.io/api/v1/firewall_stream"
 
 # Secret ECDSA key to sign commitment messages with. The ETH address derived from the public key 

--- a/testnets/holesky/commit-boost/cb-bolt-config.toml
+++ b/testnets/holesky/commit-boost/cb-bolt-config.toml
@@ -85,6 +85,8 @@ id = "BOLT_SIDECAR"
 type = "commit"
 # Docker image of the module
 docker_image = "ghcr.io/chainbound/bolt-sidecar:v0.4.0-alpha"
+# Environment file for the module
+env_file = "./bolt-sidecar.env"
 
 # Configuration for how metrics should be collected and scraped
 # OPTIONAL, skip metrics collection if missing

--- a/testnets/holesky/commit-boost/cb.docker-compose.yml
+++ b/testnets/holesky/commit-boost/cb.docker-compose.yml
@@ -3,7 +3,7 @@ services:
     image: ghcr.io/chainbound/bolt-sidecar:v0.4.0-alpha
     container_name: cb_bolt_sidecar
     env_file:
-      - bolt-sidecar.env
+      - ./bolt-sidecar.env
     environment:
       CB_MODULE_ID: BOLT_SIDECAR
       CB_CONFIG: /cb-config.toml

--- a/testnets/holesky/commit-boost/cb.docker-compose.yml
+++ b/testnets/holesky/commit-boost/cb.docker-compose.yml
@@ -2,6 +2,8 @@ services:
   cb_bolt_sidecar:
     image: ghcr.io/chainbound/bolt-sidecar:v0.4.0-alpha
     container_name: cb_bolt_sidecar
+    env_file:
+      - bolt-sidecar.env
     environment:
       CB_MODULE_ID: BOLT_SIDECAR
       CB_CONFIG: /cb-config.toml
@@ -16,9 +18,6 @@ services:
     networks:
       - signer_network
       - monitoring_network
-    depends_on:
-      cb_signer:
-        condition: service_healthy
   cb_pbs:
     healthcheck:
       test: curl -f http://localhost:18551/eth/v1/builder/status


### PR DESCRIPTION
Stacked on #691 

I had to remove the `depends_on` flag because the `cb_signer` container doesn't spin up correctly due to some config parsing error. Until that is fixed, we MUST not add this back as it will prevent the sidecar process from starting.

* add BOLT_SIDECAR_OPERATOR_PRIVATE_KEY required option in bolt-sidecar.env
* Align other missing/outdated vars from .env.example in bolt-sidecar.env
* Update formatting of .env.example for readibility