### PR TITLE
fix(cb-config): sidecar-metrics, delegations-preset.env.example

### DIFF
--- a/testnets/holesky/commit-boost/bolt-sidecar.env.example
+++ b/testnets/holesky/commit-boost/bolt-sidecar.env.example
@@ -111,5 +111,5 @@ BOLT_SIDECAR_DELEGATIONS_PATH="/etc/delegations.json"
 
 # Telemetry and Metrics
 # Changing this requires also changing the `target.json` file
-BOLT_SIDECAR_METRICS_PORT=9091 
+BOLT_SIDECAR_METRICS_PORT=10000
 BOLT_SIDECAR_DISABLE_METRICS=false

--- a/testnets/holesky/commit-boost/cb-bolt-config.toml
+++ b/testnets/holesky/commit-boost/cb-bolt-config.toml
@@ -91,6 +91,9 @@ env_file = "./bolt-sidecar.env"
 # Configuration for how metrics should be collected and scraped
 # OPTIONAL, skip metrics collection if missing
 [metrics]
+# Host for prometheus, grafana, and cadvisor
+# OPTIONAL, DEFAULT: 127.0.0.1
+host = "0.0.0.0"
 # Path to a `prometheus.yml` file to use in Prometheus. If using a custom config file, be sure to add a
 # file discovery section as follows:
 # ```yml

--- a/testnets/holesky/commit-boost/cb.docker-compose.yml
+++ b/testnets/holesky/commit-boost/cb.docker-compose.yml
@@ -28,7 +28,7 @@ services:
     image: ghcr.io/chainbound/bolt-boost:v0.4.0-alpha
     container_name: cb_pbs
     ports:
-      - 18551:18551
+      - 0.0.0.0:18551:18551
     environment:
       CB_CONFIG: /cb-config.toml
       CB_METRICS_PORT: 10000
@@ -66,7 +66,7 @@ services:
     image: prom/prometheus:v3.0.0
     container_name: cb_prometheus
     ports:
-      - 9090:9090
+      - 0.0.0.0:9090:9090
     volumes:
       - ./cb-prometheus.yml:/etc/prometheus/prometheus.yml
       - ./targets.json:/etc/prometheus/targets.json
@@ -77,7 +77,7 @@ services:
     image: grafana/grafana:11.3.1
     container_name: cb_grafana
     ports:
-      - 3000:3000
+      - 0.0.0.0:3000:3000
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=admin
     volumes:
@@ -92,7 +92,7 @@ services:
     image: gcr.io/cadvisor/cadvisor
     container_name: cb_cadvisor
     ports:
-      - 8080:8080
+      - 0.0.0.0:8080:8080
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - /sys:/sys:ro

--- a/testnets/holesky/commit-boost/cb.docker-compose.yml
+++ b/testnets/holesky/commit-boost/cb.docker-compose.yml
@@ -28,7 +28,7 @@ services:
     image: ghcr.io/chainbound/bolt-boost:v0.4.0-alpha
     container_name: cb_pbs
     ports:
-      - 0.0.0.0:18551:18551
+      - 18551:18551
     environment:
       CB_CONFIG: /cb-config.toml
       CB_METRICS_PORT: 10000
@@ -66,7 +66,7 @@ services:
     image: prom/prometheus:v3.0.0
     container_name: cb_prometheus
     ports:
-      - 127.0.0.1:9090:9090
+      - 9090:9090
     volumes:
       - ./cb-prometheus.yml:/etc/prometheus/prometheus.yml
       - ./targets.json:/etc/prometheus/targets.json
@@ -77,7 +77,7 @@ services:
     image: grafana/grafana:11.3.1
     container_name: cb_grafana
     ports:
-      - 127.0.0.1:3000:3000
+      - 3000:3000
     environment:
       - GF_SECURITY_ADMIN_PASSWORD=admin
     volumes:
@@ -92,7 +92,7 @@ services:
     image: gcr.io/cadvisor/cadvisor
     container_name: cb_cadvisor
     ports:
-      - 127.0.0.1:8080:8080
+      - 8080:8080
     volumes:
       - /var/run/docker.sock:/var/run/docker.sock:ro
       - /sys:/sys:ro

