### PR TITLE
chore(bolt-boost): pin git dep with tag

### DIFF
--- a/bolt-boost/Cargo.lock
+++ b/bolt-boost/Cargo.lock
@@ -1343,7 +1343,7 @@ dependencies = [
 [[package]]
 name = "cb-common"
 version = "0.5.0"
-source = "git+https://github.com/commit-boost/commit-boost-client?rev=v0.5.0#704e9f19719211acfd1697fb8a083c2897aea1a9"
+source = "git+https://github.com/commit-boost/commit-boost-client?tag=v0.5.0#704e9f19719211acfd1697fb8a083c2897aea1a9"
 dependencies = [
  "aes 0.8.4",
  "alloy",
@@ -1381,7 +1381,7 @@ dependencies = [
 [[package]]
 name = "cb-metrics"
 version = "0.5.0"
-source = "git+https://github.com/commit-boost/commit-boost-client?rev=v0.5.0#704e9f19719211acfd1697fb8a083c2897aea1a9"
+source = "git+https://github.com/commit-boost/commit-boost-client?tag=v0.5.0#704e9f19719211acfd1697fb8a083c2897aea1a9"
 dependencies = [
  "axum 0.7.9",
  "cb-common",
@@ -1395,7 +1395,7 @@ dependencies = [
 [[package]]
 name = "cb-pbs"
 version = "0.5.0"
-source = "git+https://github.com/commit-boost/commit-boost-client?rev=v0.5.0#704e9f19719211acfd1697fb8a083c2897aea1a9"
+source = "git+https://github.com/commit-boost/commit-boost-client?tag=v0.5.0#704e9f19719211acfd1697fb8a083c2897aea1a9"
 dependencies = [
  "alloy",
  "async-trait",

--- a/bolt-boost/Cargo.toml
+++ b/bolt-boost/Cargo.toml
@@ -42,8 +42,8 @@ alloy = { version = "0.8.3", features = ["signer-local", "provider-trace-api", "
 alloy-rlp = "0.3.11"
 
 # commit-boost
-cb-common = { git = "https://github.com/commit-boost/commit-boost-client", rev = "v0.5.0" }
-cb-pbs = { git = "https://github.com/commit-boost/commit-boost-client", rev = "v0.5.0" }
+cb-common = { git = "https://github.com/commit-boost/commit-boost-client", tag = "v0.5.0" }
+cb-pbs = { git = "https://github.com/commit-boost/commit-boost-client", tag = "v0.5.0" }
 
 # other
 rand = "0.8.5"


### PR DESCRIPTION
> Anything that is not a branch or a tag falls under rev key.
https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#choice-of-commit

`rev` is more catch-all git reference, `tag` is more clear