### PR TITLE
Bolt-cli: Add dry-run flag for developmental/testing

### DIFF
--- a/bolt-cli/README.md
+++ b/bolt-cli/README.md
@@ -303,7 +303,8 @@ Commands:
   help      Print this message or the help of the given subcommand(s)
 
 Options:
-  -h, --help  Print help
+  -h, --help      Print help
+  -d, --dry-run   Simulate without making on-chain changes (e.g Opt to using Anvil fork rather than RPC connection)
 ```
 
 </details>
@@ -329,7 +330,8 @@ Commands:
   help        Print this message or the help of the given subcommand(s)
 
 Options:
-  -h, --help  Print help
+  -h, --help      Print help
+  -d, --dry-run   Simulate without making on-chain changes (e.g Opt to using Anvil fork rather than RPC connection)
 
 ❯ bolt operators eigenlayer --help
 Commands to interact with EigenLayer and bolt
@@ -345,7 +347,8 @@ Commands:
   help        Print this message or the help of the given subcommand(s)
 
 Options:
-  -h, --help  Print help
+  -h, --help      Print help
+  -d, --dry-run   Simulate without making on-chain changes (e.g Opt to using Anvil fork rather than RPC connection)
 
 ❯ bolt operators symbiotic --help
 Commands to interact with Symbiotic and bolt
@@ -360,7 +363,8 @@ Commands:
   help        Print this message or the help of the given subcommand(s)
 
 Options:
-  -h, --help  Print help
+  -h, --help      Print help
+  -d, --dry-run   Simulate without making on-chain changes (e.g Opt to using Anvil fork rather than RPC connection)
 ```
 
 </details>

