### PR TITLE
Bolt-cli: Add dry-run flag for developmental/testing

### DIFF
--- a/bolt-cli/src/cli.rs
+++ b/bolt-cli/src/cli.rs
@@ -187,6 +187,11 @@ pub enum ValidatorsSubcommand {
         /// The private key to sign the transactions with.
         #[clap(long, env = "ADMIN_PRIVATE_KEY")]
         admin_private_key: B256,
+
+        /// Run the command in "dry run" mode, run all steps without broadcast.
+        /// Useful for testing and debugging purposes.
+        #[clap(short, long, env = "DRY_RUN", default_value = "false")]
+        dry_run: bool,
     },
     /// Check the status of a validator (batch).
     Status {
@@ -242,6 +247,10 @@ pub enum EigenLayerSubcommand {
         /// The amount to deposit into the strategy, in units (e.g. '1ether', '10gwei').
         #[clap(long, env = "EIGENLAYER_STRATEGY_DEPOSIT_AMOUNT", value_parser = parse_ether_value)]
         amount: U256,
+        /// Run the command in "dry run" mode, run all steps without broadcast.
+        /// Useful for testing and debugging purposes.
+        #[clap(short, long, env = "DRY_RUN", default_value = "false")]
+        dry_run: bool,
     },
 
     /// Register an operator into the bolt AVS.
@@ -264,6 +273,10 @@ pub enum EigenLayerSubcommand {
         /// If not provided, a random value is used.
         #[clap(long, env = "OPERATOR_SIGNATURE_SALT")]
         salt: Option<B256>,
+        /// Run the command in "dry run" mode, run all steps without broadcast.
+        /// Useful for testing and debugging purposes.
+        #[clap(short, long, env = "DRY_RUN", default_value = "false")]
+        dry_run: bool,
     },
 
     /// Deregister an EigenLayer operator from the bolt AVS.
@@ -274,6 +287,10 @@ pub enum EigenLayerSubcommand {
         /// The private key of the operator.
         #[clap(long, env = "OPERATOR_PRIVATE_KEY")]
         operator_private_key: B256,
+        /// Run the command in "dry run" mode, run all steps without broadcast.
+        /// Useful for testing and debugging purposes.
+        #[clap(short, long, env = "DRY_RUN", default_value = "false")]
+        dry_run: bool,
     },
 
     /// Update the operator RPC.
@@ -287,6 +304,10 @@ pub enum EigenLayerSubcommand {
         /// The URL of the operator RPC.
         #[clap(long, env = "OPERATOR_RPC")]
         operator_rpc: Url,
+        /// Run the command in "dry run" mode, run all steps without broadcast.
+        /// Useful for testing and debugging purposes.
+        #[clap(short, long, env = "DRY_RUN", default_value = "false")]
+        dry_run: bool,
     },
 
     /// Check the status of an operator in the bolt AVS.
@@ -304,6 +325,10 @@ pub enum EigenLayerSubcommand {
         /// The URL of the RPC to read data from
         #[clap(long, env = "RPC_URL")]
         rpc_url: Url,
+        /// Run the command in "dry run" mode, run all steps without broadcast.
+        /// Useful for testing and debugging purposes.
+        #[clap(short, long, env = "DRY_RUN", default_value = "false")]
+        dry_run: bool,
     },
 }
 
@@ -325,6 +350,10 @@ pub enum SymbioticSubcommand {
         /// The operator's extra data string to be stored in the registry.
         #[clap(long, env = "OPERATOR_EXTRA_DATA")]
         extra_data: String,
+        /// Run the command in "dry run" mode, run all steps without broadcast.
+        /// Useful for testing and debugging purposes.
+        #[clap(short, long, env = "DRY_RUN", default_value = "false")]
+        dry_run: bool,
     },
 
     /// Deregister a Symbiotic operator from bolt.
@@ -335,6 +364,10 @@ pub enum SymbioticSubcommand {
         /// The private key of the operator.
         #[clap(long, env = "OPERATOR_PRIVATE_KEY")]
         operator_private_key: B256,
+        /// Run the command in "dry run" mode, run all steps without broadcast.
+        /// Useful for testing and debugging purposes.
+        #[clap(short, long, env = "DRY_RUN", default_value = "false")]
+        dry_run: bool,
     },
 
     /// Update the operator RPC.
@@ -348,6 +381,10 @@ pub enum SymbioticSubcommand {
         /// The URL of the operator RPC.
         #[clap(long, env = "OPERATOR_RPC")]
         operator_rpc: Url,
+        /// Run the command in "dry run" mode, run all steps without broadcast.
+        /// Useful for testing and debugging purposes.
+        #[clap(short, long, env = "DRY_RUN", default_value = "false")]
+        dry_run: bool,
     },
 
     /// Check the status of a Symbiotic operator.
@@ -365,6 +402,10 @@ pub enum SymbioticSubcommand {
         /// The URL of the RPC to read data from
         #[clap(long, env = "RPC_URL")]
         rpc_url: Url,
+        /// Run the command in "dry run" mode, run all steps without broadcast.
+        /// Useful for testing and debugging purposes.
+        #[clap(short, long, env = "DRY_RUN", default_value = "false")]
+        dry_run: bool,
     },
 }
 

--- a/bolt-cli/src/cli.rs
+++ b/bolt-cli/src/cli.rs
@@ -325,10 +325,6 @@ pub enum EigenLayerSubcommand {
         /// The URL of the RPC to read data from
         #[clap(long, env = "RPC_URL")]
         rpc_url: Url,
-        /// Run the command in "dry run" mode, run all steps without broadcast.
-        /// Useful for testing and debugging purposes.
-        #[clap(short, long, env = "DRY_RUN", default_value = "false")]
-        dry_run: bool,
     },
 }
 
@@ -402,10 +398,6 @@ pub enum SymbioticSubcommand {
         /// The URL of the RPC to read data from
         #[clap(long, env = "RPC_URL")]
         rpc_url: Url,
-        /// Run the command in "dry run" mode, run all steps without broadcast.
-        /// Useful for testing and debugging purposes.
-        #[clap(short, long, env = "DRY_RUN", default_value = "false")]
-        dry_run: bool,
     },
 }
 

--- a/bolt-cli/src/commands/operators/eigenlayer.rs
+++ b/bolt-cli/src/commands/operators/eigenlayer.rs
@@ -501,10 +501,8 @@ impl EigenLayerSubcommand {
                 Ok(())
             }
 
