### PR TITLE
chore: group dependency updates in one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -6,7 +6,7 @@
 version: 2
 updates:
   - package-ecosystem: "cargo"
-    directories: 
+    directories:
       - "./bolt-sidecar"
       - "./bolt-cli"
       - "./bolt-boost"
@@ -16,3 +16,8 @@ updates:
       interval: "weekly"
       day: "monday"
       time: "07:00"
+    # Group all dependencies into a single pull request
+    groups:
+      all-dependencies:
+        patterns:
+          - "*"


### PR DESCRIPTION
So we don't get flooded. Reference: https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#groups--