### PR TITLE
chore(cli, justfile): send preconfs also via `eth_sendRawTransaction`

### DIFF
--- a/bolt-cli/src/cli.rs
+++ b/bolt-cli/src/cli.rs
@@ -155,6 +155,10 @@ pub struct SendCommand {
     /// The URL of the devnet sidecar for sending transactions
     #[clap(long = "devnet.sidecar_url", hide = true)]
     pub devnet_sidecar_url: Option<Url>,
+
+    /// Toggle for using `eth_sendRawTransaction` instead of `bolt_requestInclusion`
+    #[clap(long, env = "RAW", default_value_t = false)]
+    pub raw: bool,
 }
 
 #[derive(Debug, Clone, Parser)]

--- a/justfile
+++ b/justfile
@@ -139,7 +139,7 @@ grafana:
   fi
 
 # manually send a preconfirmation to the bolt devnet
-send-preconf count='1':
+send-preconf count='1' raw="":
     cd bolt-cli && RUST_LOG=info cargo run -- send \
         --devnet \
         --devnet.execution_url $(kurtosis port print bolt-devnet el-1-geth-lighthouse rpc) \
@@ -148,9 +148,10 @@ send-preconf count='1':
         --private-key 53321db7c1e331d93a11a41d16f004d7ff63972ec8ec7c25db329728ceeb1710 \
         --max-fee 4 \
         --priority-fee 3 \
-        --count {{count}}
+        --count {{count}} \
+        {{ if raw == "true" { "--raw" } else { "" } }}
 
-send-preconf-rpc count='1' rpc='http://127.0.0.1:8015/rpc':
+send-preconf-rpc count='1' raw="" rpc='http://127.0.0.1:8015/rpc':
   cd bolt-cli && RUST_LOG=info cargo run -- send \
       --devnet \
       --devnet.execution_url $(kurtosis port print bolt-devnet el-1-geth-lighthouse rpc) \
@@ -159,10 +160,11 @@ send-preconf-rpc count='1' rpc='http://127.0.0.1:8015/rpc':
       --private-key 53321db7c1e331d93a11a41d16f004d7ff63972ec8ec7c25db329728ceeb1710 \
       --max-fee 4 \
       --priority-fee 3 \
-      --count {{count}}
+      --count {{count}} \
+      {{ if raw == "true" { "--raw" } else { "" } }}
 
 # manually send a blob preconfirmation to the bolt devnet
-send-blob-preconf count='1':
+send-blob-preconf count='1' raw="":
     cd bolt-cli && RUST_LOG=info cargo run -- send \
         --devnet \
         --devnet.execution_url $(kurtosis port print bolt-devnet el-1-geth-lighthouse rpc) \
@@ -172,9 +174,10 @@ send-blob-preconf count='1':
         --blob \
         --max-fee 4 \
         --priority-fee 3 \
-        --count {{count}}
+        --count {{count}} \
+        {{ if raw == "true" { "--raw" } else { "" } }}
 
-send-blob-preconf-rpc count='1' rpc='http://127.0.0.1:8015/rpc':
+send-blob-preconf-rpc count='1' raw="" rpc='http://127.0.0.1:8015/rpc':
   cd bolt-cli && RUST_LOG=info cargo run -- send \
       --devnet \
       --devnet.execution_url $(kurtosis port print bolt-devnet el-1-geth-lighthouse rpc) \
@@ -184,7 +187,8 @@ send-blob-preconf-rpc count='1' rpc='http://127.0.0.1:8015/rpc':
       --blob \
       --max-fee 4 \
       --priority-fee 3 \
-      --count {{count}}
+      --count {{count}} \
+      {{ if raw == "true" { "--raw" } else { "" } }}
 
 # build all the docker images locally
 build-local-images:


### PR DESCRIPTION
Introduces a `--raw` flag inside the `send` command of `bolt` CLI to use `eth_sendRawTransaction` instead of `bolt_requestInclusion`. 

Updates the related Just commands to use this functionality.