-            Self::ListStrategies { rpc_url, dry_run } => {
-                let (rpc, anvil) = handle_rpc_dry_run(rpc_url, dry_run)?;
-
-                let provider = ProviderBuilder::new().on_http(rpc);
+            Self::ListStrategies { rpc_url } => {
+                let provider = ProviderBuilder::new().on_http(rpc_url.clone());
 
                 let chain = Chain::try_from_provider(&provider).await?;
 
@@ -539,8 +537,6 @@ impl EigenLayerSubcommand {
 
                     info!("- Token: {} - Strategy: {}", token_symbol, strategy_address);
                 }
-
-                shutdown_anvil(anvil);
 
                 Ok(())
             }

--- a/bolt-cli/src/commands/operators/symbiotic.rs
+++ b/bolt-cli/src/commands/operators/symbiotic.rs
@@ -388,10 +388,8 @@ impl SymbioticSubcommand {
                 Ok(())
             }
 
-            Self::ListVaults { rpc_url, dry_run } => {
-                let (rpc, anvil) = handle_rpc_dry_run(rpc_url, dry_run)?;
-
-                let provider = ProviderBuilder::new().on_http(rpc);
+            Self::ListVaults { rpc_url } => {
+                let provider = ProviderBuilder::new().on_http(rpc_url.clone());
 
                 let chain = Chain::try_from_provider(&provider).await?;
 
@@ -426,8 +424,6 @@ impl SymbioticSubcommand {
 
                     info!("- Token: {} - Vault: {}", token_symbol, vault_address);
                 }
-
-                shutdown_anvil(anvil);
 
                 Ok(())
             }

--- a/bolt-cli/src/commands/operators/symbiotic.rs
+++ b/bolt-cli/src/commands/operators/symbiotic.rs
@@ -1,10 +1,7 @@
 use alloy::{
     contract::Error as ContractError,
     network::EthereumWallet,
-    primitives::{
-        utils::format_ether,
-        U256,
-    },
+    primitives::{utils::format_ether, U256},
     providers::ProviderBuilder,
     signers::local::PrivateKeySigner,
     sol_types::SolInterface,
@@ -14,16 +11,17 @@ use tracing::{info, warn};
 
 use crate::{
     cli::{Chain, SymbioticSubcommand},
-    common::{
-        request_confirmation, try_parse_contract_error,
-    },
+    common::{handle_rpc_dry_run, request_confirmation, shutdown_anvil, try_parse_contract_error},
     contracts::{
         bolt::{
-            BoltManager::{self, BoltManagerErrors}, 
-            BoltSymbioticMiddlewareHolesky::{self, BoltSymbioticMiddlewareHoleskyErrors}, 
-            BoltSymbioticMiddlewareMainnet::{self, BoltSymbioticMiddlewareMainnetErrors}, 
-            OperatorsRegistryV1::{self, OperatorsRegistryV1Errors}
-        }, deployments_for_chain, erc20::IERC20, symbiotic::{IOptInService, IVault}
+            BoltManager::{self, BoltManagerErrors},
+            BoltSymbioticMiddlewareHolesky::{self, BoltSymbioticMiddlewareHoleskyErrors},
+            BoltSymbioticMiddlewareMainnet::{self, BoltSymbioticMiddlewareMainnetErrors},
+            OperatorsRegistryV1::{self, OperatorsRegistryV1Errors},
+        },
+        deployments_for_chain,
+        erc20::IERC20,
+        symbiotic::{IOptInService, IVault},
     },
 };
 
@@ -31,22 +29,26 @@ impl SymbioticSubcommand {
     /// Run the symbiotic subcommand.
     pub async fn run(self) -> eyre::Result<()> {
         match self {
-            Self::Register { operator_rpc, operator_private_key, rpc_url, extra_data } => {
+            Self::Register { operator_rpc, operator_private_key, rpc_url, extra_data, dry_run } => {
                 let signer = PrivateKeySigner::from_bytes(&operator_private_key)
                     .wrap_err("valid private key")?;
+
+                let (rpc, anvil) = handle_rpc_dry_run(rpc_url, dry_run)?;
 
                 let provider = ProviderBuilder::new()
                     .with_recommended_fillers()
                     .wallet(EthereumWallet::from(signer.clone()))
-                    .on_http(rpc_url);
+                    .on_http(rpc);
 
                 let chain = Chain::try_from_provider(&provider).await?;
 
                 let deployments = deployments_for_chain(chain);
 
-                let operator_rpc = operator_rpc.unwrap_or_else(|| chain.bolt_rpc().unwrap_or_else(|| 
-                    panic!("The bolt RPC is not deployed on {:?}. Please use the `--operator-rpc` flag to specify one manually.", chain))
-                );
+                let operator_rpc = operator_rpc.unwrap_or_else(|| {
+                    chain.bolt_rpc().unwrap_or_else(|| {
+                        panic!( "The bolt RPC is not deployed on {:?}. Please use the `--operator-rpc` flag to specify one manually.", chain)
+                    })
+                });
 
                 info!(operator = %signer.address(), rpc = %operator_rpc, ?chain, "Registering Symbiotic operator");
 
@@ -94,7 +96,7 @@ impl SymbioticSubcommand {
                                 eyre::bail!("Transaction failed: {:?}", receipt)
                             }
 
-                            info!("Succesfully registered Symbiotic operator");
+                            info!("Successfully registered Symbiotic operator");
                         }
                         Err(e) => parse_symbiotic_middleware_mainnet_errors(e)?,
                     }
@@ -116,25 +118,29 @@ impl SymbioticSubcommand {
                                 eyre::bail!("Transaction failed: {:?}", receipt)
                             }
 
-                            info!("Succesfully registered Symbiotic operator");
+                            info!("Successfully registered Symbiotic operator");
                         }
                         Err(e) => parse_symbiotic_middleware_holesky_errors(e)?,
                     }
                 }
 
+                shutdown_anvil(anvil);
+
                 Ok(())
             }
 
-            Self::Deregister { rpc_url, operator_private_key } => {
+            Self::Deregister { rpc_url, operator_private_key, dry_run } => {
                 let signer = PrivateKeySigner::from_bytes(&operator_private_key)
                     .wrap_err("valid private key")?;
 
                 let address = signer.address();
 
+                let (rpc, anvil) = handle_rpc_dry_run(rpc_url, dry_run)?;
+
                 let provider = ProviderBuilder::new()
                     .with_recommended_fillers()
                     .wallet(EthereumWallet::from(signer))
-                    .on_http(rpc_url);
+                    .on_http(rpc);
 
                 let chain = Chain::try_from_provider(&provider).await?;
 
@@ -163,7 +169,7 @@ impl SymbioticSubcommand {
                                 eyre::bail!("Transaction failed: {:?}", receipt)
                             }
 
-                            info!("Succesfully deregistered Symbiotic operator");
+                            info!("Successfully deregistered Symbiotic operator");
                         }
                         Err(e) => parse_symbiotic_middleware_mainnet_errors(e)?,
                     }
@@ -185,24 +191,28 @@ impl SymbioticSubcommand {
                                 eyre::bail!("Transaction failed: {:?}", receipt)
                             }
 
-                            info!("Succesfully deregistered Symbiotic operator");
+                            info!("Successfully deregistered Symbiotic operator");
                         }
                         Err(e) => parse_symbiotic_middleware_holesky_errors(e)?,
                     }
                 }
 
+                shutdown_anvil(anvil);
+
                 Ok(())
             }
 
