### PR TITLE
fix(sidecar): return version in `bolt_metadata` on ws connection

### DIFF
--- a/bolt-sidecar/src/api/commitments/firewall/processor.rs
+++ b/bolt-sidecar/src/api/commitments/firewall/processor.rs
@@ -27,7 +27,8 @@ use crate::{
     api::commitments::{
         server::CommitmentEvent,
         spec::{
-            CommitmentError, GET_METADATA_METHOD, GET_VERSION_METHOD, REQUEST_INCLUSION_METHOD,
+            CommitmentError, MetadataResponse, GET_METADATA_METHOD, GET_VERSION_METHOD,
+            REQUEST_INCLUSION_METHOD,
         },
     },
     common::BOLT_SIDECAR_VERSION,
@@ -321,8 +322,11 @@ impl CommitmentRequestProcessor {
                 self.send_response(response);
             }
             GET_METADATA_METHOD => {
-                let response =
-                    JsonRpcSuccessResponse::new(json!(self.state.limits)).with_uuid(id).into();
+                let metadata = MetadataResponse {
+                    limits: self.state.limits,
+                    version: BOLT_SIDECAR_VERSION.to_string(),
+                };
+                let response = JsonRpcSuccessResponse::new(json!(metadata)).with_uuid(id).into();
                 self.send_response(response);
             }
             REQUEST_INCLUSION_METHOD => {

--- a/bolt-sidecar/src/api/commitments/server/handlers.rs
+++ b/bolt-sidecar/src/api/commitments/server/handlers.rs
@@ -8,7 +8,6 @@ use axum::{
     Json,
 };
 use axum_extra::extract::WithRejection;
-use serde::{Deserialize, Serialize};
 use serde_json::json;
 use tracing::{debug, error, info, instrument};
 
@@ -16,12 +15,11 @@ use crate::{
     api::commitments::{
         server::headers::auth_from_headers,
         spec::{
-            CommitmentError, CommitmentsApi, GET_METADATA_METHOD, GET_VERSION_METHOD,
-            REQUEST_INCLUSION_METHOD,
+            CommitmentError, CommitmentsApi, MetadataResponse, GET_METADATA_METHOD,
+            GET_VERSION_METHOD, REQUEST_INCLUSION_METHOD,
         },
     },
     common::BOLT_SIDECAR_VERSION,
-    config::limits::LimitsOpts,
     primitives::{
         jsonrpc::{JsonRpcRequest, JsonRpcResponse, JsonRpcSuccessResponse},
         signature::SignatureError,
@@ -30,17 +28,6 @@ use crate::{
 };
 
 use super::CommitmentsApiInner;
-
-/// Response structure for the metadata endpoint that combines
-/// limits configuration with version information in a flat structure
-#[derive(Debug, Serialize, Deserialize)]
-pub struct MetadataResponse {
-    /// The operational limits of the sidecar
-    #[serde(flatten)]
-    pub limits: LimitsOpts,
-    /// The version of the Bolt sidecar
-    pub version: String,
-}
 
 /// Handler function for the root JSON-RPC path.
 #[instrument(skip_all, name = "POST /rpc", fields(method = %payload.method))]

--- a/bolt-sidecar/src/api/commitments/server/mod.rs
+++ b/bolt-sidecar/src/api/commitments/server/mod.rs
@@ -178,11 +178,11 @@ fn make_router(state: Arc<CommitmentsApiInner>) -> Router {
 #[cfg(test)]
 mod test {
     use crate::{
-        api::commitments::spec::SIGNATURE_HEADER, common::BOLT_SIDECAR_VERSION,
+        api::commitments::spec::{MetadataResponse, SIGNATURE_HEADER},
+        common::BOLT_SIDECAR_VERSION,
         primitives::jsonrpc::JsonRpcError,
     };
     use alloy::signers::{k256::SecretKey, local::PrivateKeySigner};
-    use handlers::MetadataResponse;
     use serde_json::json;
 
     use crate::{

--- a/bolt-sidecar/src/api/commitments/spec.rs
+++ b/bolt-sidecar/src/api/commitments/spec.rs
@@ -6,9 +6,11 @@ use axum::{
     response::IntoResponse,
     Json,
 };
+use serde::{Deserialize, Serialize};
 use thiserror::Error;
 
 use crate::{
+    config::limits::LimitsOpts,
     primitives::{
         commitment::InclusionCommitment,
         jsonrpc::{JsonRpcError, JsonRpcErrorResponse},
@@ -122,6 +124,17 @@ impl IntoResponse for CommitmentError {
 
         (status_code, json).into_response()
     }
+}
+
+/// Response structure for the metadata endpoint that combines
+/// limits configuration with version information in a flat structure
+#[derive(Debug, Serialize, Deserialize)]
+pub struct MetadataResponse {
+    /// The operational limits of the sidecar
+    #[serde(flatten)]
+    pub limits: LimitsOpts,
+    /// The version of the Bolt sidecar
+    pub version: String,
 }
 
 /// Implements the commitments-API: <https://chainbound.github.io/bolt-docs/api/rpc>


### PR DESCRIPTION
The version wasn't returned in case of firewall delegation. I apologize for the oversight.