### PR TITLE
feat: track balance increases in state diffs

### DIFF
--- a/bolt-sidecar/src/api/commitments/server/mod.rs
+++ b/bolt-sidecar/src/api/commitments/server/mod.rs
@@ -206,7 +206,7 @@ mod test {
         let sk = SecretKey::random(&mut rand::thread_rng());
         let signer = PrivateKeySigner::from(sk.clone());
         let tx = default_test_transaction(signer.address(), None);
-        let req = create_signed_inclusion_request(&[tx], &sk, 12).await.unwrap();
+        let req = create_signed_inclusion_request(&[tx], &sk.to_bytes(), 12).await.unwrap();
 
         let payload = json!({
             "jsonrpc": "2.0",
@@ -249,7 +249,7 @@ mod test {
         let sk = SecretKey::random(&mut rand::thread_rng());
         let signer = PrivateKeySigner::from(sk.clone());
         let tx = default_test_transaction(signer.address(), None);
-        let req = create_signed_inclusion_request(&[tx], &sk, 12).await.unwrap();
+        let req = create_signed_inclusion_request(&[tx], &sk.to_bytes(), 12).await.unwrap();
 
         let sig = req.signature.unwrap().to_hex();
 

--- a/bolt-sidecar/src/chain_io/utils.rs
+++ b/bolt-sidecar/src/chain_io/utils.rs
@@ -48,7 +48,7 @@ fn pubkey_hash_digest(key: &BlsPublicKey) -> B512 {
 ///
 /// Example usage:
 ///
-/// ```rust no_run
+/// ```rust ignore
 /// sol! {
 ///    library ErrorLib {
 ///       error SomeError(uint256 code);

--- a/bolt-sidecar/src/primitives/diffs.rs
+++ b/bolt-sidecar/src/primitives/diffs.rs
@@ -1,0 +1,98 @@
+use std::collections::HashMap;
+
+use alloy::primitives::{Address, U256};
+
+/// StateDiff tracks the intermediate changes to the state according to the block template.
+#[derive(Debug, Default)]
+pub struct StateDiff {
+    /// Map of diffs per address. Each diff is a tuple of the nonce and balance diff
+    /// that should be applied to the current state.
+    pub(crate) diffs: HashMap<Address, AccountDiff>,
+}
+
+impl StateDiff {
+    /// Returns a tuple of the nonce and balance diff for the given address.
+    /// The nonce diff should be added to the current nonce, the balance diff should be subtracted
+    /// from the current balance.
+    pub fn get_diff(&self, address: &Address) -> Option<AccountDiff> {
+        self.diffs.get(address).copied()
+    }
+}
+
+/// AccountDiff tracks the changes to an account's nonce and balance.
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct AccountDiff {
+    /// The nonce of the account.
+    nonce: u64,
+    /// The balance diff of the account.
+    balance: BalanceDiff,
+}
+
+impl AccountDiff {
+    /// Creates a new account diff with the given nonce and balance diff.
+    pub fn new(nonce: u64, balance: BalanceDiff) -> Self {
+        Self { nonce, balance }
+    }
+
+    /// Returns the nonce diff of the account.
+    pub fn nonce(&self) -> u64 {
+        self.nonce
+    }
+
+    /// Returns the balance diff of the account.
+    pub fn balance(&self) -> BalanceDiff {
+        self.balance
+    }
+}
+
+/// A balance diff is a tuple of consisting of a balance increase and a balance decrease.
+///
+/// An `increase` should be _added_ to the current balance, while a `decrease` should be _subtracted_.
+///
+/// Example:
+/// ```rs
+/// let balance = U256::from(100);
+/// let balance_diff = BalanceDiff::new(U256::from(50), U256::from(10));
+/// assert_eq!(balance_diff.apply(balance), U256::from(140));
+/// ```
+#[derive(Debug, Default, Clone, Copy, PartialEq, Eq)]
+pub struct BalanceDiff {
+    /// The balance increase.
+    increase: U256,
+    /// The balance decrease.
+    decrease: U256,
+}
+
+impl BalanceDiff {
+    /// Creates a new balance diff with the given increase and decrease.
+    pub fn new(increase: U256, decrease: U256) -> Self {
+        Self { increase, decrease }
+    }
+
+    /// Returns the increase of the balance diff.
+    pub fn increase(&self) -> U256 {
+        self.increase
+    }
+
+    /// Returns the decrease of the balance diff.
+    pub fn decrease(&self) -> U256 {
+        self.decrease
+    }
+
+    /// Applies the balance diff to the given balance.
+    pub fn apply(&self, balance: U256) -> U256 {
+        balance.saturating_add(self.increase).saturating_sub(self.decrease)
+    }
+}
+
+/// A trait for applying a balance diff to a U256 balance.
+pub trait BalanceDiffApplier {
+    /// Applies the balance diff to the given balance.
+    fn apply_diff(&self, diff: BalanceDiff) -> U256;
+}
+
+impl BalanceDiffApplier for U256 {
+    fn apply_diff(&self, diff: BalanceDiff) -> U256 {
+        self.saturating_add(diff.increase).saturating_sub(diff.decrease)
+    }
+}

--- a/bolt-sidecar/src/primitives/mod.rs
+++ b/bolt-sidecar/src/primitives/mod.rs
@@ -45,6 +45,9 @@ pub mod signature;
 /// JSON-RPC helper types and functions.
 pub mod jsonrpc;
 
+/// Types and utilties relates to calculating account diffs.
+pub mod diffs;
+
 /// An alias for a Beacon Chain slot number
 pub type Slot = u64;
 

--- a/bolt-sidecar/src/primitives/transaction.rs
+++ b/bolt-sidecar/src/primitives/transaction.rs
@@ -5,7 +5,7 @@ use alloy::{
     },
     eips::eip2718::{Decodable2718, Encodable2718},
     hex,
-    primitives::{Address, U256},
+    primitives::Address,
 };
 use reth_primitives::TransactionSigned;
 use serde::{de, ser::SerializeSeq};
@@ -14,9 +14,6 @@ use std::{borrow::Cow, fmt};
 /// Trait that exposes additional information on transaction types that don't already do it
 /// by themselves (e.g. [`PooledTransaction`]).
 pub trait TransactionExt {
-    /// Returns the value of the transaction.
-    fn value(&self) -> U256;
-
     /// Returns the blob sidecar of the transaction, if any.
     fn blob_sidecar(&self) -> Option<&BlobTransactionSidecar>;
 
@@ -25,16 +22,6 @@ pub trait TransactionExt {
 }
 
 impl TransactionExt for PooledTransaction {
-    fn value(&self) -> U256 {
-        match self {
-            Self::Legacy(transaction) => transaction.tx().value,
-            Self::Eip1559(transaction) => transaction.tx().value,
-            Self::Eip2930(transaction) => transaction.tx().value,
-            Self::Eip4844(transaction) => transaction.tx().tx().value,
-            Self::Eip7702(transaction) => transaction.tx().value,
-        }
-    }
-
     fn blob_sidecar(&self) -> Option<&BlobTransactionSidecar> {
         match self {
             Self::Eip4844(transaction) => Some(&transaction.tx().sidecar),

--- a/bolt-sidecar/src/state/execution.rs
+++ b/bolt-sidecar/src/state/execution.rs
@@ -144,7 +144,7 @@ pub struct ExecutionState<C> {
     basefee: u128,
     /// The blob basefee at the head block.
     blob_basefee: u128,
-    /// The cached account states. This should never be read directly. These only contain the
+    /// The cached account states. These only contain the
     /// canonical account states at the head block, not the intermediate states.
     ///
     /// INVARIANT: the entries are modified only when receiving a new head.

--- a/bolt-sidecar/src/test_util.rs
+++ b/bolt-sidecar/src/test_util.rs
@@ -5,11 +5,7 @@ use alloy::{
     network::{EthereumWallet, TransactionBuilder},
     primitives::{Address, U256},
     rpc::types::TransactionRequest,
-    signers::{
-        k256::{ecdsa::SigningKey as K256SigningKey, SecretKey as K256SecretKey},
-        local::PrivateKeySigner,
-        Signer,
-    },
+    signers::{k256::ecdsa::SigningKey as K256SigningKey, local::PrivateKeySigner, Signer},
 };
 use alloy_node_bindings::{Anvil, AnvilInstance};
 use blst::min_pk::SecretKey;
@@ -106,7 +102,7 @@ pub(crate) async fn get_test_config() -> Option<Opts> {
     Some(opts)
 }
 
-/// Launch a local instance of the Anvil test chain.
+/// Launch a local instance of the Anvil test chain with 1 second block time
 pub(crate) fn launch_anvil() -> AnvilInstance {
     Anvil::new().block_time(1).chain_id(1337).spawn()
 }
@@ -155,10 +151,10 @@ impl SignableECDSA for TestSignableData {
 /// from the given transaction, private key of the sender, and slot.
 pub(crate) async fn create_signed_inclusion_request(
     txs: &[TransactionRequest],
-    sk: &K256SecretKey,
+    sk: &[u8],
     slot: u64,
 ) -> eyre::Result<InclusionRequest> {
-    let sk = K256SigningKey::from_slice(sk.to_bytes().as_slice())?;
+    let sk = K256SigningKey::from_slice(sk)?;
     let signer = PrivateKeySigner::from_signing_key(sk.clone());
     let wallet = EthereumWallet::from(signer.clone());
 


### PR DESCRIPTION
This PR introduces chained preconfirmations from different users in the sidecar. Example:
- Alice sends 1 ETH to Bob which has no balance
- Bob wants to use that money without waiting for Alice transaction to be included in a block

In order to do that the state diffs logic has been slightly modified by tracking both balance increases and decreases. Some refactoring has been done to avoid opaque tuple types and improve readability. Comes with tests included.

I strongly suggest to read the PR commit by commit, where some of them carry their own description and rationale.