-            Self::UpdateRpc { rpc_url, operator_private_key, operator_rpc } => {
+            Self::UpdateRpc { rpc_url, operator_private_key, operator_rpc, dry_run } => {
                 let signer = PrivateKeySigner::from_bytes(&operator_private_key)
                     .wrap_err("valid private key")?;
                 let address = signer.address();
 
+                let (rpc, anvil) = handle_rpc_dry_run(rpc_url, dry_run)?;
+
                 let provider = ProviderBuilder::new()
                     .with_recommended_fillers()
                     .wallet(EthereumWallet::from(signer))
-                    .on_http(rpc_url);
+                    .on_http(rpc);
 
                 let chain = Chain::try_from_provider(&provider).await?;
 
@@ -217,10 +227,14 @@ impl SymbioticSubcommand {
                     info!(?address, "Symbiotic operator is registered");
                 } else {
                     warn!(?address, "Operator not registered");
-                    return Ok(())
+                    return Ok(());
                 }
 
-                match bolt_manager.updateOperatorRPC(operator_rpc.to_string()).send().await {
+                let result = match bolt_manager
+                    .updateOperatorRPC(operator_rpc.to_string())
+                    .send()
+                    .await
+                {
                     Ok(pending) => {
                         info!(
                             hash = ?pending.tx_hash(),
@@ -232,7 +246,8 @@ impl SymbioticSubcommand {
                             eyre::bail!("Transaction failed: {:?}", receipt)
                         }
 
-                        info!("Succesfully updated Symbiotic operator RPC");
+                        info!("Successfully updated Symbiotic operator RPC");
+                        Ok(())
                     }
                     Err(e) => match try_parse_contract_error::<BoltManagerErrors>(e)? {
                         BoltManagerErrors::OperatorNotRegistered(_) => {
@@ -242,8 +257,11 @@ impl SymbioticSubcommand {
                             unreachable!("Unexpected error with selector {:?}", other.selector())
                         }
                     },
-                }
-                Ok(())
+                };
+
+                shutdown_anvil(anvil);
+
+                result
             }
 
             Self::Status { rpc_url, address } => {
@@ -274,13 +292,13 @@ impl SymbioticSubcommand {
                                 info!(?address, "Symbiotic operator is registered");
                             } else {
                                 warn!(?address, "Operator not registered");
-                                return Ok(())
+                                return Ok(());
                             }
                         }
                         Err(e) => {
                             let other = try_parse_contract_error::<OperatorsRegistryV1Errors>(e)?;
                             bail!("Unexpected error with selector {:?}", other.selector())
-                        },
+                        }
                     }
 
                     match registry.isActiveOperator(address).call().await {
@@ -294,7 +312,7 @@ impl SymbioticSubcommand {
                         Err(e) => {
                             let other = try_parse_contract_error::<OperatorsRegistryV1Errors>(e)?;
                             bail!("Unexpected error with selector {:?}", other.selector())
-                        },
+                        }
                     }
 
                     match middleware.getOperatorCollaterals(address).call().await {
@@ -322,10 +340,13 @@ impl SymbioticSubcommand {
                         info!(?address, "Symbiotic operator is registered");
                     } else {
                         warn!(?address, "Operator not registered");
-                        return Ok(())
+                        return Ok(());
                     }
 
-                    let middleware = BoltSymbioticMiddlewareHolesky::new(deployments.bolt.symbiotic_middleware, provider.clone());
+                    let middleware = BoltSymbioticMiddlewareHolesky::new(
+                        deployments.bolt.symbiotic_middleware,
+                        provider.clone(),
+                    );
 
                     match bolt_manager.getOperatorData(address).call().await {
                         Ok(operator_data) => {
@@ -367,8 +388,10 @@ impl SymbioticSubcommand {
                 Ok(())
             }
 
-            Self::ListVaults { rpc_url } => {
-                let provider = ProviderBuilder::new().on_http(rpc_url.clone());
+            Self::ListVaults { rpc_url, dry_run } => {
+                let (rpc, anvil) = handle_rpc_dry_run(rpc_url, dry_run)?;
+
+                let provider = ProviderBuilder::new().on_http(rpc);
 
                 let chain = Chain::try_from_provider(&provider).await?;
 
@@ -403,6 +426,8 @@ impl SymbioticSubcommand {
 
                     info!("- Token: {} - Vault: {}", token_symbol, vault_address);
                 }
+
+                shutdown_anvil(anvil);
 
                 Ok(())
             }
@@ -585,6 +610,7 @@ mod tests {
                     operator_private_key: secret_key,
                     extra_data: "sudo rm -rf / --no-preserve-root".to_string(),
                     operator_rpc: None,
+                    dry_run: false,
                 },
             },
         };
@@ -610,6 +636,7 @@ mod tests {
                     operator_rpc: "https://boooooooooooooooolt.chainbound.io"
                         .parse()
                         .expect("valid url"),
+                    dry_run: false,
                 },
             },
         };
@@ -632,6 +659,7 @@ mod tests {
                 subcommand: SymbioticSubcommand::Deregister {
                     rpc_url: anvil_url.clone(),
                     operator_private_key: secret_key,
+                    dry_run: false,
                 },
             },
         };