--- a/bolt-cli/src/cli.rs
+++ b/bolt-cli/src/cli.rs
@@ -190,6 +190,11 @@ pub enum ValidatorsSubcommand {
         /// The private key to sign the transactions with.
         #[clap(long, env = "ADMIN_PRIVATE_KEY")]
         admin_private_key: B256,
+
+        /// Run the command in "dry run" mode, run all steps without broadcast.
+        /// Useful for testing and debugging purposes.
+        #[clap(short, long, env = "DRY_RUN", default_value = "false")]
+        dry_run: bool,
     },
     /// Check the status of a validator (batch).
     Status {
@@ -245,6 +250,11 @@ pub enum EigenLayerSubcommand {
         /// If no unit is provided, it is assumed to be in wei.
         #[clap(long, env = "EIGENLAYER_STRATEGY_DEPOSIT_AMOUNT", value_parser = parse_ether_value)]
         amount: U256,
+
+        /// Run the command in "dry run" mode, run all steps without broadcast.
+        /// Useful for testing and debugging purposes.
+        #[clap(short, long, env = "DRY_RUN", default_value = "false")]
+        dry_run: bool,
     },
 
     /// Register an operator into the bolt AVS.
@@ -261,6 +271,11 @@ pub enum EigenLayerSubcommand {
         /// The salt for the operator signature.
         #[clap(long, env = "OPERATOR_SIGNATURE_SALT")]
         salt: B256,
+
+        /// Run the command in "dry run" mode, run all steps without broadcast.
+        /// Useful for testing and debugging purposes.
+        #[clap(short, long, env = "DRY_RUN", default_value = "false")]
+        dry_run: bool,
     },
 
     /// Deregister an EigenLayer operator from the bolt AVS.
@@ -271,6 +286,11 @@ pub enum EigenLayerSubcommand {
         /// The private key of the operator.
         #[clap(long, env = "OPERATOR_PRIVATE_KEY")]
         operator_private_key: B256,
+
+        /// Run the command in "dry run" mode, run all steps without broadcast.
+        /// Useful for testing and debugging purposes.
+        #[clap(short, long, env = "DRY_RUN", default_value = "false")]
+        dry_run: bool,
     },
 
     /// Update the operator RPC.
@@ -310,6 +330,11 @@ pub enum SymbioticSubcommand {
         /// The URL of the operator RPC.
         #[clap(long, env = "OPERATOR_RPC")]
         operator_rpc: Url,
+
+        /// Run the command in "dry run" mode, run all steps without broadcast.
+        /// Useful for testing and debugging purposes.
+        #[clap(short, long, env = "DRY_RUN", default_value = "false")]
+        dry_run: bool,
     },
 
     /// Deregister a Symbiotic operator from bolt.
@@ -320,6 +345,11 @@ pub enum SymbioticSubcommand {
         /// The private key of the operator.
         #[clap(long, env = "OPERATOR_PRIVATE_KEY")]
         operator_private_key: B256,
+
+        /// Run the command in "dry run" mode, run all steps without broadcast.
+        /// Useful for testing and debugging purposes.
+        #[clap(short, long, env = "DRY_RUN", default_value = "false")]
+        dry_run: bool,
     },
 
     /// Update the operator RPC.

--- a/bolt-cli/src/cli.rs
+++ b/bolt-cli/src/cli.rs
@@ -304,6 +304,11 @@ pub enum EigenLayerSubcommand {
         /// The URL of the operator RPC.
         #[clap(long, env = "OPERATOR_RPC")]
         operator_rpc: Url,
+
+        /// Run the command in "dry run" mode, run all steps without broadcast.
+        /// Useful for testing and debugging purposes.
+        #[clap(short, long, env = "DRY_RUN", default_value = "false")]
+        dry_run: bool,
     },
 
     /// Check the status of an operator in the bolt AVS.
@@ -363,6 +368,11 @@ pub enum SymbioticSubcommand {
         /// The URL of the operator RPC.
         #[clap(long, env = "OPERATOR_RPC")]
         operator_rpc: Url,
+
+        /// Run the command in "dry run" mode, run all steps without broadcast.
+        /// Useful for testing and debugging purposes.
+        #[clap(short, long, env = "DRY_RUN", default_value = "false")]
+        dry_run: bool,
     },
 
     /// Check the status of a Symbiotic operator.

--- a/bolt-cli/src/commands/operators/eigenlayer.rs
+++ b/bolt-cli/src/commands/operators/eigenlayer.rs
@@ -18,7 +18,7 @@ use crate::{
     cli::{Chain, EigenLayerSubcommand},
     common::{
         bolt_manager::BoltManagerContract::{self, BoltManagerContractErrors},
-        request_confirmation, try_parse_contract_error,
+        handle_rpc_dry_run, request_confirmation, shutdown_anvil, try_parse_contract_error,
     },
     contracts::{
         bolt::{
@@ -43,10 +43,12 @@ impl EigenLayerSubcommand {
                     .wrap_err("valid private key")?;
                 let operator = signer.address();
 
+                let (rpc, anvil) = handle_rpc_dry_run(rpc_url, dry_run)?;
+
                 let provider = ProviderBuilder::new()
                     .with_recommended_fillers()
                     .wallet(EthereumWallet::from(signer))
-                    .on_http(rpc_url);
+                    .on_http(rpc);
 
                 let chain = Chain::try_from_provider(&provider).await?;
 
@@ -91,7 +93,9 @@ impl EigenLayerSubcommand {
                     eyre::bail!("Transaction failed: {:?}", receipt)
                 }
 
-                info!("Succesfully deposited collateral into strategy");
+                info!("Successfully deposited collateral into strategy");
+
+                shutdown_anvil(anvil);
 
                 Ok(())
             }
@@ -100,10 +104,12 @@ impl EigenLayerSubcommand {
                 let signer = PrivateKeySigner::from_bytes(&operator_private_key)
                     .wrap_err("valid private key")?;
 
+                let (rpc, anvil) = handle_rpc_dry_run(rpc_url, dry_run)?;
+
                 let provider = ProviderBuilder::new()
                     .with_recommended_fillers()
                     .wallet(EthereumWallet::from(signer.clone()))
-                    .on_http(rpc_url);
+                    .on_http(rpc);
 
                 let chain = Chain::try_from_provider(&provider).await?;
 
@@ -138,7 +144,7 @@ impl EigenLayerSubcommand {
                     Bytes::from(signer.sign_hash_sync(&signature_digest_hash)?.as_bytes());
                 let signature = SignatureWithSaltAndExpiry { signature, expiry, salt };
 
-                match bolt_eigenlayer_middleware
+                let result = match bolt_eigenlayer_middleware
                     .registerOperator(operator_rpc.to_string(), signature)
                     .send()
                     .await
@@ -154,7 +160,9 @@ impl EigenLayerSubcommand {
                             eyre::bail!("Transaction failed: {:?}", receipt)
                         }
 
-                        info!("Succesfully registered EigenLayer operator");
+                        info!("Successfully registered EigenLayer operator");
+
+                        Ok(())
                     }
                     Err(e) => {
                         match try_parse_contract_error::<BoltEigenLayerMiddlewareErrors>(e)? {
@@ -173,9 +181,11 @@ impl EigenLayerSubcommand {
                             ),
                         }
                     }
-                }
+                };
 
-                Ok(())
+                shutdown_anvil(anvil);
+
+                result
             }
 
             Self::Deregister { rpc_url, operator_private_key, dry_run } => {
@@ -183,10 +193,12 @@ impl EigenLayerSubcommand {
                     .wrap_err("valid private key")?;
                 let address = signer.address();
 
+                let (rpc, anvil) = handle_rpc_dry_run(rpc_url, dry_run)?;
+
                 let provider = ProviderBuilder::new()
                     .with_recommended_fillers()
                     .wallet(EthereumWallet::from(signer))
-                    .on_http(rpc_url);
+                    .on_http(rpc);
 
                 let chain = Chain::try_from_provider(&provider).await?;
 
@@ -200,7 +212,7 @@ impl EigenLayerSubcommand {
                 let bolt_eigenlayer_middleware =
                     BoltEigenLayerMiddleware::new(bolt_avs_address, provider);
 
-                match bolt_eigenlayer_middleware.deregisterOperator().send().await {
+                let result = match bolt_eigenlayer_middleware.deregisterOperator().send().await {
                     Ok(pending) => {
                         info!(
                             hash = ?pending.tx_hash(),
@@ -212,7 +224,9 @@ impl EigenLayerSubcommand {
                             eyre::bail!("Transaction failed: {:?}", receipt)
                         }
 
-                        info!("Succesfully deregistered EigenLayer operator");
+                        info!("Successfully deregistered EigenLayer operator");
+
+                        Ok(())
                     }
                     Err(e) => {
                         match try_parse_contract_error::<BoltEigenLayerMiddlewareErrors>(e)? {
@@ -225,20 +239,24 @@ impl EigenLayerSubcommand {
                             ),
                         }
                     }
-                }
+                };
 
-                Ok(())
+                shutdown_anvil(anvil);
+
+                result
             }
 
-            Self::UpdateRpc { rpc_url, operator_private_key, operator_rpc } => {
+            Self::UpdateRpc { rpc_url, operator_private_key, operator_rpc, dry_run } => {
                 let signer = PrivateKeySigner::from_bytes(&operator_private_key)
                     .wrap_err("valid private key")?;
                 let address = signer.address();
 
+                let (rpc, anvil) = handle_rpc_dry_run(rpc_url, dry_run)?;
+
                 let provider = ProviderBuilder::new()
                     .with_recommended_fillers()
                     .wallet(EthereumWallet::from(signer))
-                    .on_http(rpc_url);
+                    .on_http(rpc);
 
                 let chain = Chain::try_from_provider(&provider).await?;
 
@@ -257,7 +275,11 @@ impl EigenLayerSubcommand {
                     return Ok(());
                 }
 
-                match bolt_manager.updateOperatorRPC(operator_rpc.to_string()).send().await {
+                let result = match bolt_manager
+                    .updateOperatorRPC(operator_rpc.to_string())
+                    .send()
+                    .await
+                {
                     Ok(pending) => {
                         info!(
                             hash = ?pending.tx_hash(),
@@ -269,7 +291,9 @@ impl EigenLayerSubcommand {
                             eyre::bail!("Transaction failed: {:?}", receipt)
                         }
 
-                        info!("Succesfully updated EigenLayer operator RPC");
+                        info!("Successfully updated EigenLayer operator RPC");
+
+                        Ok(())
                     }
                     Err(e) => match try_parse_contract_error::<BoltManagerContractErrors>(e)? {
                         BoltManagerContractErrors::OperatorNotRegistered(_) => {
@@ -279,8 +303,11 @@ impl EigenLayerSubcommand {
                             unreachable!("Unexpected error with selector {:?}", other.selector())
                         }
                     },
-                }
-                Ok(())
+                };
+
+                shutdown_anvil(anvil);
+
+                result
             }
 
             Self::Status { rpc_url: rpc, address } => {
@@ -295,7 +322,7 @@ impl EigenLayerSubcommand {
                     info!(?address, "EigenLayer operator is registered");
                 } else {
                     warn!(?address, "Operator not registered");
-                    return Ok(())
+                    return Ok(());
                 }
 
                 match bolt_manager.getOperatorData(address).call().await {
@@ -444,7 +471,7 @@ mod tests {
                     operator_private_key: secret_key,
                     strategy: EigenLayerStrategy::WEth,
                     amount: U256::from(1),
-                    dry_run: true,
+                    dry_run: false,
                 },
             },
         };
@@ -460,7 +487,7 @@ mod tests {
                     operator_private_key: secret_key,
                     operator_rpc: "https://bolt.chainbound.io/rpc".parse().expect("valid url"),
                     salt: B256::ZERO,
-                    dry_run: true,
+                    dry_run: false,
                 },
             },
         };
@@ -485,6 +512,7 @@ mod tests {
                     rpc_url: anvil_url.clone(),
                     operator_private_key: secret_key,
                     operator_rpc: "https://boooooolt.chainbound.io/rpc".parse().expect("valid url"),
+                    dry_run: false,
                 },
             },
         };
@@ -507,7 +535,7 @@ mod tests {
                 subcommand: EigenLayerSubcommand::Deregister {
                     rpc_url: anvil_url.clone(),
                     operator_private_key: secret_key,
-                    dry_run: true,
+                    dry_run: false,
                 },
             },
         };

--- a/bolt-cli/src/commands/operators/eigenlayer.rs
+++ b/bolt-cli/src/commands/operators/eigenlayer.rs
@@ -38,7 +38,7 @@ impl EigenLayerSubcommand {
     /// Run the EigenLayer subcommand.
     pub async fn run(self) -> eyre::Result<()> {
         match self {
-            Self::Deposit { rpc_url, strategy, amount, operator_private_key } => {
+            Self::Deposit { rpc_url, strategy, amount, operator_private_key, dry_run } => {
                 let signer = PrivateKeySigner::from_bytes(&operator_private_key)
                     .wrap_err("valid private key")?;
                 let operator = signer.address();
@@ -96,7 +96,7 @@ impl EigenLayerSubcommand {
                 Ok(())
             }
 
-            Self::Register { rpc_url, operator_rpc, salt, operator_private_key } => {
+            Self::Register { rpc_url, operator_rpc, salt, operator_private_key, dry_run } => {
                 let signer = PrivateKeySigner::from_bytes(&operator_private_key)
                     .wrap_err("valid private key")?;
 
@@ -178,7 +178,7 @@ impl EigenLayerSubcommand {
                 Ok(())
             }
 
-            Self::Deregister { rpc_url, operator_private_key } => {
+            Self::Deregister { rpc_url, operator_private_key, dry_run } => {
                 let signer = PrivateKeySigner::from_bytes(&operator_private_key)
                     .wrap_err("valid private key")?;
                 let address = signer.address();
@@ -444,6 +444,7 @@ mod tests {
                     operator_private_key: secret_key,
                     strategy: EigenLayerStrategy::WEth,
                     amount: U256::from(1),
+                    dry_run: true,
                 },
             },
         };
@@ -459,6 +460,7 @@ mod tests {
                     operator_private_key: secret_key,
                     operator_rpc: "https://bolt.chainbound.io/rpc".parse().expect("valid url"),
                     salt: B256::ZERO,
+                    dry_run: true,
                 },
             },
         };
@@ -505,6 +507,7 @@ mod tests {
                 subcommand: EigenLayerSubcommand::Deregister {
                     rpc_url: anvil_url.clone(),
                     operator_private_key: secret_key,
+                    dry_run: true,
                 },
             },
         };

--- a/bolt-cli/src/commands/operators/symbiotic.rs
+++ b/bolt-cli/src/commands/operators/symbiotic.rs
@@ -25,7 +25,7 @@ impl SymbioticSubcommand {
     /// Run the symbiotic subcommand.
     pub async fn run(self) -> eyre::Result<()> {
         match self {
-            Self::Register { operator_rpc, operator_private_key, rpc_url } => {
+            Self::Register { operator_rpc, operator_private_key, rpc_url, dry_run } => {
                 let signer = PrivateKeySigner::from_bytes(&operator_private_key)
                     .wrap_err("valid private key")?;
 
@@ -94,7 +94,7 @@ impl SymbioticSubcommand {
                 Ok(())
             }
 
-            Self::Deregister { rpc_url, operator_private_key } => {
+            Self::Deregister { rpc_url, operator_private_key, dry_run } => {
                 let signer = PrivateKeySigner::from_bytes(&operator_private_key)
                     .wrap_err("valid private key")?;
 
@@ -387,6 +387,7 @@ mod tests {
                     rpc_url: anvil_url.clone(),
                     operator_private_key: secret_key,
                     operator_rpc: "https://bolt.chainbound.io".parse().expect("valid url"),
+                    dry_run: true,
                 },
             },
         };
@@ -434,6 +435,7 @@ mod tests {
                 subcommand: SymbioticSubcommand::Deregister {
                     rpc_url: anvil_url.clone(),
                     operator_private_key: secret_key,
+                    dry_run: true,
                 },
             },
         };

--- a/bolt-cli/src/commands/operators/symbiotic.rs
+++ b/bolt-cli/src/commands/operators/symbiotic.rs
@@ -12,7 +12,7 @@ use crate::{
     cli::{Chain, SymbioticSubcommand},
     common::{
         bolt_manager::BoltManagerContract::{self, BoltManagerContractErrors},
-        request_confirmation, try_parse_contract_error,
+        handle_rpc_dry_run, request_confirmation, shutdown_anvil, try_parse_contract_error,
     },
     contracts::{
         bolt::BoltSymbioticMiddleware::{self, BoltSymbioticMiddlewareErrors},
@@ -29,10 +29,12 @@ impl SymbioticSubcommand {
                 let signer = PrivateKeySigner::from_bytes(&operator_private_key)
                     .wrap_err("valid private key")?;
 
+                let (rpc, anvil) = handle_rpc_dry_run(rpc_url, dry_run)?;
+
                 let provider = ProviderBuilder::new()
                     .with_recommended_fillers()
                     .wallet(EthereumWallet::from(signer.clone()))
-                    .on_http(rpc_url);
+                    .on_http(rpc);
 
                 let chain = Chain::try_from_provider(&provider).await?;
 
@@ -64,7 +66,11 @@ impl SymbioticSubcommand {
                     provider.clone(),
                 );
 
-                match middleware.registerOperator(operator_rpc.to_string()).send().await {
+                let result = match middleware
+                    .registerOperator(operator_rpc.to_string())
+                    .send()
+                    .await
+                {
                     Ok(pending) => {
                         info!(
                             hash = ?pending.tx_hash(),
@@ -76,7 +82,9 @@ impl SymbioticSubcommand {
                             eyre::bail!("Transaction failed: {:?}", receipt)
                         }
 
-                        info!("Succesfully registered Symbiotic operator");
+                        info!("Successfully registered Symbiotic operator");
+
+                        Ok(())
                     }
                     Err(e) => match try_parse_contract_error::<BoltSymbioticMiddlewareErrors>(e)? {
                         BoltSymbioticMiddlewareErrors::AlreadyRegistered(_) => {
@@ -89,9 +97,11 @@ impl SymbioticSubcommand {
                             unreachable!("Unexpected error with selector {:?}", other.selector())
                         }
                     },
-                }
+                };
 
-                Ok(())
+                shutdown_anvil(anvil);
+
+                result
             }
 
             Self::Deregister { rpc_url, operator_private_key, dry_run } => {
@@ -100,10 +110,12 @@ impl SymbioticSubcommand {
 
                 let address = signer.address();
 
+                let (rpc, anvil) = handle_rpc_dry_run(rpc_url, dry_run)?;
+
                 let provider = ProviderBuilder::new()
                     .with_recommended_fillers()
                     .wallet(EthereumWallet::from(signer))
-                    .on_http(rpc_url);
+                    .on_http(rpc);
 
                 let chain = Chain::try_from_provider(&provider).await?;
 
@@ -116,7 +128,7 @@ impl SymbioticSubcommand {
                 let middleware =
                     BoltSymbioticMiddleware::new(deployments.bolt.symbiotic_middleware, provider);
 
-                match middleware.deregisterOperator().send().await {
+                let result = match middleware.deregisterOperator().send().await {
                     Ok(pending) => {
                         info!(
                             hash = ?pending.tx_hash(),
@@ -128,7 +140,9 @@ impl SymbioticSubcommand {
                             eyre::bail!("Transaction failed: {:?}", receipt)
                         }
 
-                        info!("Succesfully deregistered Symbiotic operator");
+                        info!("Successfully deregistered Symbiotic operator");
+
+                        Ok(())
                     }
                     Err(e) => match try_parse_contract_error::<BoltSymbioticMiddlewareErrors>(e)? {
                         BoltSymbioticMiddlewareErrors::NotRegistered(_) => {
@@ -138,20 +152,24 @@ impl SymbioticSubcommand {
                             unreachable!("Unexpected error with selector {:?}", other.selector())
                         }
                     },
-                }
+                };
 
-                Ok(())
+                shutdown_anvil(anvil);
+
+                result
             }
 
-            Self::UpdateRpc { rpc_url, operator_private_key, operator_rpc } => {
+            Self::UpdateRpc { rpc_url, operator_private_key, operator_rpc, dry_run } => {
                 let signer = PrivateKeySigner::from_bytes(&operator_private_key)
                     .wrap_err("valid private key")?;
                 let address = signer.address();
 
+                let (rpc, anvil) = handle_rpc_dry_run(rpc_url, dry_run)?;
+
                 let provider = ProviderBuilder::new()
                     .with_recommended_fillers()
                     .wallet(EthereumWallet::from(signer))
-                    .on_http(rpc_url);
+                    .on_http(rpc);
 
                 let chain = Chain::try_from_provider(&provider).await?;
 
@@ -167,10 +185,14 @@ impl SymbioticSubcommand {
                     info!(?address, "Symbiotic operator is registered");
                 } else {
                     warn!(?address, "Operator not registered");
-                    return Ok(())
+                    return Ok(());
                 }
 
-                match bolt_manager.updateOperatorRPC(operator_rpc.to_string()).send().await {
+                let result = match bolt_manager
+                    .updateOperatorRPC(operator_rpc.to_string())
+                    .send()
+                    .await
+                {
                     Ok(pending) => {
                         info!(
                             hash = ?pending.tx_hash(),
@@ -182,7 +204,9 @@ impl SymbioticSubcommand {
                             eyre::bail!("Transaction failed: {:?}", receipt)
                         }
 
-                        info!("Succesfully updated Symbiotic operator RPC");
+                        info!("Successfully updated Symbiotic operator RPC");
+
+                        Ok(())
                     }
                     Err(e) => match try_parse_contract_error::<BoltManagerContractErrors>(e)? {
                         BoltManagerContractErrors::OperatorNotRegistered(_) => {
@@ -192,8 +216,11 @@ impl SymbioticSubcommand {
                             unreachable!("Unexpected error with selector {:?}", other.selector())
                         }
                     },
-                }
-                Ok(())
+                };
+
+                shutdown_anvil(anvil);
+
+                result
             }
 
             Self::Status { rpc_url, address } => {
@@ -208,7 +235,7 @@ impl SymbioticSubcommand {
                     info!(?address, "Symbiotic operator is registered");
                 } else {
                     warn!(?address, "Operator not registered");
-                    return Ok(())
+                    return Ok(());
                 }
 
                 match bolt_manager.getOperatorData(address).call().await {
@@ -387,7 +414,7 @@ mod tests {
                     rpc_url: anvil_url.clone(),
                     operator_private_key: secret_key,
                     operator_rpc: "https://bolt.chainbound.io".parse().expect("valid url"),
-                    dry_run: true,
+                    dry_run: false,
                 },
             },
         };
@@ -413,6 +440,7 @@ mod tests {
                     operator_rpc: "https://boooooooooooooooolt.chainbound.io"
                         .parse()
                         .expect("valid url"),
+                    dry_run: false,
                 },
             },
         };
@@ -435,7 +463,7 @@ mod tests {
                 subcommand: SymbioticSubcommand::Deregister {
                     rpc_url: anvil_url.clone(),
                     operator_private_key: secret_key,
-                    dry_run: true,
+                    dry_run: false,
                 },
             },
         };

--- a/bolt-cli/src/commands/validators.rs
+++ b/bolt-cli/src/commands/validators.rs
@@ -9,7 +9,8 @@ use tracing::{info, warn};
 use crate::{
     cli::{Chain, ValidatorsCommand, ValidatorsSubcommand},
     common::{
-        handle_dry_run, hash::compress_bls_pubkey, request_confirmation, try_parse_contract_error,
+        handle_rpc_dry_run, hash::compress_bls_pubkey, request_confirmation, shutdown_anvil,
+        try_parse_contract_error,
     },
     contracts::{
         bolt::BoltValidators::{self, BoltValidatorsErrors},
@@ -31,8 +32,7 @@ impl ValidatorsCommand {
                 let signer = PrivateKeySigner::from_bytes(&admin_private_key)
                     .wrap_err("valid private key")?;
 
-                // let rpc = handle_dry_run(rpc_url, dry_run)?;
-                let (rpc, anvil) = handle_dry_run(rpc_url, dry_run)?;
+                let (rpc, anvil) = handle_rpc_dry_run(rpc_url, dry_run)?;
 
                 let provider = ProviderBuilder::new()
                     .with_recommended_fillers()
@@ -103,11 +103,7 @@ impl ValidatorsCommand {
                     }
                 };
 
-                // drop the Anvil instance to control resource consumption
-                if let Some(anvil_instance) = anvil {
-                    info!("[dry-run] Shutting down Anvil instance.");
-                    drop(anvil_instance);
-                }
+                shutdown_anvil(anvil);
 
                 result
             }
@@ -196,7 +192,7 @@ mod tests {
                 authorized_operator: account,
                 pubkeys_path: "./test_data/pubkeys.json".parse().unwrap(),
                 rpc_url: anvil_url.clone(),
-                dry_run: true,
+                dry_run: false,
             },
         };
 

--- a/bolt-cli/src/commands/validators.rs
+++ b/bolt-cli/src/commands/validators.rs
@@ -8,7 +8,9 @@ use tracing::{info, warn};
 
 use crate::{
     cli::{Chain, ValidatorsCommand, ValidatorsSubcommand},
-    common::{hash::compress_bls_pubkey, request_confirmation, try_parse_contract_error},
+    common::{
+        handle_dry_run, hash::compress_bls_pubkey, request_confirmation, try_parse_contract_error,
+    },
     contracts::{
         bolt::BoltValidators::{self, BoltValidatorsErrors},
         deployments_for_chain,
@@ -24,14 +26,18 @@ impl ValidatorsCommand {
                 admin_private_key,
                 authorized_operator,
                 rpc_url,
+                dry_run,
             } => {
                 let signer = PrivateKeySigner::from_bytes(&admin_private_key)
                     .wrap_err("valid private key")?;
 
+                // let rpc = handle_dry_run(rpc_url, dry_run)?;
+                let (rpc, anvil) = handle_dry_run(rpc_url, dry_run)?;
+
                 let provider = ProviderBuilder::new()
                     .with_recommended_fillers()
                     .wallet(EthereumWallet::from(signer))
-                    .on_http(rpc_url);
+                    .on_http(rpc);
 
                 let chain = Chain::try_from_provider(&provider).await?;
 
@@ -54,7 +60,7 @@ impl ValidatorsCommand {
 
                 request_confirmation();
 
-                match bolt_validators
+                let result = match bolt_validators
                     .batchRegisterValidatorsUnsafe(
                         pubkey_hashes,
                         max_committed_gas_limit,
@@ -74,6 +80,7 @@ impl ValidatorsCommand {
                         }
 
                         info!("Successfully registered validators into bolt");
+                        Ok(())
                     }
                     Err(e) => {
                         let decoded = try_parse_contract_error::<BoltValidatorsErrors>(e)?;
@@ -94,9 +101,15 @@ impl ValidatorsCommand {
                             ),
                         }
                     }
+                };
+
+                // drop the Anvil instance to control resource consumption
+                if let Some(anvil_instance) = anvil {
+                    info!("[dry-run] Shutting down Anvil instance.");
+                    drop(anvil_instance);
                 }
 
-                Ok(())
+                result
             }
 
             ValidatorsSubcommand::Status { rpc_url, pubkeys_path, pubkeys } => {
@@ -183,6 +196,7 @@ mod tests {
                 authorized_operator: account,
                 pubkeys_path: "./test_data/pubkeys.json".parse().unwrap(),
                 rpc_url: anvil_url.clone(),
+                dry_run: true,
             },
         };
 

--- a/bolt-cli/src/common/mod.rs
+++ b/bolt-cli/src/common/mod.rs
@@ -143,9 +143,9 @@ pub fn request_confirmation() {
         })
 }
 
-/// Determines the RPC URL to use. If `dry_run` is enabled, it spawns an `Anvil` instance and returns
-/// its endpoint. Otherwise, returns the original `rpc_url`.
-pub(crate) fn handle_dry_run(
+/// Determines the RPC URL to use. If `dry_run` is enabled, it spawns an `Anvil` instance and
+/// returns its endpoint. Otherwise, returns the original `rpc_url`.
+pub(crate) fn handle_rpc_dry_run(
     rpc_url: Url,
     dry_run: bool,
 ) -> eyre::Result<(Url, Option<AnvilInstance>)> {
@@ -162,4 +162,12 @@ pub(crate) fn handle_dry_run(
     info!("[dry-run] Anvil endpoint URL: {}", anvil_url);
 
     Ok((anvil_url, Some(anvil)))
+}
+
+/// drop provided `AnvilInstance` to control resource consumption
+pub fn shutdown_anvil(anvil: Option<AnvilInstance>) {
+    if let Some(anvil_instance) = anvil {
+        info!("[dry-run] Shutting down Anvil instance.");
+        drop(anvil_instance);
+    }
 }

--- a/bolt-cli/src/common/mod.rs
+++ b/bolt-cli/src/common/mod.rs
@@ -3,6 +3,7 @@ use std::{fs, path::PathBuf, str::FromStr};
 use alloy::{
     contract::Error as ContractError,
     dyn_abi::DynSolType,
+    node_bindings::{Anvil, AnvilInstance},
     primitives::{Bytes, U256},
     sol_types::SolInterface,
     transports::TransportError,
@@ -10,6 +11,7 @@ use alloy::{
 use ethereum_consensus::crypto::PublicKey as BlsPublicKey;
 use eyre::{Context, ContextCompat, Result};
 use inquire::{error::InquireError, Confirm};
+use reqwest::Url;
 use serde::Serialize;
 use tracing::{error, info};
 
@@ -131,12 +133,33 @@ pub fn request_confirmation() {
                 std::process::exit(0);
             }
             InquireError::OperationInterrupted => {
-	       // Triggered a SIGINT via Ctrl-C
-	       std::process::exit(130);     
+                // Triggered a SIGINT via Ctrl-C
+                std::process::exit(130);
             }
             _ => {
                 error!("aborting due to unexpected error: {}", err);
                 std::process::exit(1);
             }
         })
+}
+
+/// Determines the RPC URL to use. If `dry_run` is enabled, it spawns an `Anvil` instance and returns
+/// its endpoint. Otherwise, returns the original `rpc_url`.
+pub(crate) fn handle_dry_run(
+    rpc_url: Url,
+    dry_run: bool,
+) -> eyre::Result<(Url, Option<AnvilInstance>)> {
+    if !dry_run {
+        return Ok((rpc_url, None));
+    }
+
+    let anvil = Anvil::new()
+        .fork(rpc_url)
+        .try_spawn()
+        .map_err(|e| eyre::eyre!("[dry-run] Failed to spawn Anvil: {}", e))?;
+
+    let anvil_url = anvil.endpoint_url();
+    info!("[dry-run] Anvil endpoint URL: {}", anvil_url);
+
+    Ok((anvil_url, Some(anvil)))
 }

--- a/bolt-cli/src/pb/v1.rs
+++ b/bolt-cli/src/pb/v1.rs
@@ -89,10 +89,9 @@ pub mod lister_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
-    use tonic::codegen::*;
-    use tonic::codegen::http::Uri;
+    use tonic::codegen::{http::Uri, *};
     #[derive(Debug, Clone)]
     pub struct ListerClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -136,9 +135,8 @@ pub mod lister_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             ListerClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -176,18 +174,11 @@ pub mod lister_client {
         pub async fn list_accounts(
             &mut self,
             request: impl tonic::IntoRequest<super::ListAccountsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ListAccountsResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::ListAccountsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/v1.Lister/ListAccounts");
             let mut req = request.into_request();
@@ -203,19 +194,17 @@ pub mod lister_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
     use tonic::codegen::*;
-    /// Generated trait containing gRPC methods that should be implemented for use with ListerServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with
+    /// ListerServer.
     #[async_trait]
     pub trait Lister: std::marker::Send + std::marker::Sync + 'static {
         async fn list_accounts(
             &self,
             request: tonic::Request<super::ListAccountsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ListAccountsResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::ListAccountsResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct ListerServer<T> {
@@ -238,10 +227,7 @@ pub mod lister_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -296,23 +282,16 @@ pub mod lister_server {
                 "/v1.Lister/ListAccounts" => {
                     #[allow(non_camel_case_types)]
                     struct ListAccountsSvc<T: Lister>(pub Arc<T>);
-                    impl<
-                        T: Lister,
-                    > tonic::server::UnaryService<super::ListAccountsRequest>
-                    for ListAccountsSvc<T> {
+                    impl<T: Lister> tonic::server::UnaryService<super::ListAccountsRequest> for ListAccountsSvc<T> {
                         type Response = super::ListAccountsResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ListAccountsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as Lister>::list_accounts(&inner, request).await
-                            };
+                            let fut =
+                                async move { <T as Lister>::list_accounts(&inner, request).await };
                             Box::pin(fut)
                         }
                     }
@@ -338,23 +317,16 @@ pub mod lister_server {
                     };
                     Box::pin(fut)
                 }
-                _ => {
-                    Box::pin(async move {
-                        let mut response = http::Response::new(empty_body());
-                        let headers = response.headers_mut();
-                        headers
-                            .insert(
-                                tonic::Status::GRPC_STATUS,
-                                (tonic::Code::Unimplemented as i32).into(),
-                            );
-                        headers
-                            .insert(
-                                http::header::CONTENT_TYPE,
-                                tonic::metadata::GRPC_CONTENT_TYPE,
-                            );
-                        Ok(response)
-                    })
-                }
+                _ => Box::pin(async move {
+                    let mut response = http::Response::new(empty_body());
+                    let headers = response.headers_mut();
+                    headers.insert(
+                        tonic::Status::GRPC_STATUS,
+                        (tonic::Code::Unimplemented as i32).into(),
+                    );
+                    headers.insert(http::header::CONTENT_TYPE, tonic::metadata::GRPC_CONTENT_TYPE);
+                    Ok(response)
+                }),
             }
         }
     }
@@ -498,10 +470,9 @@ pub mod signer_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
-    use tonic::codegen::*;
-    use tonic::codegen::http::Uri;
+    use tonic::codegen::{http::Uri, *};
     #[derive(Debug, Clone)]
     pub struct SignerClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -545,9 +516,8 @@ pub mod signer_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             SignerClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -586,14 +556,9 @@ pub mod signer_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SignRequest>,
         ) -> std::result::Result<tonic::Response<super::SignResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/v1.Signer/Sign");
             let mut req = request.into_request();
@@ -603,18 +568,10 @@ pub mod signer_client {
         pub async fn multisign(
             &mut self,
             request: impl tonic::IntoRequest<super::MultisignRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::MultisignResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::MultisignResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/v1.Signer/Multisign");
             let mut req = request.into_request();
@@ -625,66 +582,39 @@ pub mod signer_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SignBeaconAttestationRequest>,
         ) -> std::result::Result<tonic::Response<super::SignResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/v1.Signer/SignBeaconAttestation",
-            );
+            let path = http::uri::PathAndQuery::from_static("/v1.Signer/SignBeaconAttestation");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("v1.Signer", "SignBeaconAttestation"));
+            req.extensions_mut().insert(GrpcMethod::new("v1.Signer", "SignBeaconAttestation"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn sign_beacon_attestations(
             &mut self,
             request: impl tonic::IntoRequest<super::SignBeaconAttestationsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::MultisignResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::MultisignResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/v1.Signer/SignBeaconAttestations",
-            );
+            let path = http::uri::PathAndQuery::from_static("/v1.Signer/SignBeaconAttestations");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("v1.Signer", "SignBeaconAttestations"));
+            req.extensions_mut().insert(GrpcMethod::new("v1.Signer", "SignBeaconAttestations"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn sign_beacon_proposal(
             &mut self,
             request: impl tonic::IntoRequest<super::SignBeaconProposalRequest>,
         ) -> std::result::Result<tonic::Response<super::SignResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/v1.Signer/SignBeaconProposal",
-            );
+            let path = http::uri::PathAndQuery::from_static("/v1.Signer/SignBeaconProposal");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("v1.Signer", "SignBeaconProposal"));
+            req.extensions_mut().insert(GrpcMethod::new("v1.Signer", "SignBeaconProposal"));
             self.inner.unary(req, path, codec).await
         }
     }
@@ -696,10 +626,11 @@ pub mod signer_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
     use tonic::codegen::*;
-    /// Generated trait containing gRPC methods that should be implemented for use with SignerServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with
+    /// SignerServer.
     #[async_trait]
     pub trait Signer: std::marker::Send + std::marker::Sync + 'static {
         async fn sign(
@@ -709,10 +640,7 @@ pub mod signer_server {
         async fn multisign(
             &self,
             request: tonic::Request<super::MultisignRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::MultisignResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::MultisignResponse>, tonic::Status>;
         async fn sign_beacon_attestation(
             &self,
             request: tonic::Request<super::SignBeaconAttestationRequest>,
@@ -720,10 +648,7 @@ pub mod signer_server {
         async fn sign_beacon_attestations(
             &self,
             request: tonic::Request<super::SignBeaconAttestationsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::MultisignResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::MultisignResponse>, tonic::Status>;
         async fn sign_beacon_proposal(
             &self,
             request: tonic::Request<super::SignBeaconProposalRequest>,
@@ -750,10 +675,7 @@ pub mod signer_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -808,21 +730,15 @@ pub mod signer_server {
                 "/v1.Signer/Sign" => {
                     #[allow(non_camel_case_types)]
                     struct SignSvc<T: Signer>(pub Arc<T>);
-                    impl<T: Signer> tonic::server::UnaryService<super::SignRequest>
-                    for SignSvc<T> {
+                    impl<T: Signer> tonic::server::UnaryService<super::SignRequest> for SignSvc<T> {
                         type Response = super::SignResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SignRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as Signer>::sign(&inner, request).await
-                            };
+                            let fut = async move { <T as Signer>::sign(&inner, request).await };
                             Box::pin(fut)
                         }
                     }
@@ -851,21 +767,16 @@ pub mod signer_server {
                 "/v1.Signer/Multisign" => {
                     #[allow(non_camel_case_types)]
                     struct MultisignSvc<T: Signer>(pub Arc<T>);
-                    impl<T: Signer> tonic::server::UnaryService<super::MultisignRequest>
-                    for MultisignSvc<T> {
+                    impl<T: Signer> tonic::server::UnaryService<super::MultisignRequest> for MultisignSvc<T> {
                         type Response = super::MultisignResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::MultisignRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as Signer>::multisign(&inner, request).await
-                            };
+                            let fut =
+                                async move { <T as Signer>::multisign(&inner, request).await };
                             Box::pin(fut)
                         }
                     }
@@ -894,23 +805,18 @@ pub mod signer_server {
                 "/v1.Signer/SignBeaconAttestation" => {
                     #[allow(non_camel_case_types)]
                     struct SignBeaconAttestationSvc<T: Signer>(pub Arc<T>);
-                    impl<
-                        T: Signer,
-                    > tonic::server::UnaryService<super::SignBeaconAttestationRequest>
-                    for SignBeaconAttestationSvc<T> {
+                    impl<T: Signer> tonic::server::UnaryService<super::SignBeaconAttestationRequest>
+                        for SignBeaconAttestationSvc<T>
+                    {
                         type Response = super::SignResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SignBeaconAttestationRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as Signer>::sign_beacon_attestation(&inner, request)
-                                    .await
+                                <T as Signer>::sign_beacon_attestation(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -940,23 +846,19 @@ pub mod signer_server {
                 "/v1.Signer/SignBeaconAttestations" => {
                     #[allow(non_camel_case_types)]
                     struct SignBeaconAttestationsSvc<T: Signer>(pub Arc<T>);
-                    impl<
-                        T: Signer,
-                    > tonic::server::UnaryService<super::SignBeaconAttestationsRequest>
-                    for SignBeaconAttestationsSvc<T> {
+                    impl<T: Signer>
+                        tonic::server::UnaryService<super::SignBeaconAttestationsRequest>
+                        for SignBeaconAttestationsSvc<T>
+                    {
                         type Response = super::MultisignResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SignBeaconAttestationsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as Signer>::sign_beacon_attestations(&inner, request)
-                                    .await
+                                <T as Signer>::sign_beacon_attestations(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -986,15 +888,11 @@ pub mod signer_server {
                 "/v1.Signer/SignBeaconProposal" => {
                     #[allow(non_camel_case_types)]
                     struct SignBeaconProposalSvc<T: Signer>(pub Arc<T>);
-                    impl<
-                        T: Signer,
-                    > tonic::server::UnaryService<super::SignBeaconProposalRequest>
-                    for SignBeaconProposalSvc<T> {
+                    impl<T: Signer> tonic::server::UnaryService<super::SignBeaconProposalRequest>
+                        for SignBeaconProposalSvc<T>
+                    {
                         type Response = super::SignResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SignBeaconProposalRequest>,
@@ -1028,23 +926,16 @@ pub mod signer_server {
                     };
                     Box::pin(fut)
                 }
-                _ => {
-                    Box::pin(async move {
-                        let mut response = http::Response::new(empty_body());
-                        let headers = response.headers_mut();
-                        headers
-                            .insert(
-                                tonic::Status::GRPC_STATUS,
-                                (tonic::Code::Unimplemented as i32).into(),
-                            );
-                        headers
-                            .insert(
-                                http::header::CONTENT_TYPE,
-                                tonic::metadata::GRPC_CONTENT_TYPE,
-                            );
-                        Ok(response)
-                    })
-                }
+                _ => Box::pin(async move {
+                    let mut response = http::Response::new(empty_body());
+                    let headers = response.headers_mut();
+                    headers.insert(
+                        tonic::Status::GRPC_STATUS,
+                        (tonic::Code::Unimplemented as i32).into(),
+                    );
+                    headers.insert(http::header::CONTENT_TYPE, tonic::metadata::GRPC_CONTENT_TYPE);
+                    Ok(response)
+                }),
             }
         }
     }
@@ -1117,10 +1008,9 @@ pub mod account_manager_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
-    use tonic::codegen::*;
-    use tonic::codegen::http::Uri;
+    use tonic::codegen::{http::Uri, *};
     #[derive(Debug, Clone)]
     pub struct AccountManagerClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -1164,9 +1054,8 @@ pub mod account_manager_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             AccountManagerClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -1204,18 +1093,11 @@ pub mod account_manager_client {
         pub async fn unlock(
             &mut self,
             request: impl tonic::IntoRequest<super::UnlockAccountRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::UnlockAccountResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::UnlockAccountResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/v1.AccountManager/Unlock");
             let mut req = request.into_request();
@@ -1225,18 +1107,11 @@ pub mod account_manager_client {
         pub async fn lock(
             &mut self,
             request: impl tonic::IntoRequest<super::LockAccountRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::LockAccountResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::LockAccountResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/v1.AccountManager/Lock");
             let mut req = request.into_request();
@@ -1246,25 +1121,14 @@ pub mod account_manager_client {
         pub async fn generate(
             &mut self,
             request: impl tonic::IntoRequest<super::GenerateRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GenerateResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::GenerateResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/v1.AccountManager/Generate",
-            );
+            let path = http::uri::PathAndQuery::from_static("/v1.AccountManager/Generate");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("v1.AccountManager", "Generate"));
+            req.extensions_mut().insert(GrpcMethod::new("v1.AccountManager", "Generate"));
             self.inner.unary(req, path, codec).await
         }
     }
@@ -1276,33 +1140,25 @@ pub mod account_manager_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
     use tonic::codegen::*;
-    /// Generated trait containing gRPC methods that should be implemented for use with AccountManagerServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with
+    /// AccountManagerServer.
     #[async_trait]
     pub trait AccountManager: std::marker::Send + std::marker::Sync + 'static {
         async fn unlock(
             &self,
             request: tonic::Request<super::UnlockAccountRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::UnlockAccountResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::UnlockAccountResponse>, tonic::Status>;
         async fn lock(
             &self,
             request: tonic::Request<super::LockAccountRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::LockAccountResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::LockAccountResponse>, tonic::Status>;
         async fn generate(
             &self,
             request: tonic::Request<super::GenerateRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GenerateResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::GenerateResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct AccountManagerServer<T> {
@@ -1325,10 +1181,7 @@ pub mod account_manager_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -1383,23 +1236,16 @@ pub mod account_manager_server {
                 "/v1.AccountManager/Unlock" => {
                     #[allow(non_camel_case_types)]
                     struct UnlockSvc<T: AccountManager>(pub Arc<T>);
-                    impl<
-                        T: AccountManager,
-                    > tonic::server::UnaryService<super::UnlockAccountRequest>
-                    for UnlockSvc<T> {
+                    impl<T: AccountManager> tonic::server::UnaryService<super::UnlockAccountRequest> for UnlockSvc<T> {
                         type Response = super::UnlockAccountResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::UnlockAccountRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as AccountManager>::unlock(&inner, request).await
-                            };
+                            let fut =
+                                async move { <T as AccountManager>::unlock(&inner, request).await };
                             Box::pin(fut)
                         }
                     }
@@ -1428,23 +1274,16 @@ pub mod account_manager_server {
                 "/v1.AccountManager/Lock" => {
                     #[allow(non_camel_case_types)]
                     struct LockSvc<T: AccountManager>(pub Arc<T>);
-                    impl<
-                        T: AccountManager,
-                    > tonic::server::UnaryService<super::LockAccountRequest>
-                    for LockSvc<T> {
+                    impl<T: AccountManager> tonic::server::UnaryService<super::LockAccountRequest> for LockSvc<T> {
                         type Response = super::LockAccountResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::LockAccountRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as AccountManager>::lock(&inner, request).await
-                            };
+                            let fut =
+                                async move { <T as AccountManager>::lock(&inner, request).await };
                             Box::pin(fut)
                         }
                     }
@@ -1473,15 +1312,9 @@ pub mod account_manager_server {
                 "/v1.AccountManager/Generate" => {
                     #[allow(non_camel_case_types)]
                     struct GenerateSvc<T: AccountManager>(pub Arc<T>);
-                    impl<
-                        T: AccountManager,
-                    > tonic::server::UnaryService<super::GenerateRequest>
-                    for GenerateSvc<T> {
+                    impl<T: AccountManager> tonic::server::UnaryService<super::GenerateRequest> for GenerateSvc<T> {
                         type Response = super::GenerateResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GenerateRequest>,
@@ -1515,23 +1348,16 @@ pub mod account_manager_server {
                     };
                     Box::pin(fut)
                 }
-                _ => {
-                    Box::pin(async move {
-                        let mut response = http::Response::new(empty_body());
-                        let headers = response.headers_mut();
-                        headers
-                            .insert(
-                                tonic::Status::GRPC_STATUS,
-                                (tonic::Code::Unimplemented as i32).into(),
-                            );
-                        headers
-                            .insert(
-                                http::header::CONTENT_TYPE,
-                                tonic::metadata::GRPC_CONTENT_TYPE,
-                            );
-                        Ok(response)
-                    })
-                }
+                _ => Box::pin(async move {
+                    let mut response = http::Response::new(empty_body());
+                    let headers = response.headers_mut();
+                    headers.insert(
+                        tonic::Status::GRPC_STATUS,
+                        (tonic::Code::Unimplemented as i32).into(),
+                    );
+                    headers.insert(http::header::CONTENT_TYPE, tonic::metadata::GRPC_CONTENT_TYPE);
+                    Ok(response)
+                }),
             }
         }
     }
@@ -1582,10 +1408,9 @@ pub mod wallet_manager_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
-    use tonic::codegen::*;
-    use tonic::codegen::http::Uri;
+    use tonic::codegen::{http::Uri, *};
     #[derive(Debug, Clone)]
     pub struct WalletManagerClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -1629,9 +1454,8 @@ pub mod wallet_manager_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             WalletManagerClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -1669,18 +1493,11 @@ pub mod wallet_manager_client {
         pub async fn unlock(
             &mut self,
             request: impl tonic::IntoRequest<super::UnlockWalletRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::UnlockWalletResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::UnlockWalletResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/v1.WalletManager/Unlock");
             let mut req = request.into_request();
@@ -1690,18 +1507,11 @@ pub mod wallet_manager_client {
         pub async fn lock(
             &mut self,
             request: impl tonic::IntoRequest<super::LockWalletRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::LockWalletResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::LockWalletResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/v1.WalletManager/Lock");
             let mut req = request.into_request();
@@ -1717,26 +1527,21 @@ pub mod wallet_manager_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
     use tonic::codegen::*;
-    /// Generated trait containing gRPC methods that should be implemented for use with WalletManagerServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with
+    /// WalletManagerServer.
     #[async_trait]
     pub trait WalletManager: std::marker::Send + std::marker::Sync + 'static {
         async fn unlock(
             &self,
             request: tonic::Request<super::UnlockWalletRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::UnlockWalletResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::UnlockWalletResponse>, tonic::Status>;
         async fn lock(
             &self,
             request: tonic::Request<super::LockWalletRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::LockWalletResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::LockWalletResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct WalletManagerServer<T> {
@@ -1759,10 +1564,7 @@ pub mod wallet_manager_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -1817,23 +1619,16 @@ pub mod wallet_manager_server {
                 "/v1.WalletManager/Unlock" => {
                     #[allow(non_camel_case_types)]
                     struct UnlockSvc<T: WalletManager>(pub Arc<T>);
-                    impl<
-                        T: WalletManager,
-                    > tonic::server::UnaryService<super::UnlockWalletRequest>
-                    for UnlockSvc<T> {
+                    impl<T: WalletManager> tonic::server::UnaryService<super::UnlockWalletRequest> for UnlockSvc<T> {
                         type Response = super::UnlockWalletResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::UnlockWalletRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as WalletManager>::unlock(&inner, request).await
-                            };
+                            let fut =
+                                async move { <T as WalletManager>::unlock(&inner, request).await };
                             Box::pin(fut)
                         }
                     }
@@ -1862,23 +1657,16 @@ pub mod wallet_manager_server {
                 "/v1.WalletManager/Lock" => {
                     #[allow(non_camel_case_types)]
                     struct LockSvc<T: WalletManager>(pub Arc<T>);
-                    impl<
-                        T: WalletManager,
-                    > tonic::server::UnaryService<super::LockWalletRequest>
-                    for LockSvc<T> {
+                    impl<T: WalletManager> tonic::server::UnaryService<super::LockWalletRequest> for LockSvc<T> {
                         type Response = super::LockWalletResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::LockWalletRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as WalletManager>::lock(&inner, request).await
-                            };
+                            let fut =
+                                async move { <T as WalletManager>::lock(&inner, request).await };
                             Box::pin(fut)
                         }
                     }
@@ -1904,23 +1692,16 @@ pub mod wallet_manager_server {
                     };
                     Box::pin(fut)
                 }
-                _ => {
-                    Box::pin(async move {
-                        let mut response = http::Response::new(empty_body());
-                        let headers = response.headers_mut();
-                        headers
-                            .insert(
-                                tonic::Status::GRPC_STATUS,
-                                (tonic::Code::Unimplemented as i32).into(),
-                            );
-                        headers
-                            .insert(
-                                http::header::CONTENT_TYPE,
-                                tonic::metadata::GRPC_CONTENT_TYPE,
-                            );
-                        Ok(response)
-                    })
-                }
+                _ => Box::pin(async move {
+                    let mut response = http::Response::new(empty_body());
+                    let headers = response.headers_mut();
+                    headers.insert(
+                        tonic::Status::GRPC_STATUS,
+                        (tonic::Code::Unimplemented as i32).into(),
+                    );
+                    headers.insert(http::header::CONTENT_TYPE, tonic::metadata::GRPC_CONTENT_TYPE);
+                    Ok(response)
+                }),
             }
         }
     }

--- a/bolt-contracts/script/holesky/admin/Deploy.s.sol
+++ b/bolt-contracts/script/holesky/admin/Deploy.s.sol
@@ -18,6 +18,8 @@ import {BoltSymbioticMiddlewareV1} from "../../../src/contracts/BoltSymbioticMid
 import {BoltConfig} from "../../../src/lib/BoltConfig.sol";
 
 /// @notice Script to deploy the Bolt contracts.
+/// Run: forge script script/holesky/admin/Deploy.s.sol --rpc-url $RPC_HOLESKY --private-key $NETWORK_PRIVATE_KEY --force -vvvv
+/// Run with Broadcast: forge script script/holesky/admin/Deploy.s.sol --rpc-url $RPC_HOLESKY --private-key $NETWORK_PRIVATE_KEY --broadcast --verify -vvvv 
 contract DeployBolt is Script {
     function run() public {
         // The admin address will be authorized to call the adminOnly functions
@@ -94,7 +96,7 @@ contract DeployBolt is Script {
             Upgrades.deployUUPSProxy("BoltSymbioticMiddlewareV1.sol", initSymbioticMiddleware, opts);
         console.log("BoltSymbioticMiddlewareV1 proxy deployed at", address(symbioticMiddlewareProxy));
 
-        console.log("Core contracts deployed succesfully, whitelisting middleware contracts in BoltManager...");
+        console.log("Core contracts deployed successfully, whitelisting middleware contracts in BoltManager...");
         console.log("EigenLayer middleware:", address(eigenLayerMiddlewareProxy));
         console.log("Symbiotic middleware:", address(symbioticMiddlewareProxy));
         BoltManagerV1(managerProxy).addRestakingProtocol(address(eigenLayerMiddlewareProxy));

--- a/bolt-contracts/script/holesky/admin/Deploy.s.sol
+++ b/bolt-contracts/script/holesky/admin/Deploy.s.sol
@@ -18,8 +18,6 @@ import {BoltSymbioticMiddlewareV1} from "../../../src/contracts/BoltSymbioticMid
 import {BoltConfig} from "../../../src/lib/BoltConfig.sol";
 
 /// @notice Script to deploy the Bolt contracts.
-/// Run: forge script script/holesky/admin/Deploy.s.sol --rpc-url $RPC_HOLESKY --private-key $NETWORK_PRIVATE_KEY --force -vvvv
-/// Run with Broadcast: forge script script/holesky/admin/Deploy.s.sol --rpc-url $RPC_HOLESKY --private-key $NETWORK_PRIVATE_KEY --broadcast --verify -vvvv 
 contract DeployBolt is Script {
     function run() public {
         // The admin address will be authorized to call the adminOnly functions


### PR DESCRIPTION
### Improvements:
- Add -d, --dry-run flag for bolt-cli: When provided commands will "simulate" actual behavior, for instance when making RPC calls or executing smart contracts without broadcasting on net. 
 - Spin Anvil instance for use cases like testing (we can get rid of explicit declaration in test):
 https://github.com/chainbound/bolt/blob/6342fb2ba6dfafbdf518f0c4d32295fca9e8188c/bolt-cli/src/commands/validators.rs#L165-L171

Closes #416 