### PR TITLE
feat(cli): add verbosity flag to output traces on any commands

### DIFF
--- a/bolt-cli/Cargo.lock
+++ b/bolt-cli/Cargo.lock
@@ -2999,6 +2999,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "matchers"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
+dependencies = [
+ "regex-automata 0.1.10",
+]
+
+[[package]]
 name = "matchit"
 version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3611,7 +3620,7 @@ dependencies = [
  "rand",
  "rand_chacha",
  "rand_xorshift",
- "regex-syntax",
+ "regex-syntax 0.8.5",
  "rusty-fork",
  "tempfile",
  "unarray",
@@ -3806,8 +3815,17 @@ checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
 ]
 
 [[package]]
@@ -3818,8 +3836,14 @@ checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
+
+[[package]]
+name = "regex-syntax"
+version = "0.6.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
 
 [[package]]
 name = "regex-syntax"
@@ -4998,10 +5022,14 @@ version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
+ "matchers",
  "nu-ansi-term",
+ "once_cell",
+ "regex",
  "sharded-slab",
  "smallvec",
  "thread_local",
+ "tracing",
  "tracing-core",
  "tracing-log",
 ]

--- a/bolt-cli/Cargo.toml
+++ b/bolt-cli/Cargo.toml
@@ -37,7 +37,7 @@ eyre = "0.6.12"
 thiserror = "2.0"
 hex = "0.4.3"
 tracing = "0.1.40"
-tracing-subscriber = "0.3.18"
+tracing-subscriber = { version = "0.3.18", features = ["env-filter", "fmt"] }
 reqwest = { version = "0.12.9", features = ["rustls-tls"] }
 rand = "0.8.5"
 lazy_static = "1.5.0"

--- a/bolt-cli/README.md
+++ b/bolt-cli/README.md
@@ -392,6 +392,15 @@ Options:
 
 ---
 
+## Logging
+
+```text
+bolt --verbosity
+
+Options:
+-v, --verbosity  Verbosity level of logs. Enter multiple times to increase the verbosity (e.g. -v, -vv, -vvv).
+```
+
 ## Security
 
 The Bolt CLI is designed to be used offline. It does not require any network connections

--- a/bolt-cli/src/cli.rs
+++ b/bolt-cli/src/cli.rs
@@ -7,7 +7,7 @@ use alloy::{
 };
 use clap::{
     builder::styling::{AnsiColor, Color, Style},
-    Parser, Subcommand, ValueEnum,
+    ArgAction, Parser, Subcommand, ValueEnum,
 };
 use reqwest::Url;
 
@@ -20,6 +20,11 @@ pub struct Opts {
     /// The subcommand to run.
     #[clap(subcommand)]
     pub command: Cmd,
+
+    /// specify log verbosity e.g (-v, -vv, -vvv, etc.)
+    /// errors will be logged regardless of the verbosity level
+    #[clap(short, long, global = true, env = "VERBOSITY", default_value_t=1, action = ArgAction::Count)]
+    pub verbosity: u8,
 }
 
 #[derive(Subcommand, Debug, Clone)]

--- a/bolt-cli/src/main.rs
+++ b/bolt-cli/src/main.rs
@@ -16,14 +16,24 @@ mod pb;
 /// Contracts and interfaces bindings for interacting with the Bolt network.
 mod contracts;
 
+use tracing_subscriber::{fmt, prelude::*, EnvFilter};
+
 #[tokio::main]
 async fn main() -> eyre::Result<()> {
     let _ = dotenvy::dotenv();
-    let _ = tracing_subscriber::fmt().with_target(false).try_init();
+
+    let opts = cli::Opts::parse();
+    let filtered_layer =
+        EnvFilter::builder().from_env_lossy().add_directive(opts.verbosity.to_string().parse()?);
+
+    let _ = tracing_subscriber::registry()
+        .with(fmt::layer().with_target(false))
+        .with(filtered_layer)
+        .try_init();
 
     if let Err(err) = rustls::crypto::ring::default_provider().install_default() {
         error!("Failed to install default TLS provider: {:?}", err);
     }
 
-    cli::Opts::parse().command.run().await
+    opts.command.run().await
 }


### PR DESCRIPTION
Add verbosity levels from error to traces. Using `-v` increments, the higher the `-v -v -v` (aggregated as `-vvv` using clap's `ArgAction::Count`) the more verbose the traces.

closes #501 