--- a/bolt-cli/src/pb/v1.rs
+++ b/bolt-cli/src/pb/v1.rs
@@ -89,9 +89,10 @@ pub mod lister_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::{http::Uri, *};
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct ListerClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -135,8 +136,9 @@ pub mod lister_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             ListerClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -174,11 +176,18 @@ pub mod lister_client {
         pub async fn list_accounts(
             &mut self,
             request: impl tonic::IntoRequest<super::ListAccountsRequest>,
-        ) -> std::result::Result<tonic::Response<super::ListAccountsResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::ListAccountsResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/v1.Lister/ListAccounts");
             let mut req = request.into_request();
@@ -194,17 +203,19 @@ pub mod lister_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
-    /// Generated trait containing gRPC methods that should be implemented for use with
-    /// ListerServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with ListerServer.
     #[async_trait]
     pub trait Lister: std::marker::Send + std::marker::Sync + 'static {
         async fn list_accounts(
             &self,
             request: tonic::Request<super::ListAccountsRequest>,
-        ) -> std::result::Result<tonic::Response<super::ListAccountsResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::ListAccountsResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct ListerServer<T> {
@@ -227,7 +238,10 @@ pub mod lister_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -282,16 +296,23 @@ pub mod lister_server {
                 "/v1.Lister/ListAccounts" => {
                     #[allow(non_camel_case_types)]
                     struct ListAccountsSvc<T: Lister>(pub Arc<T>);
-                    impl<T: Lister> tonic::server::UnaryService<super::ListAccountsRequest> for ListAccountsSvc<T> {
+                    impl<
+                        T: Lister,
+                    > tonic::server::UnaryService<super::ListAccountsRequest>
+                    for ListAccountsSvc<T> {
                         type Response = super::ListAccountsResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ListAccountsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as Lister>::list_accounts(&inner, request).await };
+                            let fut = async move {
+                                <T as Lister>::list_accounts(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -317,16 +338,23 @@ pub mod lister_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(http::header::CONTENT_TYPE, tonic::metadata::GRPC_CONTENT_TYPE);
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -470,9 +498,10 @@ pub mod signer_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::{http::Uri, *};
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct SignerClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -516,8 +545,9 @@ pub mod signer_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             SignerClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -556,9 +586,14 @@ pub mod signer_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SignRequest>,
         ) -> std::result::Result<tonic::Response<super::SignResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/v1.Signer/Sign");
             let mut req = request.into_request();
@@ -568,10 +603,18 @@ pub mod signer_client {
         pub async fn multisign(
             &mut self,
             request: impl tonic::IntoRequest<super::MultisignRequest>,
-        ) -> std::result::Result<tonic::Response<super::MultisignResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::MultisignResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/v1.Signer/Multisign");
             let mut req = request.into_request();
@@ -582,39 +625,66 @@ pub mod signer_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SignBeaconAttestationRequest>,
         ) -> std::result::Result<tonic::Response<super::SignResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/v1.Signer/SignBeaconAttestation");
+            let path = http::uri::PathAndQuery::from_static(
+                "/v1.Signer/SignBeaconAttestation",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("v1.Signer", "SignBeaconAttestation"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("v1.Signer", "SignBeaconAttestation"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn sign_beacon_attestations(
             &mut self,
             request: impl tonic::IntoRequest<super::SignBeaconAttestationsRequest>,
-        ) -> std::result::Result<tonic::Response<super::MultisignResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::MultisignResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/v1.Signer/SignBeaconAttestations");
+            let path = http::uri::PathAndQuery::from_static(
+                "/v1.Signer/SignBeaconAttestations",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("v1.Signer", "SignBeaconAttestations"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("v1.Signer", "SignBeaconAttestations"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn sign_beacon_proposal(
             &mut self,
             request: impl tonic::IntoRequest<super::SignBeaconProposalRequest>,
         ) -> std::result::Result<tonic::Response<super::SignResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/v1.Signer/SignBeaconProposal");
+            let path = http::uri::PathAndQuery::from_static(
+                "/v1.Signer/SignBeaconProposal",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("v1.Signer", "SignBeaconProposal"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("v1.Signer", "SignBeaconProposal"));
             self.inner.unary(req, path, codec).await
         }
     }
@@ -626,11 +696,10 @@ pub mod signer_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
-    /// Generated trait containing gRPC methods that should be implemented for use with
-    /// SignerServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with SignerServer.
     #[async_trait]
     pub trait Signer: std::marker::Send + std::marker::Sync + 'static {
         async fn sign(
@@ -640,7 +709,10 @@ pub mod signer_server {
         async fn multisign(
             &self,
             request: tonic::Request<super::MultisignRequest>,
-        ) -> std::result::Result<tonic::Response<super::MultisignResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::MultisignResponse>,
+            tonic::Status,
+        >;
         async fn sign_beacon_attestation(
             &self,
             request: tonic::Request<super::SignBeaconAttestationRequest>,
@@ -648,7 +720,10 @@ pub mod signer_server {
         async fn sign_beacon_attestations(
             &self,
             request: tonic::Request<super::SignBeaconAttestationsRequest>,
-        ) -> std::result::Result<tonic::Response<super::MultisignResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::MultisignResponse>,
+            tonic::Status,
+        >;
         async fn sign_beacon_proposal(
             &self,
             request: tonic::Request<super::SignBeaconProposalRequest>,
@@ -675,7 +750,10 @@ pub mod signer_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -730,15 +808,21 @@ pub mod signer_server {
                 "/v1.Signer/Sign" => {
                     #[allow(non_camel_case_types)]
                     struct SignSvc<T: Signer>(pub Arc<T>);
-                    impl<T: Signer> tonic::server::UnaryService<super::SignRequest> for SignSvc<T> {
+                    impl<T: Signer> tonic::server::UnaryService<super::SignRequest>
+                    for SignSvc<T> {
                         type Response = super::SignResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SignRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move { <T as Signer>::sign(&inner, request).await };
+                            let fut = async move {
+                                <T as Signer>::sign(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -767,16 +851,21 @@ pub mod signer_server {
                 "/v1.Signer/Multisign" => {
                     #[allow(non_camel_case_types)]
                     struct MultisignSvc<T: Signer>(pub Arc<T>);
-                    impl<T: Signer> tonic::server::UnaryService<super::MultisignRequest> for MultisignSvc<T> {
+                    impl<T: Signer> tonic::server::UnaryService<super::MultisignRequest>
+                    for MultisignSvc<T> {
                         type Response = super::MultisignResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::MultisignRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as Signer>::multisign(&inner, request).await };
+                            let fut = async move {
+                                <T as Signer>::multisign(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -805,18 +894,23 @@ pub mod signer_server {
                 "/v1.Signer/SignBeaconAttestation" => {
                     #[allow(non_camel_case_types)]
                     struct SignBeaconAttestationSvc<T: Signer>(pub Arc<T>);
-                    impl<T: Signer> tonic::server::UnaryService<super::SignBeaconAttestationRequest>
-                        for SignBeaconAttestationSvc<T>
-                    {
+                    impl<
+                        T: Signer,
+                    > tonic::server::UnaryService<super::SignBeaconAttestationRequest>
+                    for SignBeaconAttestationSvc<T> {
                         type Response = super::SignResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SignBeaconAttestationRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as Signer>::sign_beacon_attestation(&inner, request).await
+                                <T as Signer>::sign_beacon_attestation(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -846,19 +940,23 @@ pub mod signer_server {
                 "/v1.Signer/SignBeaconAttestations" => {
                     #[allow(non_camel_case_types)]
                     struct SignBeaconAttestationsSvc<T: Signer>(pub Arc<T>);
-                    impl<T: Signer>
-                        tonic::server::UnaryService<super::SignBeaconAttestationsRequest>
-                        for SignBeaconAttestationsSvc<T>
-                    {
+                    impl<
+                        T: Signer,
+                    > tonic::server::UnaryService<super::SignBeaconAttestationsRequest>
+                    for SignBeaconAttestationsSvc<T> {
                         type Response = super::MultisignResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SignBeaconAttestationsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as Signer>::sign_beacon_attestations(&inner, request).await
+                                <T as Signer>::sign_beacon_attestations(&inner, request)
+                                    .await
                             };
                             Box::pin(fut)
                         }
@@ -888,11 +986,15 @@ pub mod signer_server {
                 "/v1.Signer/SignBeaconProposal" => {
                     #[allow(non_camel_case_types)]
                     struct SignBeaconProposalSvc<T: Signer>(pub Arc<T>);
-                    impl<T: Signer> tonic::server::UnaryService<super::SignBeaconProposalRequest>
-                        for SignBeaconProposalSvc<T>
-                    {
+                    impl<
+                        T: Signer,
+                    > tonic::server::UnaryService<super::SignBeaconProposalRequest>
+                    for SignBeaconProposalSvc<T> {
                         type Response = super::SignResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SignBeaconProposalRequest>,
@@ -926,16 +1028,23 @@ pub mod signer_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(http::header::CONTENT_TYPE, tonic::metadata::GRPC_CONTENT_TYPE);
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -1008,9 +1117,10 @@ pub mod account_manager_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::{http::Uri, *};
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct AccountManagerClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -1054,8 +1164,9 @@ pub mod account_manager_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             AccountManagerClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -1093,11 +1204,18 @@ pub mod account_manager_client {
         pub async fn unlock(
             &mut self,
             request: impl tonic::IntoRequest<super::UnlockAccountRequest>,
-        ) -> std::result::Result<tonic::Response<super::UnlockAccountResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::UnlockAccountResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/v1.AccountManager/Unlock");
             let mut req = request.into_request();
@@ -1107,11 +1225,18 @@ pub mod account_manager_client {
         pub async fn lock(
             &mut self,
             request: impl tonic::IntoRequest<super::LockAccountRequest>,
-        ) -> std::result::Result<tonic::Response<super::LockAccountResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::LockAccountResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/v1.AccountManager/Lock");
             let mut req = request.into_request();
@@ -1121,14 +1246,25 @@ pub mod account_manager_client {
         pub async fn generate(
             &mut self,
             request: impl tonic::IntoRequest<super::GenerateRequest>,
-        ) -> std::result::Result<tonic::Response<super::GenerateResponse>, tonic::Status> {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::GenerateResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static("/v1.AccountManager/Generate");
+            let path = http::uri::PathAndQuery::from_static(
+                "/v1.AccountManager/Generate",
+            );
             let mut req = request.into_request();
-            req.extensions_mut().insert(GrpcMethod::new("v1.AccountManager", "Generate"));
+            req.extensions_mut()
+                .insert(GrpcMethod::new("v1.AccountManager", "Generate"));
             self.inner.unary(req, path, codec).await
         }
     }
@@ -1140,25 +1276,33 @@ pub mod account_manager_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
-    /// Generated trait containing gRPC methods that should be implemented for use with
-    /// AccountManagerServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with AccountManagerServer.
     #[async_trait]
     pub trait AccountManager: std::marker::Send + std::marker::Sync + 'static {
         async fn unlock(
             &self,
             request: tonic::Request<super::UnlockAccountRequest>,
-        ) -> std::result::Result<tonic::Response<super::UnlockAccountResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::UnlockAccountResponse>,
+            tonic::Status,
+        >;
         async fn lock(
             &self,
             request: tonic::Request<super::LockAccountRequest>,
-        ) -> std::result::Result<tonic::Response<super::LockAccountResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::LockAccountResponse>,
+            tonic::Status,
+        >;
         async fn generate(
             &self,
             request: tonic::Request<super::GenerateRequest>,
-        ) -> std::result::Result<tonic::Response<super::GenerateResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::GenerateResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct AccountManagerServer<T> {
@@ -1181,7 +1325,10 @@ pub mod account_manager_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -1236,16 +1383,23 @@ pub mod account_manager_server {
                 "/v1.AccountManager/Unlock" => {
                     #[allow(non_camel_case_types)]
                     struct UnlockSvc<T: AccountManager>(pub Arc<T>);
-                    impl<T: AccountManager> tonic::server::UnaryService<super::UnlockAccountRequest> for UnlockSvc<T> {
+                    impl<
+                        T: AccountManager,
+                    > tonic::server::UnaryService<super::UnlockAccountRequest>
+                    for UnlockSvc<T> {
                         type Response = super::UnlockAccountResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::UnlockAccountRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as AccountManager>::unlock(&inner, request).await };
+                            let fut = async move {
+                                <T as AccountManager>::unlock(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1274,16 +1428,23 @@ pub mod account_manager_server {
                 "/v1.AccountManager/Lock" => {
                     #[allow(non_camel_case_types)]
                     struct LockSvc<T: AccountManager>(pub Arc<T>);
-                    impl<T: AccountManager> tonic::server::UnaryService<super::LockAccountRequest> for LockSvc<T> {
+                    impl<
+                        T: AccountManager,
+                    > tonic::server::UnaryService<super::LockAccountRequest>
+                    for LockSvc<T> {
                         type Response = super::LockAccountResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::LockAccountRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as AccountManager>::lock(&inner, request).await };
+                            let fut = async move {
+                                <T as AccountManager>::lock(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1312,9 +1473,15 @@ pub mod account_manager_server {
                 "/v1.AccountManager/Generate" => {
                     #[allow(non_camel_case_types)]
                     struct GenerateSvc<T: AccountManager>(pub Arc<T>);
-                    impl<T: AccountManager> tonic::server::UnaryService<super::GenerateRequest> for GenerateSvc<T> {
+                    impl<
+                        T: AccountManager,
+                    > tonic::server::UnaryService<super::GenerateRequest>
+                    for GenerateSvc<T> {
                         type Response = super::GenerateResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GenerateRequest>,
@@ -1348,16 +1515,23 @@ pub mod account_manager_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(http::header::CONTENT_TYPE, tonic::metadata::GRPC_CONTENT_TYPE);
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }
@@ -1408,9 +1582,10 @@ pub mod wallet_manager_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
-    use tonic::codegen::{http::Uri, *};
+    use tonic::codegen::*;
+    use tonic::codegen::http::Uri;
     #[derive(Debug, Clone)]
     pub struct WalletManagerClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -1454,8 +1629,9 @@ pub mod wallet_manager_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
-                Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<
+                http::Request<tonic::body::BoxBody>,
+            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             WalletManagerClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -1493,11 +1669,18 @@ pub mod wallet_manager_client {
         pub async fn unlock(
             &mut self,
             request: impl tonic::IntoRequest<super::UnlockWalletRequest>,
-        ) -> std::result::Result<tonic::Response<super::UnlockWalletResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::UnlockWalletResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/v1.WalletManager/Unlock");
             let mut req = request.into_request();
@@ -1507,11 +1690,18 @@ pub mod wallet_manager_client {
         pub async fn lock(
             &mut self,
             request: impl tonic::IntoRequest<super::LockWalletRequest>,
-        ) -> std::result::Result<tonic::Response<super::LockWalletResponse>, tonic::Status>
-        {
-            self.inner.ready().await.map_err(|e| {
-                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
-            })?;
+        ) -> std::result::Result<
+            tonic::Response<super::LockWalletResponse>,
+            tonic::Status,
+        > {
+            self.inner
+                .ready()
+                .await
+                .map_err(|e| {
+                    tonic::Status::unknown(
+                        format!("Service was not ready: {}", e.into()),
+                    )
+                })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/v1.WalletManager/Lock");
             let mut req = request.into_request();
@@ -1527,21 +1717,26 @@ pub mod wallet_manager_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value
+        clippy::let_unit_value,
     )]
     use tonic::codegen::*;
-    /// Generated trait containing gRPC methods that should be implemented for use with
-    /// WalletManagerServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with WalletManagerServer.
     #[async_trait]
     pub trait WalletManager: std::marker::Send + std::marker::Sync + 'static {
         async fn unlock(
             &self,
             request: tonic::Request<super::UnlockWalletRequest>,
-        ) -> std::result::Result<tonic::Response<super::UnlockWalletResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::UnlockWalletResponse>,
+            tonic::Status,
+        >;
         async fn lock(
             &self,
             request: tonic::Request<super::LockWalletRequest>,
-        ) -> std::result::Result<tonic::Response<super::LockWalletResponse>, tonic::Status>;
+        ) -> std::result::Result<
+            tonic::Response<super::LockWalletResponse>,
+            tonic::Status,
+        >;
     }
     #[derive(Debug)]
     pub struct WalletManagerServer<T> {
@@ -1564,7 +1759,10 @@ pub mod wallet_manager_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(
+            inner: T,
+            interceptor: F,
+        ) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -1619,16 +1817,23 @@ pub mod wallet_manager_server {
                 "/v1.WalletManager/Unlock" => {
                     #[allow(non_camel_case_types)]
                     struct UnlockSvc<T: WalletManager>(pub Arc<T>);
-                    impl<T: WalletManager> tonic::server::UnaryService<super::UnlockWalletRequest> for UnlockSvc<T> {
+                    impl<
+                        T: WalletManager,
+                    > tonic::server::UnaryService<super::UnlockWalletRequest>
+                    for UnlockSvc<T> {
                         type Response = super::UnlockWalletResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::UnlockWalletRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as WalletManager>::unlock(&inner, request).await };
+                            let fut = async move {
+                                <T as WalletManager>::unlock(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1657,16 +1862,23 @@ pub mod wallet_manager_server {
                 "/v1.WalletManager/Lock" => {
                     #[allow(non_camel_case_types)]
                     struct LockSvc<T: WalletManager>(pub Arc<T>);
-                    impl<T: WalletManager> tonic::server::UnaryService<super::LockWalletRequest> for LockSvc<T> {
+                    impl<
+                        T: WalletManager,
+                    > tonic::server::UnaryService<super::LockWalletRequest>
+                    for LockSvc<T> {
                         type Response = super::LockWalletResponse;
-                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
+                        type Future = BoxFuture<
+                            tonic::Response<Self::Response>,
+                            tonic::Status,
+                        >;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::LockWalletRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut =
-                                async move { <T as WalletManager>::lock(&inner, request).await };
+                            let fut = async move {
+                                <T as WalletManager>::lock(&inner, request).await
+                            };
                             Box::pin(fut)
                         }
                     }
@@ -1692,16 +1904,23 @@ pub mod wallet_manager_server {
                     };
                     Box::pin(fut)
                 }
-                _ => Box::pin(async move {
-                    let mut response = http::Response::new(empty_body());
-                    let headers = response.headers_mut();
-                    headers.insert(
-                        tonic::Status::GRPC_STATUS,
-                        (tonic::Code::Unimplemented as i32).into(),
-                    );
-                    headers.insert(http::header::CONTENT_TYPE, tonic::metadata::GRPC_CONTENT_TYPE);
-                    Ok(response)
-                }),
+                _ => {
+                    Box::pin(async move {
+                        let mut response = http::Response::new(empty_body());
+                        let headers = response.headers_mut();
+                        headers
+                            .insert(
+                                tonic::Status::GRPC_STATUS,
+                                (tonic::Code::Unimplemented as i32).into(),
+                            );
+                        headers
+                            .insert(
+                                http::header::CONTENT_TYPE,
+                                tonic::metadata::GRPC_CONTENT_TYPE,
+                            );
+                        Ok(response)
+                    })
+                }
             }
         }
     }

--- a/bolt-cli/src/pb/v1.rs
+++ b/bolt-cli/src/pb/v1.rs
@@ -89,10 +89,9 @@ pub mod lister_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
-    use tonic::codegen::*;
-    use tonic::codegen::http::Uri;
+    use tonic::codegen::{http::Uri, *};
     #[derive(Debug, Clone)]
     pub struct ListerClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -136,9 +135,8 @@ pub mod lister_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             ListerClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -176,18 +174,11 @@ pub mod lister_client {
         pub async fn list_accounts(
             &mut self,
             request: impl tonic::IntoRequest<super::ListAccountsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ListAccountsResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::ListAccountsResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/v1.Lister/ListAccounts");
             let mut req = request.into_request();
@@ -203,19 +194,17 @@ pub mod lister_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
     use tonic::codegen::*;
-    /// Generated trait containing gRPC methods that should be implemented for use with ListerServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with
+    /// ListerServer.
     #[async_trait]
     pub trait Lister: std::marker::Send + std::marker::Sync + 'static {
         async fn list_accounts(
             &self,
             request: tonic::Request<super::ListAccountsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::ListAccountsResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::ListAccountsResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct ListerServer<T> {
@@ -238,10 +227,7 @@ pub mod lister_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -296,23 +282,16 @@ pub mod lister_server {
                 "/v1.Lister/ListAccounts" => {
                     #[allow(non_camel_case_types)]
                     struct ListAccountsSvc<T: Lister>(pub Arc<T>);
-                    impl<
-                        T: Lister,
-                    > tonic::server::UnaryService<super::ListAccountsRequest>
-                    for ListAccountsSvc<T> {
+                    impl<T: Lister> tonic::server::UnaryService<super::ListAccountsRequest> for ListAccountsSvc<T> {
                         type Response = super::ListAccountsResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::ListAccountsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as Lister>::list_accounts(&inner, request).await
-                            };
+                            let fut =
+                                async move { <T as Lister>::list_accounts(&inner, request).await };
                             Box::pin(fut)
                         }
                     }
@@ -338,23 +317,16 @@ pub mod lister_server {
                     };
                     Box::pin(fut)
                 }
-                _ => {
-                    Box::pin(async move {
-                        let mut response = http::Response::new(empty_body());
-                        let headers = response.headers_mut();
-                        headers
-                            .insert(
-                                tonic::Status::GRPC_STATUS,
-                                (tonic::Code::Unimplemented as i32).into(),
-                            );
-                        headers
-                            .insert(
-                                http::header::CONTENT_TYPE,
-                                tonic::metadata::GRPC_CONTENT_TYPE,
-                            );
-                        Ok(response)
-                    })
-                }
+                _ => Box::pin(async move {
+                    let mut response = http::Response::new(empty_body());
+                    let headers = response.headers_mut();
+                    headers.insert(
+                        tonic::Status::GRPC_STATUS,
+                        (tonic::Code::Unimplemented as i32).into(),
+                    );
+                    headers.insert(http::header::CONTENT_TYPE, tonic::metadata::GRPC_CONTENT_TYPE);
+                    Ok(response)
+                }),
             }
         }
     }
@@ -498,10 +470,9 @@ pub mod signer_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
-    use tonic::codegen::*;
-    use tonic::codegen::http::Uri;
+    use tonic::codegen::{http::Uri, *};
     #[derive(Debug, Clone)]
     pub struct SignerClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -545,9 +516,8 @@ pub mod signer_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             SignerClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -586,14 +556,9 @@ pub mod signer_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SignRequest>,
         ) -> std::result::Result<tonic::Response<super::SignResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/v1.Signer/Sign");
             let mut req = request.into_request();
@@ -603,18 +568,10 @@ pub mod signer_client {
         pub async fn multisign(
             &mut self,
             request: impl tonic::IntoRequest<super::MultisignRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::MultisignResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::MultisignResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/v1.Signer/Multisign");
             let mut req = request.into_request();
@@ -625,66 +582,39 @@ pub mod signer_client {
             &mut self,
             request: impl tonic::IntoRequest<super::SignBeaconAttestationRequest>,
         ) -> std::result::Result<tonic::Response<super::SignResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/v1.Signer/SignBeaconAttestation",
-            );
+            let path = http::uri::PathAndQuery::from_static("/v1.Signer/SignBeaconAttestation");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("v1.Signer", "SignBeaconAttestation"));
+            req.extensions_mut().insert(GrpcMethod::new("v1.Signer", "SignBeaconAttestation"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn sign_beacon_attestations(
             &mut self,
             request: impl tonic::IntoRequest<super::SignBeaconAttestationsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::MultisignResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::MultisignResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/v1.Signer/SignBeaconAttestations",
-            );
+            let path = http::uri::PathAndQuery::from_static("/v1.Signer/SignBeaconAttestations");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("v1.Signer", "SignBeaconAttestations"));
+            req.extensions_mut().insert(GrpcMethod::new("v1.Signer", "SignBeaconAttestations"));
             self.inner.unary(req, path, codec).await
         }
         pub async fn sign_beacon_proposal(
             &mut self,
             request: impl tonic::IntoRequest<super::SignBeaconProposalRequest>,
         ) -> std::result::Result<tonic::Response<super::SignResponse>, tonic::Status> {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/v1.Signer/SignBeaconProposal",
-            );
+            let path = http::uri::PathAndQuery::from_static("/v1.Signer/SignBeaconProposal");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("v1.Signer", "SignBeaconProposal"));
+            req.extensions_mut().insert(GrpcMethod::new("v1.Signer", "SignBeaconProposal"));
             self.inner.unary(req, path, codec).await
         }
     }
@@ -696,10 +626,11 @@ pub mod signer_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
     use tonic::codegen::*;
-    /// Generated trait containing gRPC methods that should be implemented for use with SignerServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with
+    /// SignerServer.
     #[async_trait]
     pub trait Signer: std::marker::Send + std::marker::Sync + 'static {
         async fn sign(
@@ -709,10 +640,7 @@ pub mod signer_server {
         async fn multisign(
             &self,
             request: tonic::Request<super::MultisignRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::MultisignResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::MultisignResponse>, tonic::Status>;
         async fn sign_beacon_attestation(
             &self,
             request: tonic::Request<super::SignBeaconAttestationRequest>,
@@ -720,10 +648,7 @@ pub mod signer_server {
         async fn sign_beacon_attestations(
             &self,
             request: tonic::Request<super::SignBeaconAttestationsRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::MultisignResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::MultisignResponse>, tonic::Status>;
         async fn sign_beacon_proposal(
             &self,
             request: tonic::Request<super::SignBeaconProposalRequest>,
@@ -750,10 +675,7 @@ pub mod signer_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -808,21 +730,15 @@ pub mod signer_server {
                 "/v1.Signer/Sign" => {
                     #[allow(non_camel_case_types)]
                     struct SignSvc<T: Signer>(pub Arc<T>);
-                    impl<T: Signer> tonic::server::UnaryService<super::SignRequest>
-                    for SignSvc<T> {
+                    impl<T: Signer> tonic::server::UnaryService<super::SignRequest> for SignSvc<T> {
                         type Response = super::SignResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SignRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as Signer>::sign(&inner, request).await
-                            };
+                            let fut = async move { <T as Signer>::sign(&inner, request).await };
                             Box::pin(fut)
                         }
                     }
@@ -851,21 +767,16 @@ pub mod signer_server {
                 "/v1.Signer/Multisign" => {
                     #[allow(non_camel_case_types)]
                     struct MultisignSvc<T: Signer>(pub Arc<T>);
-                    impl<T: Signer> tonic::server::UnaryService<super::MultisignRequest>
-                    for MultisignSvc<T> {
+                    impl<T: Signer> tonic::server::UnaryService<super::MultisignRequest> for MultisignSvc<T> {
                         type Response = super::MultisignResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::MultisignRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as Signer>::multisign(&inner, request).await
-                            };
+                            let fut =
+                                async move { <T as Signer>::multisign(&inner, request).await };
                             Box::pin(fut)
                         }
                     }
@@ -894,23 +805,18 @@ pub mod signer_server {
                 "/v1.Signer/SignBeaconAttestation" => {
                     #[allow(non_camel_case_types)]
                     struct SignBeaconAttestationSvc<T: Signer>(pub Arc<T>);
-                    impl<
-                        T: Signer,
-                    > tonic::server::UnaryService<super::SignBeaconAttestationRequest>
-                    for SignBeaconAttestationSvc<T> {
+                    impl<T: Signer> tonic::server::UnaryService<super::SignBeaconAttestationRequest>
+                        for SignBeaconAttestationSvc<T>
+                    {
                         type Response = super::SignResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SignBeaconAttestationRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as Signer>::sign_beacon_attestation(&inner, request)
-                                    .await
+                                <T as Signer>::sign_beacon_attestation(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -940,23 +846,19 @@ pub mod signer_server {
                 "/v1.Signer/SignBeaconAttestations" => {
                     #[allow(non_camel_case_types)]
                     struct SignBeaconAttestationsSvc<T: Signer>(pub Arc<T>);
-                    impl<
-                        T: Signer,
-                    > tonic::server::UnaryService<super::SignBeaconAttestationsRequest>
-                    for SignBeaconAttestationsSvc<T> {
+                    impl<T: Signer>
+                        tonic::server::UnaryService<super::SignBeaconAttestationsRequest>
+                        for SignBeaconAttestationsSvc<T>
+                    {
                         type Response = super::MultisignResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SignBeaconAttestationsRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
                             let fut = async move {
-                                <T as Signer>::sign_beacon_attestations(&inner, request)
-                                    .await
+                                <T as Signer>::sign_beacon_attestations(&inner, request).await
                             };
                             Box::pin(fut)
                         }
@@ -986,15 +888,11 @@ pub mod signer_server {
                 "/v1.Signer/SignBeaconProposal" => {
                     #[allow(non_camel_case_types)]
                     struct SignBeaconProposalSvc<T: Signer>(pub Arc<T>);
-                    impl<
-                        T: Signer,
-                    > tonic::server::UnaryService<super::SignBeaconProposalRequest>
-                    for SignBeaconProposalSvc<T> {
+                    impl<T: Signer> tonic::server::UnaryService<super::SignBeaconProposalRequest>
+                        for SignBeaconProposalSvc<T>
+                    {
                         type Response = super::SignResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::SignBeaconProposalRequest>,
@@ -1028,23 +926,16 @@ pub mod signer_server {
                     };
                     Box::pin(fut)
                 }
-                _ => {
-                    Box::pin(async move {
-                        let mut response = http::Response::new(empty_body());
-                        let headers = response.headers_mut();
-                        headers
-                            .insert(
-                                tonic::Status::GRPC_STATUS,
-                                (tonic::Code::Unimplemented as i32).into(),
-                            );
-                        headers
-                            .insert(
-                                http::header::CONTENT_TYPE,
-                                tonic::metadata::GRPC_CONTENT_TYPE,
-                            );
-                        Ok(response)
-                    })
-                }
+                _ => Box::pin(async move {
+                    let mut response = http::Response::new(empty_body());
+                    let headers = response.headers_mut();
+                    headers.insert(
+                        tonic::Status::GRPC_STATUS,
+                        (tonic::Code::Unimplemented as i32).into(),
+                    );
+                    headers.insert(http::header::CONTENT_TYPE, tonic::metadata::GRPC_CONTENT_TYPE);
+                    Ok(response)
+                }),
             }
         }
     }
@@ -1117,10 +1008,9 @@ pub mod account_manager_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
-    use tonic::codegen::*;
-    use tonic::codegen::http::Uri;
+    use tonic::codegen::{http::Uri, *};
     #[derive(Debug, Clone)]
     pub struct AccountManagerClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -1164,9 +1054,8 @@ pub mod account_manager_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             AccountManagerClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -1204,18 +1093,11 @@ pub mod account_manager_client {
         pub async fn unlock(
             &mut self,
             request: impl tonic::IntoRequest<super::UnlockAccountRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::UnlockAccountResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::UnlockAccountResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/v1.AccountManager/Unlock");
             let mut req = request.into_request();
@@ -1225,18 +1107,11 @@ pub mod account_manager_client {
         pub async fn lock(
             &mut self,
             request: impl tonic::IntoRequest<super::LockAccountRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::LockAccountResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::LockAccountResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/v1.AccountManager/Lock");
             let mut req = request.into_request();
@@ -1246,25 +1121,14 @@ pub mod account_manager_client {
         pub async fn generate(
             &mut self,
             request: impl tonic::IntoRequest<super::GenerateRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GenerateResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::GenerateResponse>, tonic::Status> {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
-            let path = http::uri::PathAndQuery::from_static(
-                "/v1.AccountManager/Generate",
-            );
+            let path = http::uri::PathAndQuery::from_static("/v1.AccountManager/Generate");
             let mut req = request.into_request();
-            req.extensions_mut()
-                .insert(GrpcMethod::new("v1.AccountManager", "Generate"));
+            req.extensions_mut().insert(GrpcMethod::new("v1.AccountManager", "Generate"));
             self.inner.unary(req, path, codec).await
         }
     }
@@ -1276,33 +1140,25 @@ pub mod account_manager_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
     use tonic::codegen::*;
-    /// Generated trait containing gRPC methods that should be implemented for use with AccountManagerServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with
+    /// AccountManagerServer.
     #[async_trait]
     pub trait AccountManager: std::marker::Send + std::marker::Sync + 'static {
         async fn unlock(
             &self,
             request: tonic::Request<super::UnlockAccountRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::UnlockAccountResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::UnlockAccountResponse>, tonic::Status>;
         async fn lock(
             &self,
             request: tonic::Request<super::LockAccountRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::LockAccountResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::LockAccountResponse>, tonic::Status>;
         async fn generate(
             &self,
             request: tonic::Request<super::GenerateRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::GenerateResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::GenerateResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct AccountManagerServer<T> {
@@ -1325,10 +1181,7 @@ pub mod account_manager_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -1383,23 +1236,16 @@ pub mod account_manager_server {
                 "/v1.AccountManager/Unlock" => {
                     #[allow(non_camel_case_types)]
                     struct UnlockSvc<T: AccountManager>(pub Arc<T>);
-                    impl<
-                        T: AccountManager,
-                    > tonic::server::UnaryService<super::UnlockAccountRequest>
-                    for UnlockSvc<T> {
+                    impl<T: AccountManager> tonic::server::UnaryService<super::UnlockAccountRequest> for UnlockSvc<T> {
                         type Response = super::UnlockAccountResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::UnlockAccountRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as AccountManager>::unlock(&inner, request).await
-                            };
+                            let fut =
+                                async move { <T as AccountManager>::unlock(&inner, request).await };
                             Box::pin(fut)
                         }
                     }
@@ -1428,23 +1274,16 @@ pub mod account_manager_server {
                 "/v1.AccountManager/Lock" => {
                     #[allow(non_camel_case_types)]
                     struct LockSvc<T: AccountManager>(pub Arc<T>);
-                    impl<
-                        T: AccountManager,
-                    > tonic::server::UnaryService<super::LockAccountRequest>
-                    for LockSvc<T> {
+                    impl<T: AccountManager> tonic::server::UnaryService<super::LockAccountRequest> for LockSvc<T> {
                         type Response = super::LockAccountResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::LockAccountRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as AccountManager>::lock(&inner, request).await
-                            };
+                            let fut =
+                                async move { <T as AccountManager>::lock(&inner, request).await };
                             Box::pin(fut)
                         }
                     }
@@ -1473,15 +1312,9 @@ pub mod account_manager_server {
                 "/v1.AccountManager/Generate" => {
                     #[allow(non_camel_case_types)]
                     struct GenerateSvc<T: AccountManager>(pub Arc<T>);
-                    impl<
-                        T: AccountManager,
-                    > tonic::server::UnaryService<super::GenerateRequest>
-                    for GenerateSvc<T> {
+                    impl<T: AccountManager> tonic::server::UnaryService<super::GenerateRequest> for GenerateSvc<T> {
                         type Response = super::GenerateResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::GenerateRequest>,
@@ -1515,23 +1348,16 @@ pub mod account_manager_server {
                     };
                     Box::pin(fut)
                 }
-                _ => {
-                    Box::pin(async move {
-                        let mut response = http::Response::new(empty_body());
-                        let headers = response.headers_mut();
-                        headers
-                            .insert(
-                                tonic::Status::GRPC_STATUS,
-                                (tonic::Code::Unimplemented as i32).into(),
-                            );
-                        headers
-                            .insert(
-                                http::header::CONTENT_TYPE,
-                                tonic::metadata::GRPC_CONTENT_TYPE,
-                            );
-                        Ok(response)
-                    })
-                }
+                _ => Box::pin(async move {
+                    let mut response = http::Response::new(empty_body());
+                    let headers = response.headers_mut();
+                    headers.insert(
+                        tonic::Status::GRPC_STATUS,
+                        (tonic::Code::Unimplemented as i32).into(),
+                    );
+                    headers.insert(http::header::CONTENT_TYPE, tonic::metadata::GRPC_CONTENT_TYPE);
+                    Ok(response)
+                }),
             }
         }
     }
@@ -1582,10 +1408,9 @@ pub mod wallet_manager_client {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
-    use tonic::codegen::*;
-    use tonic::codegen::http::Uri;
+    use tonic::codegen::{http::Uri, *};
     #[derive(Debug, Clone)]
     pub struct WalletManagerClient<T> {
         inner: tonic::client::Grpc<T>,
@@ -1629,9 +1454,8 @@ pub mod wallet_manager_client {
                     <T as tonic::client::GrpcService<tonic::body::BoxBody>>::ResponseBody,
                 >,
             >,
-            <T as tonic::codegen::Service<
-                http::Request<tonic::body::BoxBody>,
-            >>::Error: Into<StdError> + std::marker::Send + std::marker::Sync,
+            <T as tonic::codegen::Service<http::Request<tonic::body::BoxBody>>>::Error:
+                Into<StdError> + std::marker::Send + std::marker::Sync,
         {
             WalletManagerClient::new(InterceptedService::new(inner, interceptor))
         }
@@ -1669,18 +1493,11 @@ pub mod wallet_manager_client {
         pub async fn unlock(
             &mut self,
             request: impl tonic::IntoRequest<super::UnlockWalletRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::UnlockWalletResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::UnlockWalletResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/v1.WalletManager/Unlock");
             let mut req = request.into_request();
@@ -1690,18 +1507,11 @@ pub mod wallet_manager_client {
         pub async fn lock(
             &mut self,
             request: impl tonic::IntoRequest<super::LockWalletRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::LockWalletResponse>,
-            tonic::Status,
-        > {
-            self.inner
-                .ready()
-                .await
-                .map_err(|e| {
-                    tonic::Status::unknown(
-                        format!("Service was not ready: {}", e.into()),
-                    )
-                })?;
+        ) -> std::result::Result<tonic::Response<super::LockWalletResponse>, tonic::Status>
+        {
+            self.inner.ready().await.map_err(|e| {
+                tonic::Status::unknown(format!("Service was not ready: {}", e.into()))
+            })?;
             let codec = tonic::codec::ProstCodec::default();
             let path = http::uri::PathAndQuery::from_static("/v1.WalletManager/Lock");
             let mut req = request.into_request();
@@ -1717,26 +1527,21 @@ pub mod wallet_manager_server {
         dead_code,
         missing_docs,
         clippy::wildcard_imports,
-        clippy::let_unit_value,
+        clippy::let_unit_value
     )]
     use tonic::codegen::*;
-    /// Generated trait containing gRPC methods that should be implemented for use with WalletManagerServer.
+    /// Generated trait containing gRPC methods that should be implemented for use with
+    /// WalletManagerServer.
     #[async_trait]
     pub trait WalletManager: std::marker::Send + std::marker::Sync + 'static {
         async fn unlock(
             &self,
             request: tonic::Request<super::UnlockWalletRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::UnlockWalletResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::UnlockWalletResponse>, tonic::Status>;
         async fn lock(
             &self,
             request: tonic::Request<super::LockWalletRequest>,
-        ) -> std::result::Result<
-            tonic::Response<super::LockWalletResponse>,
-            tonic::Status,
-        >;
+        ) -> std::result::Result<tonic::Response<super::LockWalletResponse>, tonic::Status>;
     }
     #[derive(Debug)]
     pub struct WalletManagerServer<T> {
@@ -1759,10 +1564,7 @@ pub mod wallet_manager_server {
                 max_encoding_message_size: None,
             }
         }
-        pub fn with_interceptor<F>(
-            inner: T,
-            interceptor: F,
-        ) -> InterceptedService<Self, F>
+        pub fn with_interceptor<F>(inner: T, interceptor: F) -> InterceptedService<Self, F>
         where
             F: tonic::service::Interceptor,
         {
@@ -1817,23 +1619,16 @@ pub mod wallet_manager_server {
                 "/v1.WalletManager/Unlock" => {
                     #[allow(non_camel_case_types)]
                     struct UnlockSvc<T: WalletManager>(pub Arc<T>);
-                    impl<
-                        T: WalletManager,
-                    > tonic::server::UnaryService<super::UnlockWalletRequest>
-                    for UnlockSvc<T> {
+                    impl<T: WalletManager> tonic::server::UnaryService<super::UnlockWalletRequest> for UnlockSvc<T> {
                         type Response = super::UnlockWalletResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::UnlockWalletRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as WalletManager>::unlock(&inner, request).await
-                            };
+                            let fut =
+                                async move { <T as WalletManager>::unlock(&inner, request).await };
                             Box::pin(fut)
                         }
                     }
@@ -1862,23 +1657,16 @@ pub mod wallet_manager_server {
                 "/v1.WalletManager/Lock" => {
                     #[allow(non_camel_case_types)]
                     struct LockSvc<T: WalletManager>(pub Arc<T>);
-                    impl<
-                        T: WalletManager,
-                    > tonic::server::UnaryService<super::LockWalletRequest>
-                    for LockSvc<T> {
+                    impl<T: WalletManager> tonic::server::UnaryService<super::LockWalletRequest> for LockSvc<T> {
                         type Response = super::LockWalletResponse;
-                        type Future = BoxFuture<
-                            tonic::Response<Self::Response>,
-                            tonic::Status,
-                        >;
+                        type Future = BoxFuture<tonic::Response<Self::Response>, tonic::Status>;
                         fn call(
                             &mut self,
                             request: tonic::Request<super::LockWalletRequest>,
                         ) -> Self::Future {
                             let inner = Arc::clone(&self.0);
-                            let fut = async move {
-                                <T as WalletManager>::lock(&inner, request).await
-                            };
+                            let fut =
+                                async move { <T as WalletManager>::lock(&inner, request).await };
                             Box::pin(fut)
                         }
                     }
@@ -1904,23 +1692,16 @@ pub mod wallet_manager_server {
                     };
                     Box::pin(fut)
                 }
-                _ => {
-                    Box::pin(async move {
-                        let mut response = http::Response::new(empty_body());
-                        let headers = response.headers_mut();
-                        headers
-                            .insert(
-                                tonic::Status::GRPC_STATUS,
-                                (tonic::Code::Unimplemented as i32).into(),
-                            );
-                        headers
-                            .insert(
-                                http::header::CONTENT_TYPE,
-                                tonic::metadata::GRPC_CONTENT_TYPE,
-                            );
-                        Ok(response)
-                    })
-                }
+                _ => Box::pin(async move {
+                    let mut response = http::Response::new(empty_body());
+                    let headers = response.headers_mut();
+                    headers.insert(
+                        tonic::Status::GRPC_STATUS,
+                        (tonic::Code::Unimplemented as i32).into(),
+                    );
+                    headers.insert(http::header::CONTENT_TYPE, tonic::metadata::GRPC_CONTENT_TYPE);
+                    Ok(response)
+                }),
             }
         }
     }


### PR DESCRIPTION
### Improvements:
- Add -d, --dry-run flag for bolt-cli: When provided commands will "simulate" actual behavior, for instance when making RPC calls or executing smart contracts without broadcasting on net. 
 - Spin Anvil instance for use cases like testing (we can get rid of explicit declaration in test):
 https://github.com/chainbound/bolt/blob/6342fb2ba6dfafbdf518f0c4d32295fca9e8188c/bolt-cli/src/commands/validators.rs#L165-L171

Closes #416 