### PR TITLE
chore(deps): group major, minor, patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,16 +14,20 @@ updates:
       day: "monday"
       time: "07:00"
     groups:
-      sidecar-breaking:
+      sidecar-major:
         patterns:
           - "*"
         update-types:
           - "major"
-      sidecar-non-breaking:
+      sidecar-minor:
         patterns:
           - "*"
         update-types:
           - "minor"
+      sidecar-patch:
+        patterns:
+          - "*"
+        update-types:
           - "patch"
 
   - package-ecosystem: "cargo"
@@ -35,16 +39,20 @@ updates:
       day: "monday"
       time: "07:00"
     groups:
-      cli-breaking:
+      cli-major:
         patterns:
           - "*"
         update-types:
           - "major"
-      cli-non-breaking:
+      cli-minor:
         patterns:
           - "*"
         update-types:
           - "minor"
+      cli-patch:
+        patterns:
+          - "*"
+        update-types:
           - "patch"
 
   - package-ecosystem: "cargo"
@@ -56,14 +64,18 @@ updates:
       day: "monday"
       time: "07:00"
     groups:
-      boost-breaking:
+      boost-major:
         patterns:
           - "*"
         update-types:
           - "major"
-      boost-non-breaking:
+      boost-minor:
         patterns:
           - "*"
         update-types:
           - "minor"
+      boost-patch:
+        patterns:
+          - "*"
+        update-types:
           - "patch"


### PR DESCRIPTION
Attempted in https://github.com/chainbound/bolt/pull/713 to group pre v1 together with major, but couldn't get it to work.

Here I group patch separately from minor. We should be able to merge most patch updates if they pass CI even if they are pre v1.