### PR TITLE
chore(deps): don't bump transient deps with dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -7,6 +7,7 @@ version: 2
 updates:
   - package-ecosystem: "cargo"
     directory: "/bolt-sidecar"
+    versioning-strategy: "increase"
     labels:
       - "T: security"
     schedule:
@@ -32,6 +33,7 @@ updates:
 
   - package-ecosystem: "cargo"
     directory: "/bolt-cli"
+    versioning-strategy: "increase"
     labels:
       - "T: security"
     schedule:
@@ -57,6 +59,7 @@ updates:
 
   - package-ecosystem: "cargo"
     directory: "/bolt-boost"
+    versioning-strategy: "increase"
     labels:
       - "T: security"
     schedule:


### PR DESCRIPTION
We don't want https://github.com/chainbound/bolt/pull/728

Not 100% sure, but think this will work.

> For apps, always increase the minimum version requirement to match the new version. The increase strategy.
https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#versioning-strategy--