--- a/testnets/holesky/presets/sidecar-delegations-preset.env.example
+++ b/testnets/holesky/presets/sidecar-delegations-preset.env.example
@@ -1,52 +1,78 @@
-# Ethereum Node Connections + PBS URLs
+# --- Ethereum Node Connections + PBS URLs ---
 
 # Port to listen on for incoming JSON-RPC requests of the Commitments API. This
 # port should be open on your firewall in order to receive external requests!
+# If you are using the BOLT_SIDECAR_FIREWALL_RPCS option, this variable MUST remain empty.
 BOLT_SIDECAR_PORT=8017
+
+# Comma-separated list of allowed RPC addresses to subscribe via websocket to receive
+# incoming commitments requests.
+# This is incompatible with the `BOLT_SIDECAR_PORT` option.
+BOLT_SIDECAR_FIREWALL_RPCS="wss://rpc-holesky.bolt.chainbound.io/api/v1/firewall_stream"
+
+# Secret ECDSA key to sign commitment messages with. The public key associated
+# to it must be then used when registering the operator in bolt contracts
+BOLT_SIDECAR_OPERATOR_PRIVATE_KEY=
+
 # Execution client API URL
 BOLT_SIDECAR_EXECUTION_API_URL="http://172.56.0.1:8545"
+
 # URL for the beacon client
 BOLT_SIDECAR_BEACON_API_URL="http://172.56.0.1:5052"
+
 # Execution client Engine API URL. This is needed for fallback block building
 # and must be a synced Geth node
 BOLT_SIDECAR_ENGINE_API_URL="http://172.56.0.1:8551"
+
 # The port from which the Bolt sidecar will receive Builder-API requests from the Beacon client
 BOLT_SIDECAR_CONSTRAINTS_PROXY_PORT=18550
+
 # URL to forward the constraints produced by the Bolt sidecar to a server
 # supporting the Constraints API, such as an MEV-Boost fork
 BOLT_SIDECAR_CONSTRAINTS_API_URL="http://bolt-mev-boost-holesky:18551"
+
 # The JWT secret token to authenticate calls to the engine API. It can be
 # either be a hex-encoded string or a file path to a file containing the
 # hex-encoded secret.
 BOLT_SIDECAR_ENGINE_JWT_HEX=
+
 # The fee recipient address for locally-built fallback blocks. It should be the same as the
 # one set for your validators.
 BOLT_SIDECAR_FEE_RECIPIENT=
-# Secret ECDSA key used to sign commitment messages on behalf of your validators.
-# This MUST be set to the private key of your operator address registered in a restaking protocol.
-BOLT_SIDECAR_COMMITMENT_PRIVATE_KEY=
 
-# Commitments limits
+# Secret BLS key to sign fallback payloads with
+BOLT_SIDECAR_BUILDER_PRIVATE_KEY=
+
+# --- Commitments limits ---
+
 # Max committed gas per slot
 BOLT_SIDECAR_MAX_COMMITTED_GAS_PER_SLOT=10_000_000
+
 # Min profit per gas to accept a commitment
 BOLT_SIDECAR_MIN_PROFIT=2000000000 # 2 Gwei = 2 * 10^9 wei
 
-# Chain configuration
+# --- Chain configuration ---
+
 # Chain on which the sidecar is running
 BOLT_SIDECAR_CHAIN="holesky"
+
 # The deadline in the slot at which the sidecar will stop accepting new
 # commitments for the next block (parsed as milliseconds)
 BOLT_SIDECAR_COMMITMENT_DEADLINE=8000
+
 # Enable a two-epoch lookahead by enabling unsafe lookahead option
 BOLT_SIDECAR_ENABLE_UNSAFE_LOOKAHEAD=true
 
-# Signing options.
+# --- Signing options ---
+
 # The path to the delegations file
 BOLT_SIDECAR_DELEGATIONS_PATH=
+
 # The private key of the account for which delegations have been made.
 BOLT_SIDECAR_CONSTRAINT_PRIVATE_KEY=
 
-# Telemetry and Metrics
-BOLT_SIDECAR_METRICS_PORT=9091 # Changing this requires also changing the `target.json` file
+# --- Telemetry and Metrics ---
+
+# Changing this requires also changing the `target.json` file
+BOLT_SIDECAR_METRICS_PORT=9091
 BOLT_SIDECAR_DISABLE_METRICS=false


### PR DESCRIPTION
* Part of https://github.com/chainbound/bolt/pull/696
* Stacked on #691 
* Metrics are now configured to the correct port
* Updated the cb prefix env file
