### PR TITLE
fix: incorrect flag usage with PROFILE

### DIFF
--- a/scripts/bolt-cli-tarballs.sh
+++ b/scripts/bolt-cli-tarballs.sh
@@ -37,7 +37,7 @@ fi
         echo "Building for $target ($short_name)"
 
         mkdir -p "dist/$short_name"
-        cross build --$PROFILE --target "$target"
+        cross build --release --target "$target"
         cp "target/$target/$PROFILE/bolt" "dist/$short_name/bolt"
         tar -czf "dist/bolt-cli-$short_name.tar.gz" -C "dist/$short_name" bolt
 


### PR DESCRIPTION
i’ve corrected the issue where the PROFILE variable was being used as a flag in the command line, which caused it to be interpreted incorrectly. instead of using `--$PROFILE`, i’ve updated it to use `--release` directly. 

p.s. this ensures the flag is properly parsed and prevents any errors that were occurring with the old approach.