### PR TITLE
chore: remove all reth types

### DIFF
--- a/bolt-sidecar/src/builder/fallback/engine_hinter.rs
+++ b/bolt-sidecar/src/builder/fallback/engine_hinter.rs
@@ -1,18 +1,17 @@
 use std::ops::Deref;
 
 use alloy::{
-    consensus::{transaction::PooledTransaction, Header, EMPTY_OMMER_ROOT_HASH},
+    consensus::{transaction::PooledTransaction, Block, BlockBody, Header, EMPTY_OMMER_ROOT_HASH},
     primitives::{Address, Bloom, Bytes, B256, B64, U256},
-    rpc::types::{Block, Withdrawal, Withdrawals},
+    rpc::types::{Block as RpcBlock, Withdrawal, Withdrawals},
 };
 use alloy_provider::ext::EngineApi;
 use alloy_rpc_types_engine::{ClientCode, ExecutionPayloadV3, JwtSecret, PayloadStatusEnum};
 use reqwest::Url;
-use reth_primitives::{BlockBody, SealedBlock, SealedHeader};
 use tracing::{debug, error};
 
 use crate::{
-    builder::{compat::to_alloy_execution_payload, BuilderError, SealedAlloyBlock},
+    builder::{compat::to_alloy_execution_payload, BuilderError},
     client::EngineClient,
 };
 
