### PR TITLE
chore(sidecar): rm unused dependencies

### DIFF
--- a/bolt-sidecar/Cargo.lock
+++ b/bolt-sidecar/Cargo.lock
@@ -2108,7 +2108,6 @@ dependencies = [
  "bls 0.2.0 (git+https://github.com/sigp/lighthouse)",
  "blst",
  "built",
- "bytes",
  "cb-common",
  "clap",
  "criterion",
@@ -2116,7 +2115,6 @@ dependencies = [
  "dotenvy",
  "eth2_keystore 0.1.0 (git+https://github.com/sigp/lighthouse)",
  "ethereum-consensus",
- "ethereum_ssz 0.8.2",
  "eyre",
  "futures",
  "hex",
@@ -2130,16 +2128,13 @@ dependencies = [
  "regex",
  "reqwest 0.12.12",
  "reth-primitives",
- "reth-primitives-traits",
  "rustls 0.23.21",
  "secp256k1",
  "serde",
  "serde_json",
- "ssz_rs 0.9.0 (git+https://github.com/ralexstokes/ssz-rs?rev=ec3073e)",
  "thiserror 2.0.11",
  "tokio",
  "tokio-retry",
- "tokio-stream",
  "tokio-tungstenite 0.24.0",
  "tower",
  "tower-http",
@@ -3572,7 +3567,7 @@ dependencies = [
  "serde_json",
  "serde_yaml 0.8.26",
  "sha2 0.10.8",
- "ssz_rs 0.9.0 (git+https://github.com/ralexstokes/ssz-rs?rev=84ef2b71aa004f6767420badb42c902ad56b8b72)",
+ "ssz_rs",
  "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
@@ -7840,35 +7835,13 @@ dependencies = [
  "bitvec 1.0.1",
  "serde",
  "sha2 0.9.9",
- "ssz_rs_derive 0.9.0 (git+https://github.com/ralexstokes/ssz-rs?rev=84ef2b71aa004f6767420badb42c902ad56b8b72)",
-]
-
-[[package]]
-name = "ssz_rs"
-version = "0.9.0"
-source = "git+https://github.com/ralexstokes/ssz-rs?rev=ec3073e#ec3073e2273b4d0873fcb6df68ff4eff79588e92"
-dependencies = [
- "alloy-primitives 0.8.15",
- "bitvec 1.0.1",
- "serde",
- "sha2 0.9.9",
- "ssz_rs_derive 0.9.0 (git+https://github.com/ralexstokes/ssz-rs?rev=ec3073e)",
+ "ssz_rs_derive",
 ]
 
 [[package]]
 name = "ssz_rs_derive"
 version = "0.9.0"
 source = "git+https://github.com/ralexstokes/ssz-rs?rev=84ef2b71aa004f6767420badb42c902ad56b8b72#84ef2b71aa004f6767420badb42c902ad56b8b72"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
-name = "ssz_rs_derive"
-version = "0.9.0"
-source = "git+https://github.com/ralexstokes/ssz-rs?rev=ec3073e#ec3073e2273b4d0873fcb6df68ff4eff79588e92"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/bolt-sidecar/Cargo.lock
+++ b/bolt-sidecar/Cargo.lock
@@ -183,7 +183,6 @@ checksum = "a0161082e0edd9013d23083465cc04b20e44b7a15646d36ba7b0cdb7cd6fe18f"
 dependencies = [
  "alloy-primitives 0.8.15",
  "num_enum",
- "serde",
  "strum",
 ]
 
@@ -216,12 +215,10 @@ dependencies = [
  "alloy-rlp",
  "alloy-serde 0.9.2",
  "alloy-trie",
- "arbitrary",
  "auto_impl",
  "c-kzg",
  "derive_more 1.0.0",
  "k256 0.13.4",
- "rand 0.8.5",
  "serde",
 ]
 
@@ -326,19 +323,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "alloy-eip2124"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "675264c957689f0fd75f5993a73123c2cc3b5c235a38f5b9037fe6c826bfb2c0"
-dependencies = [
- "alloy-primitives 0.8.15",
- "alloy-rlp",
- "crc",
- "serde",
- "thiserror 2.0.11",
-]
-
-[[package]]
 name = "alloy-eip2930"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -346,8 +330,6 @@ checksum = "0069cf0642457f87a01a014f6dc29d5d893cd4fd8fddf0c3cdfad1bb3ebafc41"
 dependencies = [
  "alloy-primitives 0.8.15",
  "alloy-rlp",
- "arbitrary",
- "rand 0.8.5",
  "serde",
 ]
 
@@ -372,10 +354,8 @@ checksum = "cabf647eb4650c91a9d38cb6f972bb320009e7e9d61765fb688a86f1563b33e8"
 dependencies = [
  "alloy-primitives 0.8.15",
  "alloy-rlp",
- "arbitrary",
  "derive_more 1.0.0",
  "k256 0.13.4",
- "rand 0.8.5",
  "serde",
 ]
 
@@ -410,7 +390,6 @@ dependencies = [
  "alloy-primitives 0.8.15",
  "alloy-rlp",
  "alloy-serde 0.9.2",
- "arbitrary",
  "c-kzg",
  "derive_more 1.0.0",
  "once_cell",
@@ -1014,7 +993,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae0465c71d4dced7525f408d84873aeebb71faf807d22d74c4a426430ccd9b55"
 dependencies = [
  "alloy-primitives 0.8.15",
- "arbitrary",
  "serde",
  "serde_json",
 ]
@@ -1971,9 +1949,6 @@ name = "bitflags"
 version = "2.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b048fb63fd8b5923fc5aa7b340d8e156aec7ec02f0c78fa8a6ddc2613f6f71de"
-dependencies = [
- "serde",
-]
 
 [[package]]
 name = "bitvec"
@@ -1995,7 +1970,6 @@ checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
  "funty 2.0.0",
  "radium 0.7.0",
- "serde",
  "tap",
  "wyz 0.5.1",
 ]
@@ -2127,7 +2101,6 @@ dependencies = [
  "rand 0.8.5",
  "regex",
  "reqwest 0.12.12",
- "reth-primitives",
  "rustls 0.23.21",
  "secp256k1",
  "serde",
@@ -2503,15 +2476,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
-name = "convert_case"
-version = "0.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
-dependencies = [
- "unicode-segmentation",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2608,21 +2572,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "crc"
-version = "3.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69e6e4d7b33a94f0991c26729976b10ebde1d34c3ee82408fb536164fa10d636"
-dependencies = [
- "crc-catalog",
-]
-
-[[package]]
-name = "crc-catalog"
-version = "2.4.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19d374276b40fb8bbdee95aef7c7fa6b5316ec764510eb64b8dd0e2ed0d7e7f5"
-
-[[package]]
 name = "crc32fast"
 version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2666,12 +2615,6 @@ dependencies = [
  "cast",
  "itertools 0.10.5",
 ]
-
-[[package]]
-name = "critical-section"
-version = "1.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
 
 [[package]]
 name = "crossbeam-channel"
@@ -2982,7 +2925,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
- "serde",
 ]
 
 [[package]]
@@ -3013,7 +2955,7 @@ version = "0.99.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5f33878137e4dafd7fa914ad4e259e18a4e8e532b9617a2d0150262bf53abfce"
 dependencies = [
- "convert_case 0.4.0",
+ "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version 0.4.1",
@@ -3035,7 +2977,6 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
 dependencies = [
- "convert_case 0.6.0",
  "proc-macro2",
  "quote",
  "syn 2.0.90",
@@ -3177,12 +3118,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
 
 [[package]]
-name = "dyn-clone"
-version = "1.0.17"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
-
-[[package]]
 name = "ecdsa"
 version = "0.14.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3204,7 +3139,6 @@ dependencies = [
  "digest 0.10.7",
  "elliptic-curve 0.13.8",
  "rfc6979 0.4.0",
- "serdect",
  "signature 2.2.0",
  "spki 0.7.3",
 ]
@@ -3275,7 +3209,6 @@ dependencies = [
  "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1 0.7.3",
- "serdect",
  "subtle",
  "zeroize",
 ]
@@ -3325,17 +3258,6 @@ dependencies = [
  "serde",
  "sha3 0.10.8",
  "zeroize",
-]
-
-[[package]]
-name = "enumn"
-version = "0.1.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f9ed6b3789237c8a0c1c505af1c7eb2c560df6186f01b098c3a1064ea532f38"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.90",
 ]
 
 [[package]]
@@ -4818,7 +4740,6 @@ checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
  "autocfg",
  "hashbrown 0.12.3",
- "serde",
 ]
 
 [[package]]
@@ -5001,7 +4922,6 @@ dependencies = [
  "ecdsa 0.16.9",
  "elliptic-curve 0.13.8",
  "once_cell",
- "serdect",
  "sha2 0.10.8",
  "signature 2.2.0",
 ]
@@ -5504,27 +5424,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "modular-bitfield"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a53d79ba8304ac1c4f9eb3b9d281f21f7be9d4626f72ce7df4ad8fbde4f38a74"
-dependencies = [
- "modular-bitfield-impl",
- "static_assertions",
-]
-
-[[package]]
-name = "modular-bitfield-impl"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a7d5f7076603ebc68de2dc6a650ec331a062a13abaa346975be747bbfa4b789"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 1.0.109",
-]
-
-[[package]]
 name = "more-asserts"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5774,51 +5673,12 @@ name = "once_cell"
 version = "1.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1261fe7e33c73b354eab43b1273a57c8f967d0391e80353e51f764ac02cf6775"
-dependencies = [
- "critical-section",
- "portable-atomic",
-]
 
 [[package]]
 name = "oorandom"
 version = "11.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
-
-[[package]]
-name = "op-alloy-consensus"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0adb232ec805af3aa35606c19329aa7dc44c4457ae318ed0b8fc7f799dd7dbfe"
-dependencies = [
- "alloy-consensus 0.9.2",
- "alloy-eips 0.9.2",
- "alloy-primitives 0.8.15",
- "alloy-rlp",
- "alloy-serde 0.9.2",
- "arbitrary",
- "derive_more 1.0.0",
- "serde",
- "thiserror 2.0.11",
-]
-
-[[package]]
-name = "op-alloy-rpc-types"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e68d1a51fe3ee143f102b82f54fa237f21d12635da363276901e6d3ef6c65b7b"
-dependencies = [
- "alloy-consensus 0.9.2",
- "alloy-eips 0.9.2",
- "alloy-network-primitives 0.9.2",
- "alloy-primitives 0.8.15",
- "alloy-rpc-types-eth 0.9.2",
- "alloy-serde 0.9.2",
- "derive_more 1.0.0",
- "op-alloy-consensus",
- "serde",
- "serde_json",
-]
 
 [[package]]
 name = "opaque-debug"
@@ -6701,146 +6561,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "reth-codecs"
-version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth#383eb2331c41cfc6d7523c691552264e7894fd25"
-dependencies = [
- "alloy-consensus 0.9.2",
- "alloy-eips 0.9.2",
- "alloy-genesis 0.9.2",
- "alloy-primitives 0.8.15",
- "alloy-trie",
- "bytes",
- "modular-bitfield",
- "op-alloy-consensus",
- "reth-codecs-derive",
- "serde",
-]
-
-[[package]]
-name = "reth-codecs-derive"
-version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth#383eb2331c41cfc6d7523c691552264e7894fd25"
-dependencies = [
- "convert_case 0.6.0",
- "proc-macro2",
- "quote",
- "syn 2.0.90",
-]
-
-[[package]]
-name = "reth-ethereum-forks"
-version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth#383eb2331c41cfc6d7523c691552264e7894fd25"
-dependencies = [
- "alloy-chains",
- "alloy-eip2124",
- "alloy-primitives 0.8.15",
- "auto_impl",
- "dyn-clone",
- "once_cell",
- "rustc-hash 2.1.0",
- "serde",
-]
-
-[[package]]
-name = "reth-primitives"
-version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth#383eb2331c41cfc6d7523c691552264e7894fd25"
-dependencies = [
- "alloy-consensus 0.9.2",
- "alloy-eips 0.9.2",
- "alloy-network 0.9.2",
- "alloy-primitives 0.8.15",
- "alloy-rlp",
- "alloy-rpc-types 0.9.2",
- "alloy-serde 0.9.2",
- "alloy-trie",
- "bytes",
- "c-kzg",
- "derive_more 1.0.0",
- "modular-bitfield",
- "once_cell",
- "op-alloy-consensus",
- "op-alloy-rpc-types",
- "reth-codecs",
- "reth-ethereum-forks",
- "reth-primitives-traits",
- "reth-static-file-types",
- "reth-zstd-compressors",
- "revm-primitives",
- "secp256k1",
- "serde",
- "serde_with",
-]
-
-[[package]]
-name = "reth-primitives-traits"
-version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth#383eb2331c41cfc6d7523c691552264e7894fd25"
-dependencies = [
- "alloy-consensus 0.9.2",
- "alloy-eips 0.9.2",
- "alloy-genesis 0.9.2",
- "alloy-primitives 0.8.15",
- "alloy-rlp",
- "alloy-trie",
- "auto_impl",
- "byteorder",
- "bytes",
- "derive_more 1.0.0",
- "k256 0.13.4",
- "modular-bitfield",
- "once_cell",
- "op-alloy-consensus",
- "reth-codecs",
- "revm-primitives",
- "secp256k1",
- "serde",
- "serde_with",
- "thiserror 2.0.11",
-]
-
-[[package]]
-name = "reth-static-file-types"
-version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth#383eb2331c41cfc6d7523c691552264e7894fd25"
-dependencies = [
- "alloy-primitives 0.8.15",
- "derive_more 1.0.0",
- "serde",
- "strum",
-]
-
-[[package]]
-name = "reth-zstd-compressors"
-version = "1.1.5"
-source = "git+https://github.com/paradigmxyz/reth#383eb2331c41cfc6d7523c691552264e7894fd25"
-dependencies = [
- "zstd 0.13.2",
-]
-
-[[package]]
-name = "revm-primitives"
-version = "15.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48faea1ecf2c9f80d9b043bbde0db9da616431faed84c4cfa3dd7393005598e6"
-dependencies = [
- "alloy-eip2930",
- "alloy-eip7702 0.5.0",
- "alloy-primitives 0.8.15",
- "auto_impl",
- "bitflags 2.6.0",
- "bitvec 1.0.1",
- "c-kzg",
- "cfg-if",
- "dyn-clone",
- "enumn",
- "hex",
- "serde",
-]
-
-[[package]]
 name = "rfc6979"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7014,9 +6734,6 @@ name = "rustc-hash"
 version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c7fb8039b3032c191086b10f11f319a6e99e1e82889c5cc6046f515c9db1d497"
-dependencies = [
- "rand 0.8.5",
-]
 
 [[package]]
 name = "rustc-hex"
@@ -7284,7 +7001,6 @@ dependencies = [
  "der 0.7.9",
  "generic-array",
  "pkcs8 0.10.2",
- "serdect",
  "subtle",
  "zeroize",
 ]
@@ -7297,7 +7013,6 @@ checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
 dependencies = [
  "rand 0.8.5",
  "secp256k1-sys",
- "serde",
 ]
 
 [[package]]
@@ -7478,8 +7193,6 @@ dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
- "indexmap 1.9.3",
- "indexmap 2.7.0",
  "serde",
  "serde_derive",
  "serde_json",
@@ -7522,16 +7235,6 @@ dependencies = [
  "ryu",
  "serde",
  "unsafe-libyaml",
-]
-
-[[package]]
-name = "serdect"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a84f14a19e9a014bb9f4512488d9829a68e04ecabffb0f9904cd1ace94598177"
-dependencies = [
- "base16ct 0.2.0",
- "serde",
 ]
 
 [[package]]
@@ -8790,12 +8493,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-segmentation"
-version = "1.12.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f6ccf251212114b54433ec949fd6a7841275f9ada20dddd2f29e9ceea4501493"
-
-[[package]]
 name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -9557,7 +9254,7 @@ dependencies = [
  "pbkdf2 0.11.0",
  "sha1",
  "time",
- "zstd 0.11.2+zstd.1.5.2",
+ "zstd",
 ]
 
 [[package]]
@@ -9566,16 +9263,7 @@ version = "0.11.2+zstd.1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
 dependencies = [
- "zstd-safe 5.0.2+zstd.1.5.2",
-]
-
-[[package]]
-name = "zstd"
-version = "0.13.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
-dependencies = [
- "zstd-safe 7.2.1",
+ "zstd-safe",
 ]
 
 [[package]]
@@ -9585,15 +9273,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
 dependencies = [
  "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "7.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "54a3ab4db68cea366acc5c897c7b4d4d1b8994a9cd6e6f841f8964566a419059"
-dependencies = [
  "zstd-sys",
 ]
 

--- a/bolt-sidecar/Cargo.toml
+++ b/bolt-sidecar/Cargo.toml
@@ -42,9 +42,6 @@ alloy-rpc-types-engine = { version = "0.9.2", default-features = false, features
 alloy-transport-http = { version = "0.9.2", default-features = false, features = ["jwt-auth"] }
 alloy-provider = { version = "0.9.2", default-features = false, features = ["engine-api"] }
 
-# reth
-reth-primitives = { git = "https://github.com/paradigmxyz/reth", version = "1.1.5" }
-
 # commit-boost
 cb-common = { git = "https://github.com/Commit-Boost/commit-boost-client", tag = "v0.5.0" }
 

--- a/bolt-sidecar/Cargo.toml
+++ b/bolt-sidecar/Cargo.toml
@@ -21,15 +21,13 @@ axum = { version = "0.8.2", features = ["macros", "ws"] }
 axum-extra = { version = "0.10.0", features = ["typed-header"] }
 tower-http = { version = "0.5.2", features = ["timeout"] }
 http-body-util = "0.1.2"
-rustls = "0.23.21"
 reqwest = "0.12"
 tower = "0.5.1"
 
 # tokio
 tokio = { version = "1", features = ["full"] }
-tokio-retry = "0.3.0"
 tokio-tungstenite = "0.24.0"
-tokio-stream = "0.1.17"
+tokio-retry = "0.3.0"
 futures = "0.3"
 
 # crypto
@@ -37,8 +35,6 @@ blst = "0.3.12"
 tree_hash = "0.9"
 tree_hash_derive = "0.8"
 secp256k1 = { version = "0.29.0", features = ["rand"] }
-ssz_rs = { git = "https://github.com/ralexstokes/ssz-rs", rev = "ec3073e" }
-ethereum_ssz = "0.8.2"
 
 # alloy
 alloy = { version = "0.9.2", features = ["full", "provider-trace-api", "rpc-types-beacon"] }
@@ -48,7 +44,6 @@ alloy-provider = { version = "0.9.2", default-features = false, features = ["eng
 
 # reth
 reth-primitives = { git = "https://github.com/paradigmxyz/reth", version = "1.1.5" }
-reth-primitives-traits = { git = "https://github.com/paradigmxyz/reth", version = "1.1.5" }
 
 # commit-boost
 cb-common = { git = "https://github.com/Commit-Boost/commit-boost-client", tag = "v0.5.0" }
@@ -68,7 +63,6 @@ serde = { version = "1.0.217", features = ["derive"] }
 serde_json = "1.0.137"
 parking_lot = "0.12.1"
 async-trait = "0.1.85"
-bytes = "1.6.0"
 hex = "0.4.3"
 
 # utils
@@ -80,6 +74,7 @@ dotenvy = "0.15.7"
 regex = "1.10.5"
 jsonwebtoken = "9.3.0"
 derive_more = "1.0.0"
+rustls = "0.23.21"
 
 # tracing
 tracing-subscriber = { version = "0.3.18", features = ["env-filter", "fmt"] }

--- a/bolt-sidecar/src/api/commitments/firewall/receiver.rs
+++ b/bolt-sidecar/src/api/commitments/firewall/receiver.rs
@@ -270,7 +270,6 @@ mod tests {
         headers::{authorization::Bearer, Authorization, UserAgent},
         TypedHeader,
     };
-    // use bytes::Bytes;
     use futures::{FutureExt, SinkExt, StreamExt};
     use reqwest::StatusCode;
     use serde::Serialize;

--- a/bolt-sidecar/src/api/commitments/firewall/receiver.rs
+++ b/bolt-sidecar/src/api/commitments/firewall/receiver.rs
@@ -257,6 +257,7 @@ mod tests {
     use std::{net::SocketAddr, ops::ControlFlow, time::Duration};
 
     use axum::{
+        body::Bytes,
         extract::{
             ws::{CloseFrame, Message, Utf8Bytes, WebSocket},
             ConnectInfo, WebSocketUpgrade,
@@ -269,7 +270,7 @@ mod tests {
         headers::{authorization::Bearer, Authorization, UserAgent},
         TypedHeader,
     };
-    use bytes::Bytes;
+    // use bytes::Bytes;
     use futures::{FutureExt, SinkExt, StreamExt};
     use reqwest::StatusCode;
     use serde::Serialize;

--- a/bolt-sidecar/src/lib.rs
+++ b/bolt-sidecar/src/lib.rs
@@ -2,6 +2,11 @@
 #![warn(missing_debug_implementations, missing_docs, rustdoc::all)]
 #![deny(unused_must_use, rust_2018_idioms)]
 #![cfg_attr(docsrs, feature(doc_cfg, doc_auto_cfg))]
+#![cfg_attr(not(test), warn(unused_crate_dependencies))]
+
+// Manually silence "rustls" crate being unused
+#[allow(unused_extern_crates)]
+extern crate rustls;
 
 /// All APIs in use by the sidecar.
 pub mod api;


### PR DESCRIPTION
We had some unused dependencies in bolt_sidecar.
Added a library attribute to warn us in the future.

Dependencies removed: 

* tokio-stream
* ssz_rs
* ethereum_ssz
* reth_primitives
* reth_primitives_traits
* bytes