@@ -52,7 +51,7 @@ impl EngineHinter {
     pub async fn fetch_payload_from_hints(
         &self,
         mut ctx: EngineHinterContext,
-    ) -> Result<SealedAlloyBlock, BuilderError> {
+    ) -> Result<Block<PooledTransaction>, BuilderError> {
         // The block body can be the same for all iterations, since it only contains
         // the transactions and withdrawals from the context.
         let body = ctx.build_block_body();
@@ -66,20 +65,18 @@ impl EngineHinter {
             // Build a new block header using the hints from the context
             let header = ctx.build_block_header_with_hints();
 
-            let sealed_hash = header.hash_slow();
-            let sealed_header = SealedHeader::new(header, sealed_hash);
-            let sealed_block = SealedBlock::new(sealed_header, body.clone());
-            let block_hash = ctx.hints.block_hash.unwrap_or(sealed_block.hash());
+            let block = Block { header, body: body.clone() };
+            let block_hash = ctx.hints.block_hash.unwrap_or(block.hash_slow());
 
             // build the new execution payload from the block header
-            let exec_payload = to_alloy_execution_payload(&sealed_block, block_hash);
+            let exec_payload = to_alloy_execution_payload(&block, block_hash);
 
             // attempt to fetch the next hint from the engine API payload response
             let hint = self.next_hint(exec_payload, &ctx).await?;
             debug!(?hint, "Received hint from engine API");
 
             if matches!(hint, EngineApiHint::ValidPayload) {
-                return Ok(sealed_block);
+                return Ok(block);
             }
 
             // Populate the new hint in the context and continue the loop
@@ -208,7 +205,7 @@ pub struct EngineHinterContext {
     pub block_timestamp: u64,
     pub transactions: Vec<PooledTransaction>,
     pub withdrawals: Vec<Withdrawal>,
-    pub head_block: Block,
+    pub head_block: RpcBlock,
     pub hints: Hints,
     pub el_client_code: ClientCode,
 }

--- a/bolt-sidecar/src/builder/fallback/payload_builder.rs
+++ b/bolt-sidecar/src/builder/fallback/payload_builder.rs
@@ -1,9 +1,8 @@
 use alloy::{
-    consensus::{proofs, Transaction},
+    consensus::{proofs, transaction::PooledTransaction, Transaction},
     eips::{calc_excess_blob_gas, calc_next_block_base_fee, eip1559::BaseFeeParams},
     primitives::{Address, Bytes},
 };
-use reth_primitives::{SealedBlock, TransactionSigned};
 use tracing::debug;
 
 use super::{
@@ -11,7 +10,7 @@ use super::{
     DEFAULT_EXTRA_DATA,
 };
 use crate::{
-    builder::BuilderError,
+    builder::{BuilderError, SealedAlloyBlock},
     client::{BeaconClient, ExecutionClient},
     config::Opts,
 };
@@ -62,8 +61,8 @@ impl FallbackPayloadBuilder {
     pub async fn build_fallback_payload(
         &self,
         target_slot: u64,
-        transactions: &[TransactionSigned],
-    ) -> Result<SealedBlock, BuilderError> {
+        transactions: &[PooledTransaction],
+    ) -> Result<SealedAlloyBlock, BuilderError> {
         // Fetch the latest block to get the necessary parent values for the new block.
         // For the timestamp, we must use the one expected by the beacon chain instead, to
         // prevent edge cases where the proposer before us has missed their slot and therefore
@@ -145,7 +144,7 @@ mod tests {
     use std::time::{SystemTime, UNIX_EPOCH};
 
     use alloy::{
-        consensus::{constants, proofs},
+        consensus::{constants, proofs, transaction::PooledTransaction},
         eips::eip2718::{Decodable2718, Encodable2718},
         network::{EthereumWallet, TransactionBuilder},
         primitives::{hex, Address},
@@ -153,7 +152,6 @@ mod tests {
         signers::{k256::ecdsa::SigningKey, local::PrivateKeySigner},
     };
     use beacon_api_client::mainnet::Client as BeaconClient;
-    use reth_primitives::TransactionSigned;
     use tracing::warn;
 
     use crate::{
@@ -192,7 +190,7 @@ mod tests {
         let tx = default_test_transaction(addy, Some(nonce)).with_chain_id(17000);
         let tx_signed = tx.build(&wallet).await?;
         let raw_encoded = tx_signed.encoded_2718();
-        let tx_signed_reth = TransactionSigned::decode_2718(&mut raw_encoded.as_slice())?;
+        let tx_signed_reth = PooledTransaction::decode_2718(&mut raw_encoded.as_slice())?;
 
         let slot = genesis_time +
             (SystemTime::now().duration_since(UNIX_EPOCH)?.as_secs() / cfg.chain.slot_time()) +

--- a/bolt-sidecar/src/builder/fallback/payload_builder.rs
+++ b/bolt-sidecar/src/builder/fallback/payload_builder.rs
@@ -1,5 +1,5 @@
 use alloy::{
-    consensus::{proofs, transaction::PooledTransaction, Transaction},
+    consensus::{proofs, transaction::PooledTransaction, Block, Transaction},
     eips::{calc_excess_blob_gas, calc_next_block_base_fee, eip1559::BaseFeeParams},
     primitives::{Address, Bytes},
 };
@@ -10,7 +10,7 @@ use super::{
     DEFAULT_EXTRA_DATA,
 };
 use crate::{
-    builder::{BuilderError, SealedAlloyBlock},
+    builder::BuilderError,
     client::{BeaconClient, ExecutionClient},
     config::Opts,
 };
@@ -62,7 +62,7 @@ impl FallbackPayloadBuilder {
         &self,
         target_slot: u64,
         transactions: &[PooledTransaction],
-    ) -> Result<SealedAlloyBlock, BuilderError> {
+    ) -> Result<Block<PooledTransaction>, BuilderError> {
         // Fetch the latest block to get the necessary parent values for the new block.
         // For the timestamp, we must use the one expected by the beacon chain instead, to
         // prevent edge cases where the proposer before us has missed their slot and therefore
@@ -198,7 +198,7 @@ mod tests {
 
         let block = builder.build_fallback_payload(slot, &[tx_signed_reth]).await?;
 
-        assert_eq!(block.body().transactions.len(), 1);
+        assert_eq!(block.body.transactions.len(), 1);
 
         Ok(())
     }

--- a/bolt-sidecar/src/builder/mod.rs
+++ b/bolt-sidecar/src/builder/mod.rs
@@ -1,14 +1,10 @@
-use alloy::{
-    consensus::{transaction::PooledTransaction, BlockBody, Header},
-    primitives::U256,
-};
+use alloy::primitives::U256;
 use alloy_rpc_types_engine::{ClientCode, PayloadStatusEnum};
 use ethereum_consensus::{
     crypto::{KzgCommitment, PublicKey},
     deneb::mainnet::ExecutionPayloadHeader,
     ssz::prelude::{List, MerkleizationError},
 };
-use reth_primitives::SealedBlock;
 
 use crate::{
     common::secrets::BlsSecretKeyWrapper,
@@ -43,9 +39,6 @@ pub use payload_fetcher::{LocalPayloadFetcher, PayloadFetcher};
 /// Ethereum-consensus and other crates.
 #[doc(hidden)]
 mod compat;
-
-/// Type alias for the sealed block.
-type SealedAlloyBlock = SealedBlock<Header, BlockBody<PooledTransaction>>;
 
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]

--- a/bolt-sidecar/src/builder/mod.rs
+++ b/bolt-sidecar/src/builder/mod.rs
@@ -1,10 +1,14 @@
-use alloy::primitives::U256;
+use alloy::{
+    consensus::{transaction::PooledTransaction, BlockBody, Header},
+    primitives::U256,
+};
 use alloy_rpc_types_engine::{ClientCode, PayloadStatusEnum};
 use ethereum_consensus::{
     crypto::{KzgCommitment, PublicKey},
     deneb::mainnet::ExecutionPayloadHeader,
     ssz::prelude::{List, MerkleizationError},
 };
+use reth_primitives::SealedBlock;
 
 use crate::{
     common::secrets::BlsSecretKeyWrapper,
@@ -39,6 +43,9 @@ pub use payload_fetcher::{LocalPayloadFetcher, PayloadFetcher};
 /// Ethereum-consensus and other crates.
 #[doc(hidden)]
 mod compat;
+
+/// Type alias for the sealed block.
+type SealedAlloyBlock = SealedBlock<Header, BlockBody<PooledTransaction>>;
 
 #[derive(Debug, thiserror::Error)]
 #[non_exhaustive]

--- a/bolt-sidecar/src/builder/template.rs
+++ b/bolt-sidecar/src/builder/template.rs
@@ -1,12 +1,11 @@
 use alloy::{
-    consensus::Transaction,
+    consensus::{transaction::PooledTransaction, Transaction},
     primitives::{Address, TxHash, U256},
 };
 use ethereum_consensus::{
     crypto::{KzgCommitment, KzgProof},
     deneb::mainnet::{Blob, BlobsBundle},
 };
-use reth_primitives::TransactionSigned;
 use std::collections::HashMap;
 use tracing::warn;
 
@@ -47,10 +46,10 @@ impl BlockTemplate {
     /// Converts the list of signed constraints into a list of signed transactions. Use this when
     /// building a local execution payload.
     #[inline]
-    pub fn as_signed_transactions(&self) -> Vec<TransactionSigned> {
+    pub fn as_signed_transactions(&self) -> Vec<PooledTransaction> {
         self.signed_constraints_list
             .iter()
-            .flat_map(|sc| sc.message.transactions.iter().map(|c| c.clone().into_signed()))
+            .flat_map(|sc| sc.message.transactions.iter().map(|c| c.clone().into_inner()))
             .collect()
     }
 

--- a/bolt-sidecar/src/primitives/transaction.rs
+++ b/bolt-sidecar/src/primitives/transaction.rs
@@ -1,15 +1,14 @@
+use std::{borrow::Cow, fmt};
+
 use alloy::{
     consensus::{
-        transaction::PooledTransaction, BlobTransactionSidecar, Signed, Transaction, TxType,
-        Typed2718,
+        transaction::PooledTransaction, BlobTransactionSidecar, Transaction, TxType, Typed2718,
     },
     eips::eip2718::{Decodable2718, Encodable2718},
     hex,
     primitives::{Address, U256},
 };
-use reth_primitives::TransactionSigned;
 use serde::{de, ser::SerializeSeq};
-use std::{borrow::Cow, fmt};
 
 /// Trait that exposes additional information on transaction types that don't already do it
 /// by themselves (e.g. [`PooledTransaction`]).
@@ -137,22 +136,6 @@ impl FullTransaction {
     /// Returns the inner transaction.
     pub fn into_inner(self) -> PooledTransaction {
         self.tx
-    }
-
-    /// Returns the signed transaction.
-    pub fn into_signed(self) -> TransactionSigned {
-        match self.tx {
-            PooledTransaction::Legacy(tx) => tx.into(),
-            PooledTransaction::Eip1559(tx) => tx.into(),
-            PooledTransaction::Eip2930(tx) => tx.into(),
-            PooledTransaction::Eip4844(tx) => {
-                let sig = *tx.signature();
-                let hash = *tx.hash();
-                let inner_tx = tx.into_parts().0.into_parts().0;
-                Signed::new_unchecked(inner_tx, sig, hash).into()
-            }
-            PooledTransaction::Eip7702(tx) => tx.into(),
-        }
     }
 
     /// Returns the sender of the transaction, if recovered.


### PR DESCRIPTION
* We can get away with `alloy::consensus::PooledTransaction` instead of `reth_primitives::TransactionSigned` 
* Similarly, `BlockBody, SealedBlock, SealedHeader` from reth can all be avoided with `alloy::consensus::Block`!

We don't have any reth types left after this. Upstack PR #753 removes them from Cargo.toml!